### PR TITLE
Fix Error Tracing

### DIFF
--- a/plugins/scenario/worker/Parent.ts
+++ b/plugins/scenario/worker/Parent.ts
@@ -10,6 +10,7 @@ export interface Result {
   scenario: string,
   elapsed?: number,
   error?: Error,
+  trace?: string,
   skipped?: boolean
 }
 

--- a/plugins/scenario/worker/Report.ts
+++ b/plugins/scenario/worker/Report.ts
@@ -24,9 +24,9 @@ function showReportConsole(results: Result[]) {
   let errCount = 0;
   let skipCount = 0;
   let totalTime = 0;
-  let errors: Map<string, Error> = new Map();
+  let errors: Map<string, [Error, string]> = new Map();
 
-  for (let {scenario, elapsed, error, skipped} of results) {
+  for (let {scenario, elapsed, error, trace, skipped} of results) {
     if (skipped) {
       skipCount++;
     } else {
@@ -34,15 +34,15 @@ function showReportConsole(results: Result[]) {
       totalTime += elapsed;
       if (error) {
         errCount++;
-        errors[scenario] = error;
+        errors[scenario] = [error, trace];
       } else {
         succCount++;
       }
     }
   }
 
-  for (let [scenario, error] of Object.entries(errors)) {
-    console.error(`❌ ${scenario}: Error ${error.message}\n${error.stack}`);
+  for (let [scenario, [error, trace]] of Object.entries(errors)) {
+    console.error(`❌ ${scenario}: Error ${trace || error.message}`);
   }
 
   let prefix = errCount === 0 ? "✅" : "❌";

--- a/plugins/scenario/worker/Worker.ts
+++ b/plugins/scenario/worker/Worker.ts
@@ -46,10 +46,10 @@ export async function run<T>() {
       try {
         await runScenario(scenario);
         // Add timeout for flush
-        eventually(() => parentPort.postMessage({result: { scenario: scenario.name, elapsed: Date.now() - startTime, error: null }}));
+        eventually(() => parentPort.postMessage({result: { scenario: scenario.name, elapsed: Date.now() - startTime, error: null, trace: null }}));
       } catch (error) {
         // Add timeout for flush
-        eventually(() => parentPort.postMessage({result: { scenario: scenario.name, elapsed: Date.now() - startTime, error }}));
+        eventually(() => parentPort.postMessage({result: { scenario: scenario.name, elapsed: Date.now() - startTime, error, trace: error.stack.toString() }}));
       }
     } else {
       throw new Error(`Unknown or invalid worker message: ${JSON.stringify(message)}`);


### PR DESCRIPTION
This patch makes sure we don't accidentally kill the error trace for displaying assertion failures. Specifically, the trace was being lost when passed through from the child thread to the parent, so we capture the trace as a string and pass that back for error reporting, now.