### PR TITLE
use networkNameOverride argument in spider script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Compound Finance",
   "license": "UNLICENSED",
   "devDependencies": {
-    "@compound-finance/hardhat-import": "^1.0.1",
+    "@compound-finance/hardhat-import": "^1.0.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-etherscan": "^2.1.8",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/plugins/spider/index.ts
+++ b/plugins/spider/index.ts
@@ -203,5 +203,7 @@ async function loadContractConfig(
   return await fs.promises.readFile(outfile, 'utf-8') // fsStat
     .then((config) => JSON.parse(config))
     // Hardhat-import plugin (fork of Saddle import)
-    .catch(async () => await hre.run('import', { address, outdir }));
+    .catch(async () => {
+      await hre.run('import', { address, outdir, networkNameOverride: network });
+    });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@compound-finance/hardhat-import@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@compound-finance/hardhat-import/-/hardhat-import-1.0.1.tgz#3d5a17164f049e9234c4ff66d417eb8fe08b78bd"
-  integrity sha512-N6ax2TgeND7Iglo6dL6cPa7VJ4emxr82A7+OZSybkBPp/j8BlgN3zVr7BYQvwkcAR4yq4eNCWoKExndsA0iUWg==
+"@compound-finance/hardhat-import@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@compound-finance/hardhat-import/-/hardhat-import-1.0.2.tgz#fe80be6c0ab63637a2ce714bc009c433ed57d56f"
+  integrity sha512-FHRkFNJ1nMOUhjCbk5dGQi3uK1Io2DNCr/2yNiqumvz1OS2SaZNbEowIC4/Nqj/RH3AdaXlMUpcP3H8rADXGUg==
   dependencies:
     "@ethersproject/address" "^5.5.0"
     axios "^0.24.0"


### PR DESCRIPTION
Updating Comet to use the updated version of `hardhat-import` that now includes the ability to override the network name: (PR: https://github.com/compound-finance/compound-hardhat-plugins/pull/4)

should eliminate this error:

<img width="1058" alt="Screen Shot 2021-12-17 at 4 26 39 PM" src="https://user-images.githubusercontent.com/2570291/146622799-2fedf0ef-4c78-4021-bfe2-4db83dea7a15.png">