### PR TITLE
Add Utilization Constraint

### DIFF
--- a/.github/workflows/run-scenarios.yaml
+++ b/.github/workflows/run-scenarios.yaml
@@ -52,4 +52,3 @@ jobs:
           name: Scenario Tests              # Name of the check run which will be created
           path: 'scenario-results.json'     # Path to test results (inside artifact .zip)
           reporter: mocha-json              # Format of test results
-

--- a/SCENARIO.md
+++ b/SCENARIO.md
@@ -14,6 +14,14 @@ You can skip the spider step if you wish:
 
 `npx hardhat scenario --no-spider true`
 
+You can change the number of workers:
+
+`npx hardhat scenario --workers 1`
+
+And run synchronously, without worker threads:
+
+`npx hardhat scenario --workers 1 --sync true`
+
 ## Adding New Scenarios
 
 To add a new scenario, add to `scenario/`, e.g.

--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -955,4 +955,16 @@ contract Comet is CometMath, CometStorage {
 
         doTransferOut(asset, to, amount);
     }
+
+    // TODO: Remove me. Function while waiting for initializer
+    // !! NOT FOR REUSE [YES FOR REFUSE] !!
+    function XXX_REMOVEME_XXX_initialize() public {
+        require(totalsBasic.lastAccrualTime == 0, "already initialized");
+        // Initialize aggregates
+        totalsBasic.lastAccrualTime = getNow();
+        totalsBasic.baseSupplyIndex = baseIndexScale;
+        totalsBasic.baseBorrowIndex = baseIndexScale;
+        totalsBasic.trackingSupplyIndex = 0;
+        totalsBasic.trackingBorrowIndex = 0;
+    }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -76,7 +76,7 @@ function setupDefaultNetworkProviders(hardhatConfig: HardhatUserConfig) {
     hardhatConfig.networks[netConfig.network] = {
       chainId: netConfig.chainId,
       url: netConfig.url || getDefaultProviderURL(netConfig.network),
-      gas: netConfig.gasPrice || 'auto',
+      gas: netConfig.gas || 'auto',
       gasPrice: netConfig.gasPrice || 'auto',
       accounts: ETH_PK
         ? [ETH_PK]
@@ -104,7 +104,7 @@ const config: HardhatUserConfig = {
   networks: {
     hardhat: {
       chainId: 1337,
-      loggingEnabled: false,
+      loggingEnabled: !!process.env['LOGGING'],
       gas: 12000000,
       gasPrice: 'auto',
       blockGasLimit: 12000000,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@nomiclabs/hardhat-ethers": "^2.0.3",
     "@nomiclabs/hardhat-etherscan": "^3.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
-    "@openzeppelin/contracts-upgradeable": "^4.4.1",
     "@typechain/ethers-v5": "^8.0.2",
     "@typechain/hardhat": "^3.0.0",
     "@types/chai": "^4.2.22",

--- a/plugins/deployment_manager/DeploymentManager.ts
+++ b/plugins/deployment_manager/DeploymentManager.ts
@@ -521,7 +521,12 @@ export class DeploymentManager {
     C extends Contract,
     Factory extends Deployer<C, DeployArgs>,
     DeployArgs extends Array<any>
-  >(contractFile: string, deployArgs: DeployArgs, connect?: Signer): Promise<C> {
+  >(
+    contractFile: string,
+    deployArgs: DeployArgs,
+    connect?: Signer,
+    overwrite: boolean = false // should we overwrite existing contract link
+  ): Promise<C> {
     // TODO: Handle aliases, etc.
     let contractFileName = contractFile.split('/').reverse()[0];
     let contractName = contractFileName.replace('.sol', '');
@@ -553,7 +558,7 @@ export class DeploymentManager {
       output: BuildFile;
     };
 
-    if (!buildFile.contract) {
+    if (overwrite || !buildFile.contract) {
       buildFile.contract = contractName;
     }
     let cacheBuildFile = this.cacheBuildFile(contract.address);

--- a/plugins/scenario/World.ts
+++ b/plugins/scenario/World.ts
@@ -1,3 +1,4 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { Signer } from 'ethers';
 
@@ -35,7 +36,7 @@ export class World {
     });
   }
 
-  async impersonateAddress(address: string): Promise<Signer> {
+  async impersonateAddress(address: string): Promise<SignerWithAddress> {
     await this.hre.network.provider.request({
       method: 'hardhat_impersonateAccount',
       params: [address],

--- a/plugins/scenario/utils/ERC20.ts
+++ b/plugins/scenario/utils/ERC20.ts
@@ -1,4 +1,6 @@
-[
+import { ethers } from 'ethers';
+
+export const erc20 = new ethers.utils.Interface([
     {
         "constant": true,
         "inputs": [],
@@ -219,4 +221,4 @@
         "name": "Transfer",
         "type": "event"
     }
-]
+]);

--- a/plugins/scenario/worker/BootstrapWorker.js
+++ b/plugins/scenario/worker/BootstrapWorker.js
@@ -5,4 +5,9 @@ const { workerData } = require('worker_threads');
 require('ts-node').register();
 let { run } = require(path.resolve(__dirname, './Worker.ts'));
 
-run(workerData);
+run(workerData).catch((e) => {
+  console.error(e);
+  setTimeout(() => { // Deferral to allow potential console flush
+    throw e;
+  }, 0);
+});

--- a/plugins/scenario/worker/Report.ts
+++ b/plugins/scenario/worker/Report.ts
@@ -75,6 +75,23 @@ interface JsonTestResult {
   err: any
 };
 
+interface JsonSuiteResult {
+  stats: {
+    suites: number,
+    tests: number,
+    passes: number,
+    pending: number,
+    failures: number,
+    start: string,
+    end: string,
+    duration: number
+  },
+  tests: JsonTestResult[],
+  pending: JsonTestResult[],
+  failures: JsonTestResult[],
+  passes: JsonTestResult[],
+};
+
 async function showJsonReport(results: Result[], jsonOptions: JsonFormatOptions, startTime: number, endTime: number) {
   // TODO: Accept options, etc.
   let suites = new Set();
@@ -91,7 +108,7 @@ async function showJsonReport(results: Result[], jsonOptions: JsonFormatOptions,
       file: result.file,
       duration: result.elapsed || 0,
       currentRetry: 0,
-      err: result.error ?? {}
+      err: result.error ? result.error.message : {} // Not sure
     };
 
     if (result.error) {
@@ -105,8 +122,7 @@ async function showJsonReport(results: Result[], jsonOptions: JsonFormatOptions,
     return test;
   });
 
-
-  let result = JSON.stringify({
+  let suiteResult: JsonSuiteResult = {
     stats: {
       suites: suites.size,
       tests: tests.length,
@@ -121,7 +137,9 @@ async function showJsonReport(results: Result[], jsonOptions: JsonFormatOptions,
     pending,
     failures,
     passes,
-  }, null, 4);
+  }
+
+  let result = JSON.stringify(suiteResult, null, 4);
 
   if (jsonOptions.output) {
     await fs.writeFile(jsonOptions.output, result);

--- a/plugins/scenario/worker/SimpleWorker.ts
+++ b/plugins/scenario/worker/SimpleWorker.ts
@@ -1,0 +1,60 @@
+import { run, WorkerData } from './Worker';
+
+export type Handler = (any) => Promise<void>;
+
+export class SimpleWorker {
+  workerData: WorkerData;
+  childMessages: any[];
+  parentMessages: any[];
+  childHandlers: Handler[];
+  parentHandlers: Handler[];
+
+  constructor(workerData: WorkerData) {
+    this.workerData = workerData;
+    this.childMessages = [];
+    this.parentMessages = [];
+    this.childHandlers = [];
+    this.parentHandlers = [];
+  }
+
+  // Register to child messages
+  on(msg: 'message', f: (message: any) => Promise<void>) {
+    this.parentHandlers.push(f);
+
+    this.parentMessages.forEach((msg) => f(msg));
+    this.parentMessages = []; // Clear out messages
+  }
+
+  // Post message to child
+  postMessage(message: any) {
+    if (this.childHandlers.length > 0) {
+      this.childHandlers.forEach((f) => f(message));
+    } else {
+      this.childMessages.push(message); // store if no handlers
+    }
+  }
+
+  // Register to parent messages
+  onParent(msg: 'message', f: (message: any) => Promise<void>) {
+    this.childHandlers.push(f);
+
+    this.childMessages.forEach((msg) => f(msg));
+    this.childMessages = []; // Clear out messages
+  }
+
+  // Post message to parent
+  postParentMessage(message: any) {
+    this.parentHandlers.forEach((f) => f(message));
+  }
+
+  async run() {
+    try {
+      await run({ ...this.workerData, worker: this });
+    } catch (e) {
+      console.error(e);
+      setTimeout(() => { // Deferral to allow potential console flush
+        throw e;
+      }, 0);
+    }
+  }
+}

--- a/plugins/scenario/worker/Worker.ts
+++ b/plugins/scenario/worker/Worker.ts
@@ -2,7 +2,7 @@ import { parentPort } from 'worker_threads';
 import { Runner } from '../Runner';
 import { ForkSpec } from '../World';
 import { Scenario } from '../Scenario';
-import { loadScenarios } from '../Loader';
+import { getLoader, loadScenarios } from '../Loader';
 import { HardhatContext } from 'hardhat/internal/context';
 import { scenarioGlob } from './Config';
 import {
@@ -15,6 +15,8 @@ import {
 import * as util from 'util';
 import { ScenarioConfig } from '../types';
 import { AssertionError } from 'chai';
+import { SimpleWorker } from './SimpleWorker';
+
 
 interface Message {
   scenario?: {
@@ -23,24 +25,49 @@ interface Message {
   };
 }
 
+export type WorkerData = {
+  scenarioConfig: ScenarioConfig;
+  bases: ForkSpec[];
+  config: [HardhatConfig, HardhatArguments];
+  worker?: SimpleWorker;
+};
+
+// Helper function to cede control fo the thread
+// JavaScript's scheduler is cooperative, so we cede control by asking for
+// a timer callback. Once the scheduler gives us back control, we execute `f`.
 function eventually(fn: () => void) {
   setTimeout(fn, 0);
 }
 
-export async function run<T>({
-  scenarioConfig,
-  bases,
-  config,
-}: {
-  scenarioConfig: ScenarioConfig;
-  bases: ForkSpec[];
-  config: [HardhatConfig, HardhatArguments];
-}) {
-  createContext(...config);
-  let scenarios: { [name: string]: Scenario<T> } = await loadScenarios(scenarioGlob);
+function onMessage(worker: SimpleWorker | undefined, f: (message: Message) => Promise<void>) {
+  if (worker) {
+    worker.onParent('message', f)
+  } else {
+    parentPort.on('message', f);
+  }
+}
+
+function postMessage(worker: SimpleWorker | undefined, message: any) {
+  if (worker) {
+    worker.postParentMessage(message);
+  } else {
+    parentPort.postMessage(message);
+  }
+}
+
+export async function run<T>({ scenarioConfig, bases, config, worker }: WorkerData) {
+  let scenarios: { [name: string]: Scenario<T> };
+
+  if (!worker) { // only create if we're not in a simple worker
+    createContext(...config);
+    scenarios = await loadScenarios(scenarioGlob);
+  } else {
+    scenarios = getLoader<T>().getScenarios();
+  }
+
   let baseMap = Object.fromEntries(bases.map((base) => [base.name, base]));
 
-  parentPort.on('message', async (message: Message) => {
+  onMessage(worker, async (message: Message) => {
     if (message.scenario) {
       let { scenario: scenarioName, base: baseName } = message.scenario;
       let scenario = scenarios[scenarioName];
@@ -62,7 +89,7 @@ export async function run<T>({
         }
         // Add timeout for flush
         eventually(() =>
-          parentPort.postMessage({
+          postMessage(worker, {
             result: {
               base: base.name,
               file: scenario.file || scenario.name,

--- a/scenario/InterestRateScenario.ts
+++ b/scenario/InterestRateScenario.ts
@@ -1,6 +1,6 @@
 import { scenario } from './context/CometContext';
 import { expect } from 'chai';
-import { exp } from '../test/helpers';
+import { defactor, exp, factor } from '../test/helpers';
 import { BigNumber } from 'ethers';
 
 function calculateSupplyRate(
@@ -115,3 +115,10 @@ scenario(
 );
 
 // TODO: Scenario for testing custom configuration constants using a utilization constraint.
+scenario(
+  'Comet#interestRate > when utilization is 50%',
+  { utilization: 0.50, upgrade: true },
+  async ({ comet, actors }) => {
+    expect(defactor(await comet.getUtilization())).to.approximately(0.5, 0.000001);
+  }
+);

--- a/scenario/constraints/ModernConstraint.ts
+++ b/scenario/constraints/ModernConstraint.ts
@@ -1,6 +1,8 @@
 import { Constraint, Scenario, Solution, World } from '../../plugins/scenario';
 import { CometContext } from '../context/CometContext';
 import { CometConfigurationOverrides, deployComet } from '../../src/deploy';
+import CometAsset from '../context/CometAsset';
+import { Contract } from 'ethers';
 
 interface ModernConfig {
   upgrade: boolean;
@@ -25,8 +27,19 @@ export class ModernConstraint<T extends CometContext> implements Constraint<T> {
       return async (context: T): Promise<T> => {
         console.log("Upgrading to modern...");
         // TODO: Make this deployment script less ridiculous, e.g. since it redeploys tokens right now
-        let { comet: newComet } = await deployComet(context.deploymentManager, false, cometConfig);
-        await context.upgradeTo(newComet);
+        let { comet: newComet, tokens } = await deployComet(context.deploymentManager, false, cometConfig);
+        let initializer: string | undefined = undefined;
+        if (!context.comet.totalsBasic || (await context.comet.totalsBasic()).lastAccrualTime === 0) {
+          initializer = (await newComet.populateTransaction.XXX_REMOVEME_XXX_initialize()).data
+        }
+
+        await context.upgradeTo(newComet, initializer);
+
+        context.assets = {
+          DAI: new CometAsset(tokens[0]),
+          GOLD: new CometAsset(tokens[1]),
+          SILVER: new CometAsset(tokens[2]),
+        };
 
         console.log("Upgraded to modern...");
 

--- a/scenario/constraints/UtilizationConstraint.ts
+++ b/scenario/constraints/UtilizationConstraint.ts
@@ -1,0 +1,145 @@
+import { Constraint, Scenario, Solution, World } from '../../plugins/scenario';
+import { CometContext } from '../context/CometContext';
+import { deployComet } from '../../src/deploy';
+import { optionalNumber } from './utils';
+import { defactor, exp, factor, factorScale, ZERO } from '../../test/helpers';
+import { expect } from 'chai';
+
+/**
+  # Utilization Constraint
+  
+  This constraint is used to constrain the utilization rate, by adjust the total
+  supply and/or borrows of Comet.
+  
+  ## Configuration
+  
+  **requirements**: `{ utilization: number }`
+  
+  If passed in, the constraint will ensure that the utilization of the protocol
+  is exactly the given value. If this constraint cannot be fulfilled, we will
+  throw an error, rather than return "no solutions."
+  
+  * Example: `{ utilization: 0.5 }` to target 50% utilization (borrows / supply).
+  * Note: if utilization is passed as 0, this will target either borrows=0 or supply=0
+**/
+
+interface UtilizationConfig {
+  utilization?: number;
+}
+
+function getUtilizationConfig(requirements: object): UtilizationConfig | null {
+  return {
+    utilization: optionalNumber(requirements, 'utilization')
+  };
+}
+
+function floor(n: number): bigint {
+  return BigInt(Math.floor(n));
+}
+
+/*
+some math notes:
+
+let utilization = borrows / supply
+
+check if (utilization < target):
+  *> (borrows + X) / supply = target
+  -> (borrows + X) = target * supply
+  -> X = target * supply - borrows
+else
+  *> borrows / (supply+X) = target
+  -> borrows = target * (supply+X)
+  -> borrows / target = (supply+X)
+  -> ( borrows / target ) - supply = X
+*/
+export class UtilizationConstraint<T extends CometContext> implements Constraint<T> {
+  async solve(requirements: object, context: T, world: World) {
+    let { utilization } = getUtilizationConfig(requirements);
+
+    if (!utilization) {
+      return null;
+    } else {
+      // utilization is target number
+      return async ({ comet }: T): Promise<T> => {
+        let baseToken = context.getAssetByAddress(await comet.baseToken());
+        let utilizationFactor = factor(utilization);
+        let { totalSupplyBase: totalSupplyBaseBN, totalBorrowBase: totalBorrowBaseBN } = await comet.totalsBasic();
+        let totalSupplyBase = totalSupplyBaseBN.toBigInt();
+        let totalBorrowBase = totalBorrowBaseBN.toBigInt();
+
+        let toBorrowBase: bigint = 0n;
+        let toSupplyBase: bigint = 0n;
+
+        // TODO: Handle units for precision, etc
+        if (totalSupplyBase == 0n) {
+          toSupplyBase = (await comet.baseScale()).toBigInt(); // Have at least one base unit
+        }
+
+        let expectedSupplyBase = totalSupplyBase + toSupplyBase;
+        let currentUtilization = totalBorrowBase / expectedSupplyBase;
+
+        if (currentUtilization < utilizationFactor) {
+          toBorrowBase = toBorrowBase + floor(utilization * Number(expectedSupplyBase)) - totalBorrowBase;
+        } else {
+          toSupplyBase = toSupplyBase + floor(Number(totalBorrowBase) / utilization) - expectedSupplyBase;
+        }
+
+        // It's really hard to target a utilization if we don't have _any_ base token supply, since
+        // everything will come out as zero.
+        if (toSupplyBase > 0n) {
+          // Add some supply, any amount will do
+          let supplyActor = await context.allocateActor(world, "UtilizationConstraint{Supplier}", { toSupplyBase });
+
+          await baseToken.approve(supplyActor, comet);
+          await context.sourceTokens(world, toSupplyBase, baseToken, supplyActor);
+          await comet.connect(supplyActor.signer).supply(baseToken.address, toSupplyBase);
+        }
+
+        if (toBorrowBase > 0n) {
+          // To borrow as much, we need to supply some collateral. We technically
+          // could provide a solution for each token, but we don't know them in advance,
+          // generally, so let's just pick the first one and source enough of it.
+
+          let [ { asset: collateralAsset, borrowCollateralFactor }, ...assets] = await comet.assets();
+
+          // Lastly, we'll need price, which I'm going to punt until we've worked on the oracle for
+          // But this would be something like `Oracle(comet.priceOracle).getPrice(asset)`
+          let collateralToken = context.getAssetByAddress(collateralAsset);
+
+          let baseDecimals = 18; // TODO
+          let borrowDecimals = 8; // TODO
+          let priceAsset = exp(4000, 6 + 18 - borrowDecimals); // from the mock oracle
+          let priceBase = exp(4000, 6 + 18 - baseDecimals); // from the mock oracle
+
+          let collateralNeeded = ( toBorrowBase * borrowCollateralFactor.toBigInt() * priceBase ) / ( priceAsset * factorScale );
+          let info = {
+            utilization,
+            totalSupplyBase: totalSupplyBase.toString(),
+            totalBorrowBase: totalBorrowBase.toString(),
+            toBorrowBase: toBorrowBase.toString(),
+            collateralAsset,
+            borrowCollateralFactor: borrowCollateralFactor.toString(),
+            collateralNeeded: collateralNeeded.toString()
+          };
+
+          let borrowActor = await context.allocateActor(world, "UtilizationConstraint{Borrower}", info);
+
+          await context.sourceTokens(world, collateralNeeded, collateralToken, borrowActor);
+          await collateralToken.approve(borrowActor, comet);
+          await comet.connect(borrowActor.signer).supply(collateralToken.address, collateralNeeded);
+          await comet.connect(borrowActor.signer).withdraw(baseToken.address, toBorrowBase);
+        }
+
+        return context;
+      };
+    }
+  }
+
+  async check(requirements: object, { comet }: T, world: World) {
+    let { utilization } = getUtilizationConfig(requirements);
+
+    if (utilization) {
+      expect(defactor(await comet.getUtilization())).to.approximately(0.5, 0.000001);
+    }
+  }
+}

--- a/scenario/constraints/index.ts
+++ b/scenario/constraints/index.ts
@@ -2,3 +2,4 @@ export { BalanceConstraint } from '../constraints/BalanceConstraint';
 export { PauseConstraint } from '../constraints/PauseConstraint';
 export { RemoteTokenConstraint } from '../constraints/RemoteTokenConstraint';
 export { ModernConstraint } from '../constraints/ModernConstraint';
+export { UtilizationConstraint } from '../constraints/UtilizationConstraint';

--- a/scenario/constraints/utils.ts
+++ b/scenario/constraints/utils.ts
@@ -5,7 +5,7 @@ export function requireString(o: object, key: string, err: string): string {
     throw new Error(err);
   }
   if (typeof value !== 'string') {
-    throw new Error(err + ' [value required to be string type]');
+    throw new Error(`${err} [requirement ${key} required to be string type]`);
   }
   return value;
 }
@@ -16,7 +16,29 @@ export function requireList<T>(o: object, key: string, err: string): T[] {
     throw new Error(err);
   }
   if (!Array.isArray(value)) {
-    throw new Error(err + ' [value required to be list type]');
+    throw new Error(`${err} [requirement ${key} required to be list type]`);
   }
   return value as T[];
+}
+
+export function requireNumber<T>(o: object, key: string, err: string): number {
+  let value: unknown = o[key];
+  if (value === undefined) {
+    throw new Error(err);
+  }
+  if (typeof value !== 'number') {
+    throw new Error(`${err} [requirement ${key} required to be number type]`);
+  }
+  return value;  
+}
+
+export function optionalNumber<T>(o: object, key: string): number {
+  let value: unknown = o[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'number') {
+    throw new Error(`[requirement ${key} required to be number type]`);
+  }
+  return value;  
 }

--- a/scenario/context/Address.ts
+++ b/scenario/context/Address.ts
@@ -1,0 +1,15 @@
+
+export function getAddressFromNumber(n: number): string {
+  // If you think this is weird and hacky to get an address, you're right.
+  let zeroAddress = "0000000000000000000000000000000000000000";
+  let numberHex = n.toString(16);
+  let address = `${zeroAddress}${numberHex}`.slice(-40);
+
+  return '0x' + address;
+}
+
+export type AddressLike = string | { address: string };
+
+export function resolveAddress(v: AddressLike): string {
+  return typeof(v) === 'string' ? v : v.address;
+}

--- a/scenario/context/CometAsset.ts
+++ b/scenario/context/CometAsset.ts
@@ -1,5 +1,9 @@
 import { BigNumberish, Contract, Signer } from 'ethers';
 import { ERC20 } from '../../build/types';
+import CometActor from './CometActor';
+import { AddressLike, resolveAddress } from './Address';
+import { constants } from 'ethers';
+import { wait } from '../../test/helpers';
 
 export default class CometAsset {
   token: ERC20;
@@ -10,7 +14,26 @@ export default class CometAsset {
     this.address = token.address;
   }
 
-  async balanceOf(address: string): Promise<bigint> {
-    return 0n; // XXX
+  async balanceOf(actorOrAddress: string | CometActor): Promise<bigint> {
+    let address: string;
+    if (typeof(actorOrAddress) === 'string') {
+      address = actorOrAddress;
+    } else {
+      address = actorOrAddress.address;
+    }
+
+    return (await this.token.balanceOf(address)).toBigInt();
+  }
+
+  async transfer(from: CometActor, amount: number | bigint, recipient: CometAsset | string) {
+    let recipientAddress = typeof(recipient) === 'string' ? recipient : recipient.address;
+
+    await wait(this.token.connect(from.signer).transfer(recipientAddress, amount));
+  }
+
+  async approve(from: CometActor, spender: AddressLike, amount?: number) {
+    let spenderAddress = resolveAddress(spender)
+    let finalAmount = amount ?? constants.MaxUint256;
+    await wait(this.token.connect(from.signer).approve(spenderAddress, finalAmount));
   }
 }

--- a/scenario/context/CometContext.ts
+++ b/scenario/context/CometContext.ts
@@ -1,4 +1,4 @@
-import { Signer, Contract } from 'ethers';
+import { BytesLike, Signer, Contract } from 'ethers';
 import { ForkSpec, World, buildScenarioFn } from '../../plugins/scenario';
 import { ContractMap, DeploymentManager } from '../../plugins/deployment_manager/DeploymentManager';
 import {
@@ -6,12 +6,15 @@ import {
   ModernConstraint,
   PauseConstraint,
   RemoteTokenConstraint,
+  UtilizationConstraint,
 } from '../constraints';
 import CometActor from './CometActor';
 import CometAsset from './CometAsset';
 import { Comet, deployComet } from '../../src/deploy';
 import { ProxyAdmin, ERC20 } from '../../build/types';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { sourceTokens } from '../../plugins/scenario/utils/TokenSourcer';
+import { AddressLike, getAddressFromNumber, resolveAddress } from './Address';
 
 export class CometContext {
   deploymentManager: DeploymentManager;
@@ -31,18 +34,78 @@ export class CometContext {
     this.proxyAdmin = proxyAdmin;
   }
 
+  private debug(...args: any[]) {
+    if (true) { // debug if?
+      if (typeof args[0] === 'function') {
+        console.log(...args[0]());
+      } else {
+        console.log(...args);
+      }
+    }
+  }
+
   contracts(): ContractMap {
     return this.deploymentManager.contracts;
   }
 
-  async upgradeTo(newComet: Comet) {
-    await this.proxyAdmin.upgrade(this.comet.address, newComet.address);
+  async upgradeTo(newComet: Comet, data?: string) {
+    if (data) {
+      await this.proxyAdmin.upgradeAndCall(this.comet.address, newComet.address, data);
+    } else {
+      await this.proxyAdmin.upgrade(this.comet.address, newComet.address);
+    }
+
     this.comet = new this.deploymentManager.hre.ethers.Contract(this.comet.address, newComet.interface, this.comet.signer) as Comet;
+  }
+
+  async allocateActor(world: World, name: string, info: object = {}): Promise<CometActor> {
+    let actorAddress = getAddressFromNumber(Object.keys(this.actors).length + 1);
+    let signer = await world.impersonateAddress(actorAddress);
+    let actor: CometActor = new CometActor(name, signer, actorAddress, this, info);
+    this.actors[name] = actor;
+
+    // For now, send some Eth from the first actor. Pay attention in the future
+    let [_name, admin] = Object.entries(this.actors)[0];
+    await admin.sendEth(actor, 0.1);
+
+    return actor;
+  }
+
+  getAssetByAddress(address: string): CometAsset {
+    for (let [name, asset] of Object.entries(this.assets)) {
+      if (asset.address.toLowerCase() === address.toLowerCase()) {
+        return asset;
+      }
+    }
+    throw new Error(`Unable to find asset by address ${address}`);
+  }
+
+  async sourceTokens(world: World, amount: number | bigint, asset: CometAsset | string, recipient: AddressLike) {
+    let recipientAddress = resolveAddress(recipient);
+    let cometAsset = typeof(asset) === 'string' ? this.getAssetByAddress(asset) : asset;
+
+    // First, try to steal from a known actor
+    for (let [name, actor] of Object.entries(this.actors)) {
+      let actorBalance = await cometAsset.balanceOf(actor);
+      if (actorBalance > amount) {
+        this.debug(`Source Tokens: stealing from actor ${name}`);
+        await cometAsset.transfer(actor, amount, recipientAddress);
+        return;
+      }
+    }
+
+    if (world.isDevelopment()) {
+      throw new Error('Tokens cannot be sourced from Etherscan for development. Actors did not have sufficient assets.');
+    } else {
+      this.debug("Source Tokens: sourcing from Etherscan...");
+      // TODO: Note, this never gets called right now since all tokens are faucet tokens we've created.
+      await sourceTokens({hre: this.deploymentManager.hre, amount, asset: cometAsset.address, address: recipientAddress});
+    }
   }
 }
 
-async function buildActor(signer: SignerWithAddress, context: CometContext) {
-  return new CometActor(signer, await signer.getAddress(), context);
+async function buildActor(name: string, signer: SignerWithAddress, context: CometContext) {
+  return new CometActor(name, signer, await signer.getAddress(), context);
 }
 
 const getInitialContext = async (world: World): Promise<CometContext> => {
@@ -85,14 +148,16 @@ const getInitialContext = async (world: World): Promise<CometContext> => {
   let context = new CometContext(deploymentManager, comet, proxyAdmin);
 
   context.actors = {
-    admin: await buildActor(adminSigner, context),
-    pauseGuardian: await buildActor(pauseGuardianSigner, context),
-    albert: await buildActor(albertSigner, context),
-    betty: await buildActor(bettySigner, context),
-    charles: await buildActor(charlesSigner, context),
+    admin: await buildActor("admin", adminSigner, context),
+    pauseGuardian: await buildActor("pauseGuardian", pauseGuardianSigner, context),
+    albert: await buildActor("albert", albertSigner, context),
+    betty: await buildActor("betty", bettySigner, context),
+    charles: await buildActor("charles", charlesSigner, context),
+    signer: await buildActor("signer", localAdminSigner, context),
   };
 
   context.assets = {
+    DAI: new CometAsset(getContract<ERC20>('DAI')),
     GOLD: new CometAsset(getContract<ERC20>('GOLD')),
     SILVER: new CometAsset(getContract<ERC20>('SILVER')),
   };
@@ -109,6 +174,7 @@ export const constraints = [
   new PauseConstraint(),
   new BalanceConstraint(),
   new RemoteTokenConstraint(),
+  new UtilizationConstraint(),
 ];
 
 export const scenario = buildScenarioFn<CometContext>(getInitialContext, forkContext, constraints);

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -9,6 +9,7 @@ import {
   MockedOracle__factory,
   ProxyAdmin,
   ProxyAdmin__factory,
+  ERC20,
   TransparentUpgradeableProxy__factory,
   TransparentUpgradeableProxy,
 } from '../build/types';
@@ -17,20 +18,20 @@ import { BigNumberish } from 'ethers';
 export { Comet } from '../build/types';
 
 export interface CometConfigurationOverrides {
-  governor?: string,
-  pauseGuardian?: string,
-  priceOracle?: string,
-  baseToken?: string,
-  trackingIndexScale?: string,
-  baseMinForRewards?: BigNumberish,
-  baseTrackingSupplySpeed?: BigNumberish,
-  baseTrackingBorrowSpeed?: BigNumberish,
-  assetInfo?: AssetInfoStruct[],
-  kink?: BigNumberish,
-  perYearInterestRateBase?: BigNumberish,
-  perYearInterestRateSlopeLow?: BigNumberish,
-  perYearInterestRateSlopeHigh?: BigNumberish,
-  reserveRate?: BigNumberish,
+  governor?: string;
+  pauseGuardian?: string;
+  priceOracle?: string;
+  baseToken?: string;
+  trackingIndexScale?: string;
+  baseMinForRewards?: BigNumberish;
+  baseTrackingSupplySpeed?: BigNumberish;
+  baseTrackingBorrowSpeed?: BigNumberish;
+  assetInfo?: AssetInfoStruct[];
+  kink?: BigNumberish;
+  perYearInterestRateBase?: BigNumberish;
+  perYearInterestRateSlopeLow?: BigNumberish;
+  perYearInterestRateSlopeHigh?: BigNumberish;
+  reserveRate?: BigNumberish;
 }
 
 async function makeToken(
@@ -43,14 +44,20 @@ async function makeToken(
   return await deploymentManager.deploy<
     FaucetToken,
     FaucetToken__factory,
-    [number, string, number, string]
-  >('test/FaucetToken.sol', [amount, name, decimals, symbol]);
+    [string, string, number, string]
+  >('test/FaucetToken.sol', [
+    (BigInt(amount) * 10n ** BigInt(decimals)).toString(),
+    name,
+    decimals,
+    symbol,
+  ]);
 }
 
 interface DeployedContracts {
   comet: Comet;
   oracle: MockedOracle;
   proxy: TransparentUpgradeableProxy | null;
+  tokens: ERC20[];
 }
 
 // TODO: Support configurable assets as well?
@@ -61,9 +68,9 @@ export async function deployComet(
 ): Promise<DeployedContracts> {
   const [governor, pauseGuardian] = await deploymentManager.hre.ethers.getSigners();
 
-  let baseToken = await makeToken(deploymentManager, 100000, 'DAI', 18, 'DAI');
-  let asset0 = await makeToken(deploymentManager, 200000, 'GOLD', 8, 'GOLD');
-  let asset1 = await makeToken(deploymentManager, 300000, 'SILVER', 10, 'SILVER');
+  let baseToken = await makeToken(deploymentManager, 1000000, 'DAI', 18, 'DAI');
+  let asset0 = await makeToken(deploymentManager, 2000000, 'GOLD', 8, 'GOLD');
+  let asset1 = await makeToken(deploymentManager, 3000000, 'SILVER', 10, 'SILVER');
 
   const oracle = await deploymentManager.deploy<MockedOracle, MockedOracle__factory, []>(
     'test/MockedOracle.sol',
@@ -85,30 +92,30 @@ export async function deployComet(
     supplyCap: (500000e10).toString(),
   };
 
+  let configuration = {
+    ...{
+      governor: await governor.getAddress(),
+      pauseGuardian: await pauseGuardian.getAddress(),
+      priceOracle: oracle.address,
+      baseToken: baseToken.address,
+      kink: (8e17).toString(), // 0.8
+      perYearInterestRateBase: (5e15).toString(), // 0.005
+      perYearInterestRateSlopeLow: (1e17).toString(), // 0.1
+      perYearInterestRateSlopeHigh: (3e18).toString(), // 3.0
+      reserveRate: (1e17).toString(), // 0.1
+      trackingIndexScale: (1e15).toString(), // XXX add 'exp' to scen framework?
+      baseTrackingSupplySpeed: 0, // XXX
+      baseTrackingBorrowSpeed: 0, // XXX
+      baseMinForRewards: 1, // XXX
+      baseBorrowMin: 1, // XXX
+      assetInfo: [assetInfo0, assetInfo1],
+    },
+    ...configurationOverrides,
+  };
+
   const comet = await deploymentManager.deploy<Comet, Comet__factory, [ConfigurationStruct]>(
     'Comet.sol',
-    [
-      {
-        ...{
-          governor: await governor.getAddress(),
-          pauseGuardian: await pauseGuardian.getAddress(),
-          priceOracle: oracle.address,
-          baseToken: baseToken.address,
-          kink: (8e17).toString(), // 0.8
-          perYearInterestRateBase: (5e15).toString(), // 0.005
-          perYearInterestRateSlopeLow: (1e17).toString(), // 0.1
-          perYearInterestRateSlopeHigh: (3e18).toString(), // 3.0
-          reserveRate: (1e17).toString(), // 0.1
-          trackingIndexScale: (1e15).toString(), // XXX add 'exp' to scen framework?
-          baseTrackingSupplySpeed: 0, // XXX
-          baseTrackingBorrowSpeed: 0, // XXX
-          baseMinForRewards: 1, // XXX
-          baseBorrowMin: 1, // XXX
-          assetInfo: [assetInfo0, assetInfo1],
-        },
-        ...configurationOverrides
-      },
-    ]
+    [configuration]
   );
 
   let proxy = null;
@@ -122,11 +129,11 @@ export async function deployComet(
     proxy = await deploymentManager.deploy<
       TransparentUpgradeableProxy,
       TransparentUpgradeableProxy__factory,
-      [string, string, []]
+      [string, string, string]
     >('vendor/proxy/TransparentUpgradeableProxy.sol', [
       comet.address,
       proxyAdmin.address,
-      [],
+      (await comet.populateTransaction.XXX_REMOVEME_XXX_initialize()).data,
     ]);
 
     await deploymentManager.setRoots({ TransparentUpgradeableProxy: proxy.address } as Roots);
@@ -136,5 +143,6 @@ export async function deployComet(
     comet,
     oracle,
     proxy,
+    tokens: [baseToken, asset0, asset1],
   };
 }

--- a/tasks/scenario/task.ts
+++ b/tasks/scenario/task.ts
@@ -26,13 +26,15 @@ function getBasesFromTaskArgs(givenBases: string | undefined, env: HardhatRuntim
 task('scenario', 'Runs scenario tests')
   .addOptionalParam('bases', 'Bases to run on [defaults to all]')
   .addOptionalParam('noSpider', 'skip spider', false, types.boolean)
+  .addOptionalParam('workers', 'count of workers', 6, types.int)
+  .addOptionalParam('sync', 'run synchronously', false, types.boolean)
   .setAction(async (taskArgs, env: HardhatRuntimeEnvironment) => {
     let bases: ForkSpec[] = getBasesFromTaskArgs(taskArgs.bases, env);
 
     if (!taskArgs.noSpider) {
       await env.run('scenario:spider', taskArgs);
     }
-    await runScenario(env.config.scenario, bases);
+    await runScenario(env.config.scenario, bases, taskArgs.workers, !taskArgs.sync);
   });
 
 task('scenario:spider', 'Runs spider in preparation for scenarios')

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -10,6 +10,7 @@ import {
   MockedOracle,
   MockedOracle__factory,
 } from '../build/types';
+import { BigNumber } from 'ethers';
 
 export { Comet, ethers, expect };
 
@@ -66,8 +67,26 @@ export function exp(i: number, d: Numeric = 0, r: Numeric = 6): bigint {
   return (BigInt(Math.floor(i * 10 ** Number(r))) * 10n ** BigInt(d)) / 10n ** BigInt(r);
 }
 
-const factorScale = exp(1, 18);
-const ONE = factorScale;
+export function factor(f: number): bigint {
+  return exp(f, factorDecimals);
+}
+
+function toBigInt(f: bigint | BigNumber): bigint {
+  if (typeof(f) === 'bigint') {
+    return f;
+  } else {
+    return f.toBigInt();
+  }
+}
+
+export function defactor(f: bigint | BigNumber): number {
+  return Number(toBigInt(f)) / 1e18;
+}
+
+export const factorDecimals = 18;
+export const factorScale = factor(1);
+export const ONE = factorScale;
+export const ZERO = factor(0);
 
 export async function getBlock(n?: number): Promise<Block> {
   const blockNumber = n === undefined ? await ethers.provider.getBlockNumber() : n;

--- a/yarn.lock
+++ b/yarn.lock
@@ -612,11 +612,6 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts-upgradeable@^4.4.1":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.4.1.tgz#5d2c0e82cc1f94ee38a27572217ef103d5c3d0ef"
-  integrity sha512-84dUN+TBY42D52BzUc4RHxU4KORs8Ys7dj3nH0WX1QKtlS6rrN45gL+sxaotkPdCqFLVLPyj+kd8GfJ4puxVjA==
-
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@resolver-engine/core/-/core-0.3.3.tgz#590f77d85d45bc7ecc4e06c654f41345db6ca967"


### PR DESCRIPTION
This patch adds a utilization constraint. We have to figure out exactly how much `base` to supply or borrow (or both, if there was no starting supply) to reach a target utilization ratio. We then also need to get the relative prices and figure out how much collateral to supply to get there. We then need to source that collateral. Plus we need to actually supply or borrow, which also, is not currently in Comet. So lots of little pieces. We also:
    
     * Stub supply, withdrawal and initialize as they are needed to get a working test
     * Fix a bug in hardhat config for `gasPrice !== gas`
     * Add optional logging for development
     * Add optional `--sync` option for workers that do not use threads (useful for extended debugging messages)
     * Remove unused contract (npm) dependency
     * Switch from `Token.sol` to `ERC20.sol` which is more canonical
     * Fix a malfunctioning `erc20.json` dependency
     * Fix (mostly) `sourceToken` that had an infinite stack bug
     * Add sourcing of tokens from known accounts (e.g. the creator) for dev. Many tokens don't emit `Transfer` in the constructor.
     * Add option for `upgradeAndCall` on `upgradeTo`
     * Reset assets in a redeploy (this is really wrong but needs to be thought of in the bigger network context).
     * Add `allocateActor` that creates a clean account with some Eth to prevent "reuse" errors on known accounts.
