### PR TITLE
Better Caching

### DIFF
--- a/.github/workflows/run-scenarios.yaml
+++ b/.github/workflows/run-scenarios.yaml
@@ -22,8 +22,15 @@ jobs:
       - name: Cache Deployments
         uses: actions/cache@v2
         with:
-          path: deployments
-          key: deployments
+          path: |
+            deployments/*/cache/*
+            deployments/*/pointers.json
+            deployments/*/proxies.json
+            !deployments/hardhat
+            !deployments/relations.json
+            !deployments/**/roots.json
+            !deployments/**/relations.json
+          key: deployments-v2
 
       - name: Install packages
         run: yarn install --non-interactive --frozen-lockfile && yarn build


### PR DESCRIPTION
This patch attempts to improve caching for scenarios (deployments/spider) by caching only files that should not be overwritten. We specifically cover `roots.json` and `relations.json`, which should never be cached.