### PR TITLE
add memoized version of loadEtherscanContract

### DIFF
--- a/scenario/CometContext.ts
+++ b/scenario/CometContext.ts
@@ -126,8 +126,7 @@ const getInitialContext = async (world: World, base: ForkSpec): Promise<CometCon
   const isDevelopment = !base.url;
   let deploymentManager = new DeploymentManager(
     base.name,
-    world.hre,
-    { importRetryDelay: 7000 } // !! very high retry delay to avoid Etherscan throttling
+    world.hre
   );
 
   if (isDevelopment) {


### PR DESCRIPTION
Currently, running scenarios involves a call to Etherscan for each scenario. Once we added enough scenarios, we started getting rate-limited by Etherscan.

We have back-off/retry logic in the DeploymentManager, but we have to set the retry delay up to 7,000ms in order to avoid rate-limiting. So we're currently spending a lot of time waiting.

In this PR, I've added a memoized version of the `loadEtherscanContract` function, so repeated calls for the same network/address combo will be served from an in-memory cache instead of making duplicate requests. This speeds things up a fair bit

Before:

![image](https://user-images.githubusercontent.com/2570291/147696706-dce9c76b-51ff-42c7-bf33-7577feef9952.png)

After:

![image](https://user-images.githubusercontent.com/2570291/147696602-4ad13182-1738-46ed-b2b1-7131c629ae26.png)

I've avoid writing a more generalizable `memoize` function, though that might be useful ultimately.

I've also added this as part of the `import` plugin and not part of the `DeploymentManager`; maybe it makes more sense in the DeploymentManager, since that's where retry logic/writing to disk takes place. Open to suggestions.