### PR TITLE
Fix Scenarios

### DIFF
--- a/.github/workflows/run-scenarios.yaml
+++ b/.github/workflows/run-scenarios.yaml
@@ -19,8 +19,23 @@ jobs:
           cache: 'yarn'
           node-version: '16'
 
+      - name: Cache Deployments
+        uses: actions/cache@v2
+        with:
+          path: deployments
+          key: deployments
+
       - name: Install packages
         run: yarn install --non-interactive --frozen-lockfile && yarn build
 
+      - name: Compile
+        run: npx hardhat compile
+
+      - name: Spider Goerli
+        run: npx hardhat spider --network goerli
+
+      - name: Spider Fuji
+        run: npx hardhat spider --network fuji
+
       - name: Run scenarios
-        run: WORKERS=1 yarn scenario
+        run: yarn scenario

--- a/contracts/asteroid/FaucetToken.sol
+++ b/contracts/asteroid/FaucetToken.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: XXX
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/asteroid/MockedOracle.sol
+++ b/contracts/asteroid/MockedOracle.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: XXX
 pragma solidity ^0.8.0;
 
 contract MockedOracle {

--- a/contracts/asteroid/Token.sol
+++ b/contracts/asteroid/Token.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: XXX
+pragma solidity ^0.8.0;
+
+interface Token {
+  function balanceOf(address) external view returns (uint);
+  function transfer(address, uint) external returns (bool);
+  function transferFrom(address, address, uint) external returns(bool);
+}

--- a/contracts/asteroid/vendor/access/Ownable.sol
+++ b/contracts/asteroid/vendor/access/Ownable.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../utils/Context.sol";
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract Ownable is Context {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    constructor () {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(owner() == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}

--- a/contracts/asteroid/vendor/proxy/ProxyAdmin.sol
+++ b/contracts/asteroid/vendor/proxy/ProxyAdmin.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../access/Ownable.sol";
+import "./TransparentUpgradeableProxy.sol";
+
+/**
+ * @dev This is an auxiliary contract meant to be assigned as the admin of a {TransparentUpgradeableProxy}. For an
+ * explanation of why you would want to use this see the documentation for {TransparentUpgradeableProxy}.
+ */
+contract ProxyAdmin is Ownable {
+
+    /**
+     * @dev Returns the current implementation of `proxy`.
+     *
+     * Requirements:
+     *
+     * - This contract must be the admin of `proxy`.
+     */
+    function getProxyImplementation(TransparentUpgradeableProxy proxy) public view virtual returns (address) {
+        // We need to manually run the static call since the getter cannot be flagged as view
+        // bytes4(keccak256("implementation()")) == 0x5c60da1b
+        (bool success, bytes memory returndata) = address(proxy).staticcall(hex"5c60da1b");
+        require(success);
+        return abi.decode(returndata, (address));
+    }
+
+    /**
+     * @dev Returns the current admin of `proxy`.
+     *
+     * Requirements:
+     *
+     * - This contract must be the admin of `proxy`.
+     */
+    function getProxyAdmin(TransparentUpgradeableProxy proxy) public view virtual returns (address) {
+        // We need to manually run the static call since the getter cannot be flagged as view
+        // bytes4(keccak256("admin()")) == 0xf851a440
+        (bool success, bytes memory returndata) = address(proxy).staticcall(hex"f851a440");
+        require(success);
+        return abi.decode(returndata, (address));
+    }
+
+    /**
+     * @dev Changes the admin of `proxy` to `newAdmin`.
+     *
+     * Requirements:
+     *
+     * - This contract must be the current admin of `proxy`.
+     */
+    function changeProxyAdmin(TransparentUpgradeableProxy proxy, address newAdmin) public virtual onlyOwner {
+        proxy.changeAdmin(newAdmin);
+    }
+
+    /**
+     * @dev Upgrades `proxy` to `implementation`. See {TransparentUpgradeableProxy-upgradeTo}.
+     *
+     * Requirements:
+     *
+     * - This contract must be the admin of `proxy`.
+     */
+    function upgrade(TransparentUpgradeableProxy proxy, address implementation) public virtual onlyOwner {
+        proxy.upgradeTo(implementation);
+    }
+
+    /**
+     * @dev Upgrades `proxy` to `implementation` and calls a function on the new implementation. See
+     * {TransparentUpgradeableProxy-upgradeToAndCall}.
+     *
+     * Requirements:
+     *
+     * - This contract must be the admin of `proxy`.
+     */
+    function upgradeAndCall(TransparentUpgradeableProxy proxy, address implementation, bytes memory data) public payable virtual onlyOwner {
+        proxy.upgradeToAndCall{value: msg.value}(implementation, data);
+    }
+}

--- a/contracts/asteroid/vendor/utils/Context.sol
+++ b/contracts/asteroid/vendor/utils/Context.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}

--- a/plugins/deployment_manager/DeploymentManager.ts
+++ b/plugins/deployment_manager/DeploymentManager.ts
@@ -127,7 +127,7 @@ export class DeploymentManager {
   }
 
   async readCache<T>(file: string): Promise<T> {
-    let cached = this.cache[file];
+    let cached = this.cache[file.toLowerCase()];
     if (cached) {
       return cached as T;
     } else {
@@ -137,7 +137,7 @@ export class DeploymentManager {
 
   // Checks to see if a file exists, either in in-memory cache or on disk.
   private async cacheFileExists(file: string): Promise<boolean> {
-    if (this.cache[file]) {
+    if (this.cache[file.toLowerCase()]) {
       return true;
     } else {
       return await fileExists(file);
@@ -159,7 +159,7 @@ export class DeploymentManager {
 
       await fs.writeFile(filePath, JSON.stringify(object, null, 4));
     } else {
-      this.cache[filePath] = object;
+      this.cache[filePath.toLowerCase()] = object;
     }
   }
 

--- a/plugins/scenario/worker/Parent.ts
+++ b/plugins/scenario/worker/Parent.ts
@@ -117,7 +117,13 @@ export async function run<T>(scenarioConfig: ScenarioConfig, bases: ForkSpec[]) 
     checkDone();
   }
 
-  const worker = [...new Array(workerCount)].map((_, index) => {
+  const envWorkers = process.env['WORKERS'];
+  const trueWorkerCount = envWorkers ? Number(envWorkers) : workerCount;
+  if (Number.isNaN(trueWorkerCount) || trueWorkerCount <= 0) {
+    throw new Error(`Invalid worker count: ${envWorkers}`);
+  }
+
+  const worker = [...new Array(trueWorkerCount)].map((_, index) => {
     let worker = new Worker(path.resolve(__dirname, './BootstrapWorker.js'), {
       workerData: {
         scenarioConfig,


### PR DESCRIPTION
This patch fixes scenarios by adding back in contracts we use in deployments. Additionally, we improve the speed and efficiency of scenarios by compiling and spidering before calling into scenarios, which means scenarios need to do less spidering themselves (which was being done inefficiently). This should fix the majority of problems we see in CI scenario runs. We also cache the deployment (spider) artifacts, so that spiders can run faster in the future.
