### PR TITLE
Add ForkSpec to Scenario Inputs

### DIFF
--- a/plugins/scenario/Runner.ts
+++ b/plugins/scenario/Runner.ts
@@ -1,13 +1,8 @@
 import { Constraint, Scenario, Solution } from './Scenario';
-import { World } from './World';
+import { ForkSpec, World } from './World';
 import hreForBase from './utils/hreForBase';
 
 export type Address = string;
-export type ForkSpec = {
-  name: string;
-  url?: string;
-  blockNumber?: number;
-};
 
 export type ResultFn<T> = (base: ForkSpec, scenario: Scenario<T>, err?: any) => void;
 
@@ -59,14 +54,14 @@ export class Runner<T> {
 
     for (const base of bases) {
       // construct a base world and context
-      const world = new World(hreForBase(base)); // XXX can cache/re-use HREs per base
+      const world = new World(hreForBase(base), base); // XXX can cache/re-use HREs per base
 
       // freeze the world as it was before we run any scenarios
       let snapshot = await world._snapshot();
 
       for (const scenario of scenarios) {
         const { constraints = [] } = scenario;
-        const context = await scenario.initializer(world, base);
+        const context = await scenario.initializer(world);
 
         // generate worlds which satisfy the constraints
         // note: `solve` is expected not to modify context or world

--- a/plugins/scenario/Scenario.ts
+++ b/plugins/scenario/Scenario.ts
@@ -1,4 +1,3 @@
-import { ForkSpec } from './Runner';
 import { World } from './World';
 
 // A solution modifies a given context and world in a way that satisfies a constraint.
@@ -17,7 +16,7 @@ export interface Constraint<T> {
 }
 
 export type Property<T> = (context: T, world: World) => Promise<any>;
-export type Initializer<T> = (world: World, base: ForkSpec) => Promise<T>;
+export type Initializer<T> = (world: World) => Promise<T>;
 export type Forker<T> = (T) => Promise<T>;
 
 export type ScenarioFlags = null | 'only' | 'skip';

--- a/plugins/scenario/World.ts
+++ b/plugins/scenario/World.ts
@@ -1,11 +1,24 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { Signer } from 'ethers';
 
+export type ForkSpec = {
+  name: string;
+  url?: string;
+  blockNumber?: number;
+};
+
 export class World {
   hre: HardhatRuntimeEnvironment;
+  base: ForkSpec;
 
-  constructor(hre) {
+  constructor(hre, base: ForkSpec) {
     this.hre = hre;
+    this.base = base;
+  }
+
+  // TODO: Can we do this better?
+  isDevelopment(): boolean {
+    return !this.base.url;
   }
 
   async _snapshot() {

--- a/plugins/scenario/index.ts
+++ b/plugins/scenario/index.ts
@@ -1,8 +1,7 @@
 import { Constraint, Forker, Initializer, Property, ScenarioFlags } from './Scenario';
 import { getLoader } from './Loader';
 export { Constraint, Initializer, Property, Scenario, Solution } from './Scenario';
-export { World } from './World';
-export { ForkSpec } from './Runner';
+export { ForkSpec, World } from './World';
 
 type ScenarioFn<T> = (name: string, requirements: object, property: Property<T>) => Promise<void>;
 

--- a/plugins/scenario/types.ts
+++ b/plugins/scenario/types.ts
@@ -1,4 +1,4 @@
-import { ForkSpec } from './Runner';
+import { ForkSpec } from './World';
 
 export interface ScenarioConfig {
   bases: ForkSpec[];

--- a/plugins/scenario/utils/hreForBase.ts
+++ b/plugins/scenario/utils/hreForBase.ts
@@ -15,7 +15,7 @@ import { loadConfigAndTasks } from 'hardhat/internal/core/config/config-loading'
 import { getEnvHardhatArguments } from 'hardhat/internal/core/params/env-variables';
 import { HARDHAT_PARAM_DEFINITIONS } from 'hardhat/internal/core/params/hardhat-params';
 import { Environment } from 'hardhat/internal/core/runtime-environment';
-import { ForkSpec } from '../Runner';
+import { ForkSpec } from '../World';
 import { memoize } from '../../../src/memoize';
 
 /*

--- a/plugins/scenario/worker/Parent.ts
+++ b/plugins/scenario/worker/Parent.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { Worker } from 'worker_threads';
-import { ForkSpec } from '../Runner';
+import { ForkSpec } from '../World';
 import { Scenario } from '../Scenario';
 import { loadScenarios } from '../Loader';
 import { defaultFormats, scenarioGlob, workerCount } from './Config';

--- a/plugins/scenario/worker/Worker.ts
+++ b/plugins/scenario/worker/Worker.ts
@@ -1,5 +1,6 @@
 import { parentPort } from 'worker_threads';
-import { ForkSpec, Runner } from '../Runner';
+import { Runner } from '../Runner';
+import { ForkSpec } from '../World';
 import { Scenario } from '../Scenario';
 import { loadScenarios } from '../Loader';
 import { HardhatContext } from 'hardhat/internal/context';

--- a/scenario/CometScenario.ts
+++ b/scenario/CometScenario.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { World } from '../plugins/scenario';
 
-scenario('initializes governor correctly', {}, async ({ comet, actors }) => {
+scenario('initializes governor correctly', {}, async ({ comet, actors }, world) => {
   // TODO: Make this more interesting, plus the admin here isn't right for mainnet, etc.
   expect(await comet.governor()).to.equal(actors['admin']!.address);
 });

--- a/scenario/context/CometContext.ts
+++ b/scenario/context/CometContext.ts
@@ -28,11 +28,10 @@ export class CometContext {
   }
 }
 
-const getInitialContext = async (world: World, base: ForkSpec): Promise<CometContext> => {
-  const isDevelopment = !base.url; // TODO: Unify this concept?
-  let deploymentManager = new DeploymentManager(base.name, world.hre);
+const getInitialContext = async (world: World): Promise<CometContext> => {
+  let deploymentManager = new DeploymentManager(world.base.name, world.hre);
 
-  if (isDevelopment) {
+  if (world.isDevelopment()) {
     await deployComet(deploymentManager, false);
   }
 
@@ -40,7 +39,7 @@ const getInitialContext = async (world: World, base: ForkSpec): Promise<CometCon
 
   let comet: Comet = (await deploymentManager.contracts['Comet']) as Comet;
   if (!comet) {
-    throw new Error(`No such contract Comet for base ${base.name}`);
+    throw new Error(`No such contract Comet for base ${world.base.name}`);
   }
 
   let signers = await world.hre.ethers.getSigners();
@@ -48,7 +47,7 @@ const getInitialContext = async (world: World, base: ForkSpec): Promise<CometCon
   const [localAdminSigner, albertSigner, bettySigner, charlesSigner] = signers;
   let adminSigner;
 
-  if (isDevelopment) {
+  if (world.isDevelopment()) {
     adminSigner = localAdminSigner;
   } else {
     const governorAddress = await comet.governor();

--- a/tasks/scenario/task.ts
+++ b/tasks/scenario/task.ts
@@ -1,7 +1,7 @@
 import { task } from 'hardhat/config';
 import { run } from '../../plugins/scenario/worker/Parent';
 import '../../plugins/scenario/type-extensions';
-import { ForkSpec } from '../../plugins/scenario/Runner';
+import { ForkSpec } from '../../plugins/scenario/World';
 
 task('scenario', 'Runs scenario tests')
   .addOptionalParam('bases', 'Bases to run on [defaults to all]')


### PR DESCRIPTION
This patch just adds forkspec to the scenario inputs as a third arg. This shouldn't really be used, but it can be useful to know, for instance when debugging, which fork you're on when the failure occurs.