### PR TITLE
make INFURA_KEY required

### DIFF
--- a/.github/workflows/run-contract-linter.yaml
+++ b/.github/workflows/run-contract-linter.yaml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_KEY }}
+      INFURA_KEY: ${{ secrets.INFURA_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/run-coverage.yaml
+++ b/.github/workflows/run-coverage.yaml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_KEY }}
+      INFURA_KEY: ${{ secrets.INFURA_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/run-gas-profiler.yaml
+++ b/.github/workflows/run-gas-profiler.yaml
@@ -9,6 +9,7 @@ jobs:
     env:
       COINMARKETCAP_API_KEY: b52b18a2-d44f-4646-9949-0eb0e9c68574
       ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_KEY }}
+      INFURA_KEY: ${{ secrets.INFURA_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/run-scenarios.yaml
+++ b/.github/workflows/run-scenarios.yaml
@@ -7,6 +7,7 @@ jobs:
     name: Run scenarios
     env:
       ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_KEY }}
+      INFURA_KEY: ${{ secrets.INFURA_KEY }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -34,6 +34,7 @@ function throwIfMissing(envVariable, msg: string) {
 
 // required environmnet variables
 throwIfMissing(ETHERSCAN_KEY, "Missing required environment variable: ETHERSCAN_KEY")
+throwIfMissing(INFURA_KEY, "Missing required environment variable: INFURA_KEY")
 
 // Networks
 interface NetworkConfig {


### PR DESCRIPTION
follow-up to #76 ; we'll need to add `INFURA_KEY` to the Github Actions environment before CI will pass 