### PR TITLE
reuse getDefaultProviderURL for scenarios

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -126,7 +126,7 @@ const config: HardhatUserConfig = {
       },
       {
         name: 'goerli',
-        url: 'https://eth-goerli.alchemyapi.io/v2/Xs9F4EHXAb1wg_PvxlKu3HaXglyPkc2E',
+        url: getDefaultProviderURL('goerli'),
       },
     ],
   },


### PR DESCRIPTION
good call @kevincheng96

especially now that `INFURA_KEY` is mandatory, we might as well reuse it for scenarios 👍 