### PR TITLE
add pre-commit hook, .githooks directory

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# exit when any command fails
+set -e
+
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
+[ -z "$STAGED_FILES" ] && exit 0
+
+# typescript
+./node_modules/.bin/tsc
+
+# solhint
+echo "$STAGED_FILES" | egrep '\.sol$' | xargs ./node_modules/.bin/solhint --fix
+
+# Add back the modified/prettified files to staging
+echo "$STAGED_FILES" | xargs git add
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ REPORT_GAS=true
 MNEMONIC=<mnemonic>
 ```
 
+## Git hooks
+
+The repo's Git hooks are defined the `.githooks/` directory.
+
+You can enable them by running:
+
+```
+# requires git version 2.9 or greater
+git config core.hooksPath .githooks
+```
+
+You can skip pre-commit checks with the `-n` flag:
+
+```
+git commit -n -m "commit without running pre-commit hook"
+```
+
 ## Usage
 
 Look at the scripts section inside `package.json` to find all commands.


### PR DESCRIPTION
Adding a pre-commit hook, so that we can start running some of our linting/type-checking while committing.

Combining elements from:
- https://www.viget.com/articles/two-ways-to-share-git-hooks-with-your-team/
- https://prettier.io/docs/en/precommit.html#option-5-shell-script