### PR TITLE
Rename comet.ts to deploy.ts

### DIFF
--- a/scenario/context/CometContext.ts
+++ b/scenario/context/CometContext.ts
@@ -4,7 +4,7 @@ import { ContractMap, DeploymentManager } from '../../plugins/deployment_manager
 import { BalanceConstraint, RemoteTokenConstraint } from '../constraints';
 import CometActor from './CometActor';
 import CometAsset from './CometAsset';
-import { Comet, deploy } from '../../src/comet';
+import { Comet, deployComet } from '../../src/deploy';
 
 export class CometContext {
   deploymentManager: DeploymentManager;
@@ -33,7 +33,7 @@ const getInitialContext = async (world: World, base: ForkSpec): Promise<CometCon
   let deploymentManager = new DeploymentManager(base.name, world.hre);
 
   if (isDevelopment) {
-    await deploy(deploymentManager, false);
+    await deployComet(deploymentManager, false);
   }
 
   await deploymentManager.spider();

--- a/scripts/deploy-comet.ts
+++ b/scripts/deploy-comet.ts
@@ -4,7 +4,7 @@
 // When running the script with `npx hardhat run <script>` you'll find the Hardhat
 // Runtime Environment's members available in the global scope.
 import hre from 'hardhat';
-import { deploy } from '../src/comet';
+import { deployComet } from '../src/deploy';
 import { DeploymentManager } from '../plugins/deployment_manager/DeploymentManager';
 
 async function main() {
@@ -16,7 +16,7 @@ async function main() {
     writeCacheToDisk: true,
   });
 
-  let { comet } = await deploy(dm, !isDevelopment);
+  let { comet } = await deployComet(dm, !isDevelopment);
 
   // TODO: If we deployed fresh, we probably don't need to spider, per se. We should work on passing a deployment manager into deploy!
 

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -37,7 +37,7 @@ async function verifyContract(
   }
 }
 
-export async function deploy(
+export async function deployComet(
   deploymentManager: DeploymentManager,
   verify: boolean = false
 ): Promise<{ comet: Comet; oracle: MockedOracle; proxy: TransparentUpgradeableProxy }> {


### PR DESCRIPTION
This patch simply renames `comet.ts` to `deploy.ts`, since that's its primary use-case, and it makes it easy to search files for `deploy.ts`. This could also be `deploy-comet.ts`, but I think we have a script named that, so I don't want them to be confused. This file (`src/deploy.ts`) is going to be the primary "build a new comet deployment" for a while, and will probably grow in importance. It will eventually splinter into a "deploy versus migrate" concept, but it doesn't, per se, make sense to do that yet. Note: deploying a faucet token should one day be gated by network, as well.