### PR TITLE
Add Bases to CLI and Scenario Runner

### DIFF
--- a/plugins/scenario/worker/Parent.ts
+++ b/plugins/scenario/worker/Parent.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { Worker } from 'worker_threads';
+import { ForkSpec } from '../Runner';
 import { Scenario } from '../Scenario';
 import { loadScenarios } from '../Loader';
 import { defaultFormats, scenarioGlob, workerCount } from './Config';
@@ -8,6 +9,7 @@ import { getContext, getConfig, getHardhatArguments } from './HardhatContext';
 import { ScenarioConfig } from '../types';
 
 export interface Result {
+  base: string,
   scenario: string,
   elapsed?: number,
   error?: Error,
@@ -20,10 +22,15 @@ interface WorkerMessage {
   result?: Result
 }
 
-function filterRunning<T>(scenarios: Scenario<T>[]): [Scenario<T>[], Scenario<T>[]] {
-  let rest = scenarios.filter((scenario) => scenario.flags === null);
-  let only = scenarios.filter((scenario) => scenario.flags === "only");
-  let skip = scenarios.filter((scenario) => scenario.flags === "skip");
+type BaseScenario<T> = {
+  base: ForkSpec,
+  scenario: Scenario<T>
+}
+
+function filterRunning<T>(baseScenarios: BaseScenario<T>[]): [BaseScenario<T>[], BaseScenario<T>[]] {
+  let rest = baseScenarios.filter(({scenario}) => scenario.flags === null);
+  let only = baseScenarios.filter(({scenario}) => scenario.flags === "only");
+  let skip = baseScenarios.filter(({scenario}) => scenario.flags === "skip");
 
   if (only.length > 0) {
     return [only, skip.concat(rest)];
@@ -32,21 +39,39 @@ function filterRunning<T>(scenarios: Scenario<T>[]): [Scenario<T>[], Scenario<T>
   }
 }
 
-export async function run<T>(scenarioConfig: ScenarioConfig) {
+function getBaseScenarios<T>(bases: ForkSpec[], scenarios: Scenario<T>[]): BaseScenario<T>[] {
+  let result: BaseScenario<T>[] = [];
+
+  // Note: this could filter if scenarios had some such filtering (e.g. to state the scenario is only compatible with certain bases)
+  for (let base of bases) {
+    for (let scenario of scenarios) {
+      result.push({base, scenario});
+    }
+  }
+  return result;
+}
+
+function key(baseName: string, scenarioName: string): string {
+  return `${baseName}-${scenarioName}`;
+}
+
+export async function run<T>(scenarioConfig: ScenarioConfig, bases: ForkSpec[]) {
   let hardhatConfig = getConfig();
   let hardhatArguments = getHardhatArguments();
   let formats = defaultFormats.map(loadFormat);
   let scenarios: Scenario<T>[] = Object.values(await loadScenarios(scenarioGlob));
-  let [runningScenarios, skippedScenarios] = filterRunning(scenarios);
+  let baseScenarios: BaseScenario<T>[] = getBaseScenarios(bases, scenarios);
+  let [runningScenarios, skippedScenarios] = filterRunning(baseScenarios);
 
-  let results: Result[] = skippedScenarios.map((scenario) => ({
+  let results: Result[] = skippedScenarios.map(({base, scenario}) => ({
+    base: base.name,
     scenario: scenario.name,
     elapsed: undefined,
     error: undefined,
     skipped: true
   }));
-  let pending: Set<string> = new Set(runningScenarios.map((scenario) => scenario.name));
-  let assignable: Iterator<Scenario<T>> = runningScenarios[Symbol.iterator]();
+  let pending: Set<string> = new Set(runningScenarios.map((baseScenario) => key(baseScenario.base.name, baseScenario.scenario.name)));
+  let assignable: Iterator<BaseScenario<T>> = runningScenarios[Symbol.iterator]();
   let done;
   let hasError = false;
   let isDone = new Promise((resolve, reject_) => {
@@ -61,7 +86,7 @@ export async function run<T>(scenarioConfig: ScenarioConfig) {
 
   checkDone(); // Just in case we don't have any scens
 
-  function getNextScenario(): Scenario<T> | null {
+  function getNextScenario(): BaseScenario<T> | null {
     let next = assignable.next();
     if (!next.done && next.value) {
       return next.value;
@@ -70,15 +95,15 @@ export async function run<T>(scenarioConfig: ScenarioConfig) {
   }
 
   function assignWork(worker: Worker) {
-    let scenario = getNextScenario();
-    if (scenario) {
-      worker.postMessage({ scenario: scenario.name });
+    let baseScenario = getNextScenario();
+    if (baseScenario) {
+      worker.postMessage({ scenario: { base: baseScenario.base.name, scenario: baseScenario.scenario.name } });
     }
   }
 
   function mergeResult(index: number, result: Result) {
     results.push(result);
-    pending.delete(result.scenario);
+    pending.delete(key(result.base, result.scenario));
 
     checkDone();
   }
@@ -86,7 +111,13 @@ export async function run<T>(scenarioConfig: ScenarioConfig) {
   const worker = [...new Array(workerCount)].map((_, index) => {
     let worker = new Worker(
       path.resolve(__dirname, './BootstrapWorker.js'),
-      {workerData: scenarioConfig}
+      {
+        workerData: {
+          scenarioConfig,
+          bases,
+          config: [hardhatConfig, hardhatArguments]
+        }
+      }
     );
 
     worker.on('message', (message) => {
@@ -96,7 +127,6 @@ export async function run<T>(scenarioConfig: ScenarioConfig) {
       }
     });
 
-    worker.postMessage({config: [hardhatConfig, hardhatArguments]});
     assignWork(worker);
   });
 

--- a/plugins/scenario/worker/Report.ts
+++ b/plugins/scenario/worker/Report.ts
@@ -25,9 +25,9 @@ function showReportConsole(results: Result[]) {
   let errCount = 0;
   let skipCount = 0;
   let totalTime = 0;
-  let errors: Map<string, { error: Error, trace?: string, diff?: { actual: any, expected: any } }> = new Map();
+  let errors: { base: string, scenario: string, error: Error, trace?: string, diff?: { actual: any, expected: any } }[] = [];
 
-  for (let {scenario, elapsed, error, trace, diff, skipped} of results) {
+  for (let {base, scenario, elapsed, error, trace, diff, skipped} of results) {
     if (skipped) {
       skipCount++;
     } else {
@@ -35,15 +35,15 @@ function showReportConsole(results: Result[]) {
       totalTime += elapsed;
       if (error) {
         errCount++;
-        errors[scenario] = { error, trace, diff };
+        errors.push({ base, scenario, error, trace, diff });
       } else {
         succCount++;
       }
     }
   }
 
-  for (let [scenario, { error, trace, diff }] of Object.entries(errors)) {
-    console.error(`❌ ${scenario}: Error ${trace || error.message}`);
+  for (let { base, scenario, error, trace, diff } of errors) {
+    console.error(`❌ ${scenario}@${base}: Error ${trace || error.message}`);
     if (diff) {
       console.error(showDiff(diff.expected, diff.actual));
     }

--- a/scenario/SimpleScenario.ts
+++ b/scenario/SimpleScenario.ts
@@ -2,7 +2,7 @@ import { scenario } from './Context';
 import { expect } from 'chai';
 
 scenario.only("my scenario", {}, async ({players}, world) => {
-  expect(await players()).to.eql(["0x29e31E1eE143a76039F00860d3Bd25804357f0b3"]);
+  expect(await players()).to.eql(["0x29e31E1eE143a76039F00860d3Bd25804357f0b2"]);
 });
 
 scenario("scen 2", {}, async (context, world) => {

--- a/tasks/scenario/task.ts
+++ b/tasks/scenario/task.ts
@@ -1,8 +1,22 @@
 import { task } from 'hardhat/config';
 import { run } from '../../plugins/scenario/worker/Parent';
 import "../../plugins/scenario/type-extensions";
+import { ForkSpec } from '../../plugins/scenario/Runner';
 
 task("scenario", "Runs scenario tests")
-  .setAction(async (_taskArgs, env) => {
-    await run(env.config.scenario);
+  .addOptionalParam("bases", "Bases to run on [defaults to all]")
+  .setAction(async (taskArgs, env) => {
+    let bases: ForkSpec[] = env.config.scenario.bases;
+    if (taskArgs.bases) {
+      let baseMap = Object.fromEntries(env.config.scenario.bases.map((base) => [base.name, base]));
+      bases = taskArgs.bases.split(',').map((baseName) => {
+        let base = baseMap[baseName];
+        if (!base) {
+          throw new Error(`Unknown base: ${baseName}`);
+        }
+        return base;
+      });
+    }
+
+    await run(env.config.scenario, bases);
   });


### PR DESCRIPTION
This patch adds and passes bases through from the CLI, to the Runner and back to Reporting. We are currently doing a pairwise combination (every base against every scenario), but we could easily add in base-filtering for scenarios. You can specify the bases you want to run by the cli by doing `--bases development,goerli` or just `--bases goerli`. Everything is working pretty well right now.