### PR TITLE
Setup Modern Constraint

### DIFF
--- a/plugins/scenario/Runner.ts
+++ b/plugins/scenario/Runner.ts
@@ -21,7 +21,9 @@ function* combos(choices: object[][]) {
 
 function bindFunctions(obj: any) {
   for (let property of Object.getOwnPropertyNames(Object.getPrototypeOf(obj))) {
-    obj[property] = obj[property].bind(obj);
+    if (typeof(obj[property]) === 'function') {
+      obj[property] = obj[property].bind(obj);
+    }
   }
 }
 

--- a/scenario/CometScenario.ts
+++ b/scenario/CometScenario.ts
@@ -31,3 +31,7 @@ scenario('Comet#allow > allows a user to rescind authoization', {}, async ({ com
 scenario('has assets', {}, async ({ comet, actors, assets }, world) => {
   expect(await comet.assetAddresses()).to.have.members(Object.values(assets).map((asset) => asset.address));
 });
+
+scenario('requires upgrade', { upgrade: true }, async ({ comet }, world) => {
+  // Nothing currently here
+});

--- a/scenario/constraints/ModernConstraint.ts
+++ b/scenario/constraints/ModernConstraint.ts
@@ -1,0 +1,40 @@
+import { Constraint, Scenario, Solution, World } from '../../plugins/scenario';
+import { CometContext } from '../context/CometContext';
+import { deployComet } from '../../src/deploy';
+
+interface ModernConfig {
+  upgrade: boolean;
+}
+
+function getModernConfig(requirements: object): ModernConfig | null {
+  let upgrade = requirements['upgrade'];
+
+  return {
+    upgrade: !!upgrade
+  };
+}
+
+export class ModernConstraint<T extends CometContext> implements Constraint<T> {
+  async solve(requirements: object, context: T, world: World) {
+    let { upgrade } = getModernConfig(requirements);
+
+    if (!world.isDevelopment() && upgrade) {
+      return async (context: T): Promise<T> => {
+        console.log("Upgrading to modern...");
+        // TODO: Make this deployment script less ridiculous, e.g. since it redeploys tokens right now
+        let { comet: newComet } = await deployComet(context.deploymentManager, false);
+        await context.upgradeTo(newComet);
+
+        console.log("Upgraded to modern...");
+
+        return context; // It's been modified
+      };
+    } else {
+      return null;
+    }
+  }
+
+  async check(requirements: object, context: T, world: World) {
+    return; // XXX
+  }
+}

--- a/scenario/constraints/RemoteTokenConstraint.ts
+++ b/scenario/constraints/RemoteTokenConstraint.ts
@@ -1,32 +1,11 @@
 import { Constraint, Scenario, Solution, World } from '../../plugins/scenario';
 import { CometContext } from '../context/CometContext';
+import { requireString, requireList } from './utils';
 
 interface RemoteTokenConfig {
   network: string;
   address: string;
   args: any[];
-}
-
-function requireString(o: object, key: string, err: string): string {
-  let value: unknown = o[key];
-  if (value === undefined) {
-    throw new Error(err);
-  }
-  if (typeof value !== 'string') {
-    throw new Error(err + ' [value required to be string type]');
-  }
-  return value;
-}
-
-function requireList<T>(o: object, key: string, err: string): T[] {
-  let value: unknown = o[key];
-  if (value === undefined) {
-    throw new Error(err);
-  }
-  if (!Array.isArray(value)) {
-    throw new Error(err + ' [value required to be list type]');
-  }
-  return value as T[];
 }
 
 function getRemoteTokenConfig(requirements: object): RemoteTokenConfig | null {

--- a/scenario/constraints/index.ts
+++ b/scenario/constraints/index.ts
@@ -1,3 +1,4 @@
 export { BalanceConstraint } from '../constraints/BalanceConstraint';
 export { PauseConstraint } from '../constraints/PauseConstraint';
 export { RemoteTokenConstraint } from '../constraints/RemoteTokenConstraint';
+export { ModernConstraint } from '../constraints/ModernConstraint';

--- a/scenario/constraints/utils.ts
+++ b/scenario/constraints/utils.ts
@@ -1,0 +1,22 @@
+
+export function requireString(o: object, key: string, err: string): string {
+  let value: unknown = o[key];
+  if (value === undefined) {
+    throw new Error(err);
+  }
+  if (typeof value !== 'string') {
+    throw new Error(err + ' [value required to be string type]');
+  }
+  return value;
+}
+
+export function requireList<T>(o: object, key: string, err: string): T[] {
+  let value: unknown = o[key];
+  if (value === undefined) {
+    throw new Error(err);
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(err + ' [value required to be list type]');
+  }
+  return value as T[];
+}


### PR DESCRIPTION
This adds a constraint (currently called `ModernConstraint`) that ensures that for a given scenario, the current network has an up-to-date Comet contract that matches the current code. This is accomplished by setting a requirement `{upgrade: true}` and then the constraint will perform an upgrade on the TransparentUpgradeableProxy contract. If this is not specified, then you will be using the code from current chain (which may be out of date with your changes). This is the start in the "how do I get to a state I need to test my changes"-world, but it does not attempt to choose a long-term solution, just one that is valuable for testing out our new code developments.

Note: I'll remove `cool()` and `.only` before this is merged, but I wanted the scenario to be very clear how it works.