### PR TITLE
replace missing return in loadContractConfig

### DIFF
--- a/plugins/spider/index.ts
+++ b/plugins/spider/index.ts
@@ -204,6 +204,6 @@ async function loadContractConfig(
     .then((config) => JSON.parse(config))
     // Hardhat-import plugin (fork of Saddle import)
     .catch(async () => {
-      await hre.run('import', { address, outdir, networkNameOverride: network });
+      return await hre.run('import', { address, outdir, networkNameOverride: network });
     });
 }


### PR DESCRIPTION
if you clear the spider script cache and run scenario...

```
rm deployments/goerli/config.json
rm deployments/goerli/proxies.json
rm -rf deployments/goerli/cache
yarn hardhat scenario
```

you get an error:

![image](https://user-images.githubusercontent.com/2570291/146648775-7a5f05ae-cf77-4427-b4cb-f1df2a2c0507.png)

this patch fixes that error