### PR TITLE
add goerli base

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -105,6 +105,10 @@ function setupDefaultNetworkProviders(hardhatConfig: HardhatUserConfig) {
       {
         name: "mainnet",
         url: `https://eth-mainnet.alchemyapi.io/v2/-lH3DVZ5yNTgaJjsituB9PssBzM3SN-R`
+      },
+      {
+        name: "goerli",
+        url: "https://eth-goerli.alchemyapi.io/v2/Xs9F4EHXAb1wg_PvxlKu3HaXglyPkc2E"
       }
     ],
   },


### PR DESCRIPTION
Adding a base for Goerli.

This does not solve the `hardhat-import` issue, so if you don't have any assets in `deployments/goerli/` you'll get the `Error Unknown etherscan API host error`:

![image](https://user-images.githubusercontent.com/2570291/146609907-d865925e-373f-429e-bd8a-9c37c178cb48.png)

I'm working on a fix for `hardhat-import`; PR incoming.

