### PR TITLE
Run Scenarios in CI

### DIFF
--- a/.github/workflows/run-scenarios.yaml
+++ b/.github/workflows/run-scenarios.yaml
@@ -1,0 +1,22 @@
+name: Run Scenarios
+on:
+  workflow_dispatch:
+  pull_request:
+jobs:
+  run-coverage:
+    name: Run scenarios
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          cache: 'yarn'
+          node-version: '16'
+
+      - name: Install packages
+        run: yarn install --non-interactive --frozen-lockfile && yarn build
+
+      - name: Run scenarios
+        run: yarn scenario


### PR DESCRIPTION
This patch presents the basis for running scenarios in CI. We should probably produce consumable artifacts, but we will need to make the format appropriate for GitHub Actions, which is ... ?