### PR TITLE
remove Cache Deployments step, duplicate compile step

### DIFF
--- a/.github/workflows/run-scenarios.yaml
+++ b/.github/workflows/run-scenarios.yaml
@@ -19,14 +19,8 @@ jobs:
           cache: 'yarn'
           node-version: '16'
 
-      - name: Cache Deployments
-        uses: actions/cache@v2
-        with:
-          path: deployments
-          key: deployments
-
       - name: Install packages
-        run: yarn install --non-interactive --frozen-lockfile && yarn build
+        run: yarn install --non-interactive --frozen-lockfile
 
       - name: Compile
         run: npx hardhat compile


### PR DESCRIPTION
I think this is what's causing the issues on PRs #99 and #102 

also removed the call to `yarn build`, since we call `npx hardhat compile` immediately afterward