### PR TITLE
Add Gold and Silver Assets; Deploy ProxyAdmin

### DIFF
--- a/.github/workflows/run-scenarios.yaml
+++ b/.github/workflows/run-scenarios.yaml
@@ -23,4 +23,4 @@ jobs:
         run: yarn install --non-interactive --frozen-lockfile && yarn build
 
       - name: Run scenarios
-        run: yarn scenario
+        run: WORKERS=1 yarn scenario

--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -80,6 +80,27 @@ contract Comet {
 
         if (i == 0) return AssetInfo({asset: asset00, borrowCollateralFactor: borrowCollateralFactor00, liquidateCollateralFactor: liquidateCollateralFactor00 });
         if (i == 1) return AssetInfo({asset: asset01, borrowCollateralFactor: borrowCollateralFactor01, liquidateCollateralFactor: liquidateCollateralFactor01 });
+        revert("absurd");
+    }
+
+    function assets() public view returns (AssetInfo[] memory) {
+        AssetInfo[] memory result = new AssetInfo[](numAssets);
+
+        for (uint i = 0; i < numAssets; i++) {
+            result[i] = getAssetInfo(i);
+        }
+
+        return result;
+    }
+
+    function assetAddresses() public view returns (address[] memory) {
+        address[] memory result = new address[](numAssets);
+
+        for (uint i = 0; i < numAssets; i++) {
+            result[i] = getAssetInfo(i).asset;
+        }
+
+        return result;
     }
 
     function allow(address manager, bool _isAllowed) external {

--- a/deployments/fuji/relations.json
+++ b/deployments/fuji/relations.json
@@ -1,5 +1,0 @@
-{
-  "AsteroidRaffle": {
-    "relations": ["token", "oracle"]
-  }
-}

--- a/deployments/fuji/roots.json
+++ b/deployments/fuji/roots.json
@@ -1,3 +1,3 @@
 {
-  "Comet": "0x91f838aA5AcC507960D36cB652D424BFbAEA287b"
+    "TransparentUpgradeableProxy": "0x985FbCd0190F6EfD6456c264B662D8a6Dd6efA01"
 }

--- a/deployments/goerli/roots.json
+++ b/deployments/goerli/roots.json
@@ -1,3 +1,3 @@
 {
-  "Comet": "0x2B95115d5BB1FaE43AaE1c9585b1DF1B1D4Ef5F4"
+    "TransparentUpgradeableProxy": "0x93C747aa42548C12C58Da2cbC10C171342E2b3c2"
 }

--- a/deployments/relations.json
+++ b/deployments/relations.json
@@ -1,5 +1,10 @@
 {
-  "Comet": {
-    "relations": ["baseToken", "priceOracle"]
+  "TransparentUpgradeableProxy": {
+    "alias": "comet",
+    "implementation": "%0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc",
+    "relations": ["%0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103", "baseToken", "priceOracle", "assetAddresses"]
+  },
+  "FaucetToken": {
+    "alias": "@symbol"
   }
 }

--- a/plugins/deployment_manager/Types.ts
+++ b/plugins/deployment_manager/Types.ts
@@ -12,6 +12,7 @@ export interface ContractMetadata {
 }
 
 export interface BuildFile {
+  contract: string;
   contracts: {
     [fileContractName: string]: ContractMetadata | { [contractName: string]: ContractMetadata };
   };

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -85,6 +85,7 @@ export async function loadEtherscanContract(network: string, address: string) {
   let encodedABI = JSON.stringify(abi);
   let contractSource = `contracts/${contract}.sol:${contract}`;
   let contractBuild = {
+    contract,
     contracts: {
       [contractSource]: {
         address,

--- a/scenario/CometScenario.ts
+++ b/scenario/CometScenario.ts
@@ -27,3 +27,7 @@ scenario('Comet#allow > allows a user to rescind authoization', {}, async ({ com
 
   expect(await comet.isAllowed(albert.address, betty.address)).to.be.false;
 });
+
+scenario('has assets', {}, async ({ comet, actors, assets }, world) => {
+  expect(await comet.assetAddresses()).to.have.members(Object.values(assets).map((asset) => asset.address));
+});

--- a/scenario/constraints/BalanceConstraint.ts
+++ b/scenario/constraints/BalanceConstraint.ts
@@ -76,7 +76,7 @@ export class BalanceConstraint<T extends CometContext> implements Constraint<T> 
             await sourceTokens({
               hre: world.hre,
               amount: toTransfer,
-              asset: await asset.getAddress(),
+              asset: asset.address,
               address: actor.address,
             });
           }

--- a/scenario/context/CometAsset.ts
+++ b/scenario/context/CometAsset.ts
@@ -1,10 +1,13 @@
 import { BigNumberish, Contract, Signer } from 'ethers';
+import { Token } from '../../build/types';
 
 export default class CometAsset {
-  // XXX how are we hooking these up w/ names etc to deployment manager contracts?
-  // XXX does this abstract over erc20 and eth?
-  async getAddress(): Promise<string> {
-    return '0xxxx'; // XXX
+  token: Token;
+  address: string;
+
+  constructor(token: Token) {
+    this.token = token;
+    this.address = token.address;
   }
 
   async balanceOf(address: string): Promise<bigint> {

--- a/scripts/deploy-comet.ts
+++ b/scripts/deploy-comet.ts
@@ -9,23 +9,11 @@ import { DeploymentManager } from '../plugins/deployment_manager/DeploymentManag
 
 async function main() {
   let isDevelopment = hre.network.name === 'hardhat';
-
-  // TODO: When to verify? Configuration-type params?
-
   let dm = new DeploymentManager(hre.network.name, hre, {
     writeCacheToDisk: true,
   });
-
   let { comet } = await deployComet(dm, !isDevelopment);
-
-  // TODO: If we deployed fresh, we probably don't need to spider, per se. We should work on passing a deployment manager into deploy!
-
-  // Create a `roots.json` pointing to a just deployed contract and run spider on it.
-
-  // TODO: Worth doing this for development?
-  if (!isDevelopment) {
-    await dm.spider();
-  }
+  await dm.spider();
 }
 
 // We recommend this pattern to be able to use async/await everywhere


### PR DESCRIPTION
Topics covered in this PR from an earlier conversation:

1. I'm deploying a few more FaucetTokens in our `deploy.ts` script so that we can have a few markets for all networks right now. This isn't probably long-term the right approach, but it's a start. I've also added getting those markets to spider, aliased them, and added an easier getter to Comet.sol.
2. I've made a few fixes to Deployment Manager. Specifically:
  a. I've overhauled getPrimaryContract to actually return the contract of interest from the BuildFile (solc's output file). To accomplish this, I've just made sure that each build file (coming from import or from hardhat artifacts) has a contract: "MyContract" key, so we always actually know the contract that was being "compiled" or is otherwise of interest.
  b. I've made the getContractFromBuildFile accept the proxiesMap and actually use it when constructing the contract, such that we now have the ABI of the underlying, not the proxy, when constructing a proxied contract. This is so we can simply run something like comet.governor() even though comet here is a "TransparentUpgradeableProxy."
 c. We inconsistently used ES6 Maps. We often did a = new Map(); a[key] = value, which is pretty wrong, and then later did JSON.serialize(a). Both of these don't work and really were just using the fact that all JavaScript objects happen to be objects, so you can set properties on them. I fixed to using a.set(key, value) and using iterators to serialize those maps.
3. We were previously deploying "Comet" (hereafter, the implementation) and "TransparentUpgradeableProxy" (hereafter, the proxy). Then we said roots = { Comet: implementation } when it's supposed to be roots = { Comet: proxy } since we want to interact with the proxy, not the implementation code. This was just a temp hack, but we haven't really fixed it yet. [Note: we should use ProxyAdmin, so a small part of this will change pending adding that in]. In either case, when you use TransparentUpgradeableProxy, if you want to read the implementation() value, to get the implementation's address, you have to call as the admin of the proxy. If you want to read say collateralFactor0 to get some collateral factor from the implementation contract, you need to call as some address which is not the admin of the proxy. We were always calling as the admin, or not calling as the admin, in way that totally broke left and right. I've been working on getting that right, and as per above, also trying to get the proxying to be right. There's not a super easy approach here that I've seen yet to make the code smart to know who to call as, but there's a chance maybe we could be smart and make that work. This is a WIP, still, but I might add ProxyAdmin so we don't need to make even more changes later on. 
