### PR TITLE
Copy of #102

### DIFF
--- a/test/comet-asset-info-test.ts
+++ b/test/comet-asset-info-test.ts
@@ -72,6 +72,19 @@ describe('Comet', function () {
     expect(assetInfo01.liquidateCollateralFactor).to.equal(FACTOR);
   });
 
+  it('Should fail if too many assets are passed', async () => {
+    const CometFactory = (await ethers.getContractFactory(
+      'Comet'
+    )) as Comet__factory;
+    await expect(CometFactory.deploy({
+      governor: governor.address,
+      pauseGuardian: pauseGuardian.address,
+      priceOracle: oracle.address,
+      baseToken: token.address,
+      assetInfo: [{ asset: asset1.address, borrowCollateralFactor: FACTOR, liquidateCollateralFactor: FACTOR }, { asset: asset2.address, borrowCollateralFactor: FACTOR, liquidateCollateralFactor: FACTOR }, { asset: asset2.address, borrowCollateralFactor: FACTOR, liquidateCollateralFactor: FACTOR }]
+    })).to.be.revertedWith('too many asset configs');
+  });
+
   it('Should revert if index is greater that numAssets', async () => {
     await expect(comet.getAssetInfo(2)).to.be.revertedWith('asset info not found');
   });
@@ -96,4 +109,5 @@ describe('Comet', function () {
     expect(assets[0]).to.be.equal(assetInfo00.asset);
     expect(assets[1]).to.be.equal(assetInfo01.asset);
   });
+
 });


### PR DESCRIPTION
Testing out unexpected Github behavior.

Toni's PR (#102) was experiencing the same caching error as I was. As of opening this branch, the PR for #102 is failing CI:

<img width="1165" alt="Screen Shot 2022-01-07 at 6 23 56 PM" src="https://user-images.githubusercontent.com/2570291/148628138-fb1abe44-6bcc-43d8-b492-77bafa5b32dc.png">

I'm opening a PR with the same commits and seeing if the fresh CI run for this PR updates the status of #102.

---

UPDATE: yep, it totally worked:

![image](https://user-images.githubusercontent.com/2570291/148628169-1b0ff812-67cf-4884-9ce3-90ddfe0ae26f.png)

So this is a roundabout way of busting the cache of CI actions

