### PR TITLE
add pre-commit hook, .githooks directory

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# exit when any command fails
+set -e
+ 
+# typescript
+yarn tsc
+# solhint
+yarn lint-contracts

--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ REPORT_GAS=true
 MNEMONIC=<mnemonic>
 ```
 
+## Git hooks
+
+The repo's Git hooks are defined the `.githooks/` directory.
+
+You can enable them by running:
+
+```
+# requires git version 2.9 or greater
+git config core.hooksPath .githooks
+```
+
+You can skip pre-commit checks with the `-n` flag:
+
+```
+# skip pre-commit hook
+git commit -n -m "commit without running pre-commit hook"
+```
+
 ## Usage
 
 Look at the scripts section inside `package.json` to find all commands.


### PR DESCRIPTION
Adding a `.githooks` directory and a simple pre-commit hook. They're installed by running `git config core.hooksPath .githooks`.

Alternatively, we could run this command automatically before one of the npm/yarn lifecycle hooks:

```
// package.json
{
  "scripts": {
    "preinstall": "git config core.hooksPath .githooks"
  }
}
```

This will fail for anyone using a Git version less than 2.9, however.