### PR TITLE
Test-net Configuration

### DIFF
--- a/SCENARIO.md
+++ b/SCENARIO.md
@@ -12,7 +12,7 @@ You can run scenarios against a given base as:
 
 You can skip the spider step if you wish:
 
-`npx hardhat scenario --no-spider true`
+`npx hardhat scenario --no-spider`
 
 You can change the number of workers:
 
@@ -20,7 +20,7 @@ You can change the number of workers:
 
 And run synchronously, without worker threads:
 
-`npx hardhat scenario --workers 1 --sync true`
+`npx hardhat scenario --workers 1 --sync`
 
 ## Adding New Scenarios
 

--- a/deployments/fuji/configuration.json
+++ b/deployments/fuji/configuration.json
@@ -1,0 +1,37 @@
+{
+  "governor": "0xdd940fc821853799eaf27e9eb0a420ed3bcdc3ef",
+  "pauseGuardian": "0xdd940fc821853799eaf27e9eb0a420ed3bcdc3ef",
+  "baseToken": "USDC",
+  "baseTokenPriceFeed": "0x7898AcCC83587C3C55116c5230C17a6Cd9C71bad",
+  "reserveRate": 0.1,
+  "borrowMin": "1e6",
+  "targetReserves": 0,
+  "rates": {
+    "kink": 0.80,
+    "slopeLow": 0.02,
+    "slopeHigh": 0.10,
+    "base": 0.01
+  },
+  "tracking": {
+    "indexScale": "1e15",
+    "baseSupplySpeed": 0,
+    "baseBorrowSpeed": 0,
+    "baseMinForRewards": 1
+  },
+  "assets": {
+    "WBTC.e": {
+      "borrowCF": 0.6,
+      "liquidateCF": 0.5,
+      "supplyCap": "100e8",
+      "priceFeed": "0x31CF013A08c6Ac228C94551d535d5BAfE19c602a",
+      "scale": "1e8"
+    },
+    "WAVAX": {
+      "borrowCF": 0.7,
+      "liquidateCF": 0.8,
+      "supplyCap": "100e18",
+      "priceFeed": "0x5498BB86BC934c8D34FDA08E81D444153d0D06aD",
+      "scale": "1e18"
+    }
+  }
+}

--- a/deployments/fuji/migrations/001_DeployFuji.ts
+++ b/deployments/fuji/migrations/001_DeployFuji.ts
@@ -1,0 +1,152 @@
+import { DeploymentManager, Roots } from '../../../plugins/deployment_manager/DeploymentManager';
+import { migration } from '../../../plugins/deployment_manager/Migration';
+import { deployNetworkComet } from '../../../src/deploy/Network';
+import { DeployedContracts } from '../../../src/deploy/index';
+import { Contract } from 'ethers';
+import { exp, wait } from '../../../test/helpers';
+import { ProxyAdmin, ProxyAdmin__factory } from '../../../build/types';
+
+interface TargetConfig {
+  name: string;
+  address: string;
+  network: string;
+  args: any[];
+  pointer?: string;
+}
+
+async function clone<C extends Contract>(
+  deploymentManager: DeploymentManager,
+  target: TargetConfig,
+  initializer: (C) => Promise<void> = () => null
+): Promise<C> {
+  if (
+    !process.env['REDEPLOY'] &&
+    target.pointer &&
+    deploymentManager.contracts.hasOwnProperty(target.pointer)
+  ) {
+    console.log(`Skipping already existing contract: ${target.pointer}`);
+    return deploymentManager.contracts[target.pointer] as C;
+  }
+
+  console.log(`Importing ${target.name}`);
+  let buildFile = await deploymentManager.import(target.address, target.network);
+  console.log(`Deploying ${target.name} ${JSON.stringify(target.args)}`);
+  let contract = await deploymentManager.deployBuild(buildFile, target.args, true);
+  console.log(`Deployed ${target.name} to ${contract.address}`);
+
+  if (target.pointer) {
+    console.log(`Setting pointer from ${contract.address} to ${target.pointer}`);
+    await deploymentManager.setPointer(target.pointer, contract.address);
+  }
+
+  let deployed = (await contract.deployed()) as C;
+
+  await initializer(deployed);
+
+  return deployed;
+}
+
+async function sleep(timeout) {
+  await new Promise((resolve) => setTimeout(resolve, timeout));
+}
+
+migration<DeployedContracts>('001_DeployFuji', {
+  prepare: async (deploymentManager: DeploymentManager) => {
+    await deploymentManager.getContracts();
+    let [signer] = await deploymentManager.hre.ethers.getSigners();
+    let signerAddress = await signer.getAddress();
+
+    let usdcProxyAdminArgs: [] = [];
+    // TODO: Should we make sure this doesn't get aliased?
+    let usdcProxyAdmin = await deploymentManager.deploy<ProxyAdmin, ProxyAdmin__factory, []>(
+      'vendor/proxy/ProxyAdmin.sol',
+      usdcProxyAdminArgs
+    );
+
+    let usdcImplementation = await clone(deploymentManager, {
+      name: 'USDCImplementation',
+      address: '0xa3fa3d254bf6af295b5b22cc6730b04144314890',
+      network: 'avalanche',
+      args: [],
+      pointer: 'USDCImplementation',
+    });
+
+    let usdc;
+    let usdcProxy = await clone(
+      deploymentManager,
+      {
+        name: 'USDC',
+        address: '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e',
+        network: 'avalanche',
+        args: [usdcImplementation.address],
+        pointer: 'USDC',
+      },
+      async (usdcProxy) => {
+        await wait(await usdcProxy.changeAdmin(usdcProxyAdmin.address));
+        usdc = usdcImplementation.attach(usdcProxy.address);
+        // Give signer 10,000 USDC
+        await wait(
+          usdc.initialize(
+            'USD Coin',
+            'USDC',
+            'USD',
+            6,
+            signerAddress,
+            signerAddress,
+            signerAddress,
+            signerAddress
+          )
+        );
+        await wait(usdc.configureMinter(signerAddress, exp(10000, 6)));
+        await wait(usdc.mint(signerAddress, exp(10000, 6)));
+      }
+    );
+
+    let wbtc = await clone(
+      deploymentManager,
+      {
+        name: 'WBTC.e',
+        address: '0x50b7545627a5162f82a992c33b87adc75187b218',
+        network: 'avalanche',
+        args: [],
+        pointer: 'WBTC.e',
+      },
+      async (wbtc) => {
+        // Give signer 1000 WBTC
+        await wait(
+          wbtc.mint(
+            signerAddress,
+            exp(1000, 8),
+            '0x0000000000000000000000000000000000000000',
+            0,
+            '0x0000000000000000000000000000000000000000000000000000000000000000'
+          )
+        );
+      }
+    );
+
+    let wavax = await clone(
+      deploymentManager,
+      {
+        name: 'WAVAX',
+        address: '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7',
+        network: 'avalanche',
+        args: [],
+        pointer: 'WAVAX',
+      },
+      async (wavax) => {
+        // Give admin 0.01 WAVAX tokens [this is a precious resource here!]
+        await wait(wavax.deposit({ value: exp(0.01, 18) }));
+      }
+    );
+
+    return await deployNetworkComet(deploymentManager, true);
+  },
+  enact: async (deploymentManager: DeploymentManager, { proxy }) => {
+    console.log(
+      'Enacting by changing root... This only makes sense for the initial migration or a "reset".'
+    );
+    await deploymentManager.setRoots({ TransparentUpgradeableProxy: proxy.address } as Roots);
+    console.log('Enacted...');
+  },
+});

--- a/deployments/fuji/roots.json
+++ b/deployments/fuji/roots.json
@@ -1,3 +1,3 @@
 {
-    "TransparentUpgradeableProxy": "0xFDA1d2edD49b899c9504682bf90E5409Dd3d7116"
+    "TransparentUpgradeableProxy": "0xa192809D10d79F6c2F9571057cbf99520630292f"
 }

--- a/deployments/relations.json
+++ b/deployments/relations.json
@@ -7,8 +7,5 @@
       "baseToken",
       "assetAddresses"
     ]
-  },
-  "FaucetToken": {
-    "alias": "@symbol"
   }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -11,6 +11,7 @@ import 'solidity-coverage';
 import 'hardhat-gas-reporter';
 
 // Hardhat tasks
+import './tasks/migrate/task.ts';
 import './tasks/spider/task.ts';
 import './tasks/scenario/task.ts';
 
@@ -149,6 +150,7 @@ const config: HardhatUserConfig = {
       {
         name: 'goerli',
         url: getDefaultProviderURL('goerli'),
+        allocation: 0.1, // eth
       },
       {
         name: 'fuji',

--- a/plugins/deployment_manager/Migration.ts
+++ b/plugins/deployment_manager/Migration.ts
@@ -1,0 +1,78 @@
+import fg from 'fast-glob';
+import * as path from 'path';
+
+interface Action<T> {
+  prepare?: (DeploymentManager) => Promise<T>,
+  enact?: (DeploymentManager, T) => Promise<void>,
+}
+
+export interface Migration<T> {
+  name: string,
+  actions: Action<T>
+}
+
+class Loader<T> {
+  migrations: { [name: string]: Migration<T> };
+
+  constructor() {
+    this.migrations = {};
+  }
+
+  addMigration(
+    name: string,
+    actions: Action<T>
+  ) {
+    if (this.migrations[name]) {
+      throw new Error(`Duplicate migration by name: ${name}`);
+    }
+    this.migrations[name] = {
+      name,
+      actions
+    };
+  }
+
+  getMigrations(): { [name: string]: Migration<T> } {
+    return this.migrations;
+  }
+}
+
+let loader: any;
+
+function setupLoader<T>() {
+  if (loader) {
+    throw new Error('Loader already initialized');
+  }
+
+  loader = new Loader<T>();
+}
+
+export function getLoader<T>(): Loader<T> {
+  if (!loader) {
+    throw new Error('Loader not initialized');
+  }
+
+  return <Loader<T>>loader;
+}
+
+export async function loadMigrations<T>(glob: string): Promise<{ [name: string]: Migration<T> }> {
+  setupLoader<T>();
+
+  const entries = await fg(glob); // Grab all potential migration files
+
+  for (let entry of entries) {
+    let entryPath = path.join(process.cwd(), entry);
+
+    /* Import scenario file */
+    await import(entryPath);
+    /* Import complete */
+  }
+
+  return loader.getMigrations();
+}
+
+export function migration<T>(
+  name: string,
+  actions: Action<T>
+) {
+  getLoader().addMigration(name, actions);
+}

--- a/plugins/deployment_manager/Types.ts
+++ b/plugins/deployment_manager/Types.ts
@@ -9,6 +9,8 @@ export interface ContractMetadata {
   abi: string;
   bin: string;
   metadata: string;
+  source: string;
+  constructorArgs: string;
 }
 
 export interface BuildFile {

--- a/plugins/deployment_manager/Utils.ts
+++ b/plugins/deployment_manager/Utils.ts
@@ -60,9 +60,10 @@ export function getPrimaryContract(buildFile: BuildFile): [string, ContractMetad
   let contractEntries = Object.entries(buildFile.contracts);
   let contracts = Object.fromEntries(contractEntries.map(([key, value]) => {
     if (key.includes(':')) {
-      return [[key.split(':')[1], value as ContractMetadata]];
+      let [source, contractName] = key.split(':');
+      return [[contractName, { ...value, source } as ContractMetadata]];
     } else {
-      return Object.entries(value);
+      return Object.entries(value).map(([contractName, v]) => [contractName, { ...v, key }]);
     }
   }).flat());
 
@@ -107,10 +108,14 @@ export function mergeContracts(a: ContractMap, b: ContractMap): ContractMap {
   };
 }
 
-export function objectToMap<V>(obj: {string: V}): Map<string, V> {
+export function objectToMap<V>(obj: {[k: string]: V}): Map<string, V> {
   return new Map(Object.entries(obj));
 }
 
 export function objectFromMap<V>(map: Map<string, V>): {[k: string]: V} {
   return Object.fromEntries(map.entries());
+}
+
+export function mapValues<V, W>(o: {string: V}, f: (V) => W): {[k: string]: W} {
+  return Object.fromEntries(Object.entries(o).map(([k, v]) => [k, f(v)]));
 }

--- a/plugins/deployment_manager/Verify.ts
+++ b/plugins/deployment_manager/Verify.ts
@@ -1,0 +1,113 @@
+import * as fs from 'fs/promises';
+import { Contract, ContractFactory, Signer } from 'ethers';
+import {
+  ContractMetadata,
+  BuildFile,
+} from './Types';
+import { getPrimaryContract } from './Utils';
+import { NomicLabsHardhatPluginError } from "hardhat/plugins";
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import {
+  toCheckStatusRequest,
+  toVerifyRequest
+} from '@nomiclabs/hardhat-etherscan/dist/src/etherscan/EtherscanVerifyContractRequest';
+import {
+  delay,
+  getVerificationStatus,
+  verifyContract
+} from '@nomiclabs/hardhat-etherscan/dist/src/etherscan/EtherscanService';
+import { resolveEtherscanApiKey } from '@nomiclabs/hardhat-etherscan/dist/src/resolveEtherscanApiKey';
+
+// Note: We copied as much of this as possible from `hardhat-etherscan`
+// Hence why it doesn't match our styles.
+// Original source code: https://github.com/nomiclabs/hardhat/blob/d07e145222d6e2e465daa841d6355632ad6bc2cd/packages/hardhat-etherscan/src/index.ts#L423
+export async function manualVerifyContract(contract: Contract, buildFile: BuildFile, deployArgs: any[], hre: HardhatRuntimeEnvironment) {
+  let [contractName, contractMetadata] = getPrimaryContract(buildFile);
+
+  const {
+    network: verificationNetwork,
+    urls: etherscanAPIEndpoints,
+  } = await hre.run("verify:get-etherscan-endpoint");
+
+  const etherscanAPIKey = resolveEtherscanApiKey(
+    hre.config.etherscan,
+    verificationNetwork
+  );
+  let contractAddress = contract.address.toLowerCase();
+  let sourceName = contractMetadata.source;
+  let metadata = JSON.parse(contractMetadata.metadata);
+  let compilerVersion = metadata.compiler.version.replace(/\+commit\.([0-9a-fA-F]+)\..*/gi, '+commit.$1');
+  let language = metadata.language;
+  let sources = metadata.sources;
+  let settings = metadata.settings;
+
+  // Fix up some settings issues
+
+  // First, remove 'compilationTarget' if it exists
+  if (metadata.settings.hasOwnProperty('compilationTarget')) {
+    delete metadata.settings['compilationTarget'];
+  }
+
+  // Second, cap optimizer runs to 1MM
+  if (settings.optimizer && settings.optimizer.runs && settings.optimizer.runs > 1000000) {
+    settings.optimizer.runs = 1000000;
+  }
+
+  let request = toVerifyRequest({
+    apiKey: etherscanAPIKey,
+    contractAddress,
+    sourceCode: JSON.stringify({language, settings, sources}),
+    sourceName,
+    contractName,
+    compilerVersion,
+    constructorArguments: contractMetadata.constructorArgs,
+  });
+
+  // Since verification can fail for so many reasons; a simple logging approach for debugging
+  if (process.env['DEBUG_VERIFY']) {
+    console.log({request});
+    await fs.writeFile(`sources-${contractAddress}.json`, request.sourceCode);
+  }
+  const response = await verifyContract(etherscanAPIEndpoints.apiURL, request);
+
+  console.log(
+    `Successfully submitted source code for contract
+${sourceName}:${contractName} at ${contractAddress}
+for verification on the block explorer. Waiting for verification result...
+`
+  );
+
+  const pollRequest = toCheckStatusRequest({
+    apiKey: etherscanAPIKey,
+    guid: response.message,
+  });
+
+  // Compilation is bound to take some time so there's no sense in requesting status immediately.
+  await delay(700);
+  const verificationStatus = await getVerificationStatus(
+    etherscanAPIEndpoints.apiURL,
+    pollRequest
+  );
+
+  if (verificationStatus.isVerificationFailure()) {
+    throw new NomicLabsHardhatPluginError(
+      "DeploymentManager",
+      `The API responded with a failure message.
+  Message: ${verificationStatus.message}`,
+      undefined,
+      true
+    );
+  }
+
+  if (!verificationStatus.isVerificationSuccess()) {
+    // Reaching this point shouldn't be possible unless the API is behaving in a new way.
+    throw new NomicLabsHardhatPluginError(
+      "DeploymentManager",
+      `The API responded with an unexpected message.
+  Contract verification may have succeeded and should be checked manually.
+  Message: ${verificationStatus.message}`,
+      undefined,
+      true
+    );
+  }
+}

--- a/plugins/scenario/World.ts
+++ b/plugins/scenario/World.ts
@@ -6,6 +6,7 @@ export type ForkSpec = {
   name: string;
   url?: string;
   blockNumber?: number;
+  allocation?: number;
 };
 
 export class World {

--- a/scenario/CometScenario.ts
+++ b/scenario/CometScenario.ts
@@ -1,4 +1,4 @@
-import { scenario } from './context/CometContext';
+import { CometContext, scenario } from './context/CometContext';
 import { expect } from 'chai';
 
 scenario('initializes governor correctly', {}, async ({ comet, actors }, world) => {
@@ -26,10 +26,13 @@ scenario('Comet#allow > allows a user to rescind authorization', {}, async ({ co
   expect(await comet.isAllowed(albert.address, betty.address)).to.be.false;
 });
 
-scenario('has assets', {}, async ({ comet, actors, assets }, world) => {
-  expect(await comet.assetAddresses()).to.have.members(
-    Object.values(assets).map((asset) => asset.address)
-  );
+scenario('has assets', {}, async ({ comet, actors, assets }: CometContext, world) => {
+  let baseToken = await comet.baseToken();
+  let contextAssets =
+    Object.values(assets)
+      .map((asset) => asset.address) // grab asset address
+      .filter((address) => address.toLowerCase() !== baseToken.toLowerCase()); // filter out base token
+  expect(await comet.assetAddresses()).to.have.members(contextAssets);
 });
 
 scenario('requires upgrade', { upgrade: true }, async ({ comet }, world) => {

--- a/scenario/constraints/ModernConstraint.ts
+++ b/scenario/constraints/ModernConstraint.ts
@@ -27,19 +27,14 @@ export class ModernConstraint<T extends CometContext> implements Constraint<T> {
       return async (context: T): Promise<T> => {
         console.log("Upgrading to modern...");
         // TODO: Make this deployment script less ridiculous, e.g. since it redeploys tokens right now
-        let { comet: newComet, tokens } = await deployComet(context.deploymentManager, false, cometConfig);
+        let { comet: newComet } = await deployComet(context.deploymentManager, false, cometConfig);
         let initializer: string | undefined = undefined;
         if (!context.comet.totalsBasic || (await context.comet.totalsBasic()).lastAccrualTime === 0) {
           initializer = (await newComet.populateTransaction.XXX_REMOVEME_XXX_initialize()).data
         }
 
         await context.upgradeTo(newComet, initializer);
-
-        context.assets = {
-          DAI: new CometAsset(tokens[0]),
-          GOLD: new CometAsset(tokens[1]),
-          SILVER: new CometAsset(tokens[2]),
-        };
+        await context.setAssets();
 
         console.log("Upgraded to modern...");
 

--- a/scenario/constraints/UtilizationConstraint.ts
+++ b/scenario/constraints/UtilizationConstraint.ts
@@ -72,7 +72,7 @@ export class UtilizationConstraint<T extends CometContext> implements Constraint
 
         // TODO: Handle units for precision, etc
         if (totalSupplyBase == 0n) {
-          toSupplyBase = (await comet.baseScale()).toBigInt(); // Have at least one base unit
+          toSupplyBase = 10n * (await comet.baseScale()).toBigInt(); // Have at least 10 base units
         }
 
         let expectedSupplyBase = totalSupplyBase + toSupplyBase;

--- a/scenario/context/CometActor.ts
+++ b/scenario/context/CometActor.ts
@@ -44,7 +44,7 @@ export default class CometActor {
       value: floor(amount * 1e18)
     });
     await tx.wait();
-  }  
+  }
 
   async allow(manager: CometActor, isAllowed: boolean) {
     await (await this.context.comet.connect(this.signer).allow(manager.address, isAllowed)).wait();

--- a/src/deploy/Development.ts
+++ b/src/deploy/Development.ts
@@ -1,4 +1,5 @@
-import { DeploymentManager, Roots } from '../plugins/deployment_manager/DeploymentManager';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeploymentManager, Roots } from '../../plugins/deployment_manager/DeploymentManager';
 import {
   Comet__factory,
   Comet,
@@ -7,31 +8,15 @@ import {
   ProxyAdmin,
   ProxyAdmin__factory,
   ERC20,
-  TransparentUpgradeableProxy__factory,
-  TransparentUpgradeableProxy,
   SimplePriceFeed,
   SimplePriceFeed__factory,
-} from '../build/types';
-import { AssetInfoStruct, ConfigurationStruct } from '../build/types/Comet';
+  TransparentUpgradeableProxy__factory,
+  TransparentUpgradeableProxy,
+} from '../../build/types';
+import { AssetInfoStruct, ConfigurationStruct } from '../../build/types/Comet';
 import { BigNumberish } from 'ethers';
-export { Comet } from '../build/types';
-
-export interface CometConfigurationOverrides {
-  governor?: string;
-  pauseGuardian?: string;
-  baseToken?: string;
-  baseTokenPriceFeed?: string;
-  trackingIndexScale?: string;
-  baseMinForRewards?: BigNumberish;
-  baseTrackingSupplySpeed?: BigNumberish;
-  baseTrackingBorrowSpeed?: BigNumberish;
-  assetInfo?: AssetInfoStruct[];
-  kink?: BigNumberish;
-  perYearInterestRateBase?: BigNumberish;
-  perYearInterestRateSlopeLow?: BigNumberish;
-  perYearInterestRateSlopeHigh?: BigNumberish;
-  reserveRate?: BigNumberish;
-}
+export { Comet } from '../../build/types';
+import { DeployedContracts, CometConfigurationOverrides } from './index';
 
 async function makeToken(
   deploymentManager: DeploymentManager,
@@ -64,14 +49,8 @@ async function makePriceFeed(
   >('test/SimplePriceFeed.sol', [initialPrice * 1e8, decimals]);
 }
 
-interface DeployedContracts {
-  comet: Comet;
-  proxy: TransparentUpgradeableProxy | null;
-  tokens: ERC20[];
-}
-
 // TODO: Support configurable assets as well?
-export async function deployComet(
+export async function deployDevelopmentComet(
   deploymentManager: DeploymentManager,
   deployProxy: boolean = true,
   configurationOverrides: CometConfigurationOverrides = {}

--- a/src/deploy/Network.ts
+++ b/src/deploy/Network.ts
@@ -1,0 +1,61 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeploymentManager, Roots } from '../../plugins/deployment_manager/DeploymentManager';
+import {
+  Comet__factory,
+  Comet,
+  FaucetToken__factory,
+  FaucetToken,
+  ProxyAdmin,
+  ProxyAdmin__factory,
+  ERC20,
+  TransparentUpgradeableProxy__factory,
+  TransparentUpgradeableProxy,
+} from '../../build/types';
+import { AssetInfoStruct, ConfigurationStruct } from '../../build/types/Comet';
+import { BigNumberish } from 'ethers';
+export { Comet } from '../../build/types';
+import { DeployedContracts, CometConfigurationOverrides } from './index';
+import { getConfiguration } from './NetworkConfiguration';
+
+export async function deployNetworkComet(
+  deploymentManager: DeploymentManager,
+  deployProxy: boolean = true,
+  configurationOverrides: CometConfigurationOverrides = {}
+): Promise<DeployedContracts> {
+  const [governor, pauseGuardian] = await deploymentManager.hre.ethers.getSigners();
+
+  let networkConfiguration = await getConfiguration(deploymentManager.deployment, deploymentManager.hre);
+  let configuration = {
+    ...networkConfiguration,
+    ...configurationOverrides,
+  };
+
+  const comet = await deploymentManager.deploy<Comet, Comet__factory, [ConfigurationStruct]>(
+    'Comet.sol',
+    [configuration]
+  );
+
+  let proxy = null;
+  if (deployProxy) {
+    let proxyAdminArgs: [] = [];
+    let proxyAdmin = await deploymentManager.deploy<ProxyAdmin, ProxyAdmin__factory, []>(
+      'vendor/proxy/ProxyAdmin.sol',
+      proxyAdminArgs
+    );
+
+    proxy = await deploymentManager.deploy<
+      TransparentUpgradeableProxy,
+      TransparentUpgradeableProxy__factory,
+      [string, string, string]
+    >('vendor/proxy/TransparentUpgradeableProxy.sol', [
+      comet.address,
+      proxyAdmin.address,
+      (await comet.populateTransaction.XXX_REMOVEME_XXX_initialize()).data,
+    ]);
+  }
+
+  return {
+    comet,
+    proxy,
+  };
+}

--- a/src/deploy/NetworkConfiguration.ts
+++ b/src/deploy/NetworkConfiguration.ts
@@ -1,0 +1,196 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { AssetInfoStruct, ConfigurationStruct } from '../../build/types/Comet';
+import { BigNumberish, Signature, ethers } from 'ethers';
+import { ContractMap, DeploymentManager } from '../../plugins/deployment_manager/DeploymentManager';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { fileExists } from '../../plugins/deployment_manager/Utils';
+
+function isAddress(a: string): boolean {
+  return a.match(/^0x[a-fA-F0-9]{40}$/) !== null;
+}
+
+function address(a: string): string {
+  if (!isAddress(a)) {
+    throw new Error(`expected address, got \`${a}\``);
+  }
+
+  return a;
+}
+
+function floor(n: number): bigint {
+  return BigInt(Math.floor(n));
+}
+
+function number(n: number, checkRange: boolean = true): bigint {
+  return floor(Number(n));
+}
+
+function percentage(n: number, checkRange: boolean = true): bigint {
+  if (checkRange) {
+    if (n > 1.0) {
+      throw new Error(`percentage greater than 100% [received=${n}]`);
+    } else if (n < 0) {
+      throw new Error(`percentage less than 0% [received=${n}]`);
+    }
+  }
+
+  return floor(n * 1e18);
+}
+
+interface NetworkRateConfiguration {
+  kink: number;
+  slopeLow: number;
+  slopeHigh: number;
+  base: number;
+}
+
+interface NetworkTrackingConfiguration {
+  indexScale: number;
+  baseSupplySpeed: number;
+  baseBorrowSpeed: number;
+  baseMinForRewards: number;
+}
+
+interface NetworkAssetConfiguration {
+  borrowCF: number;
+  liquidateCF: number;
+  supplyCap: number;
+  priceFeed: string;
+  scale: number;
+}
+
+interface NetworkConfiguration {
+  governor: string;
+  pauseGuardian: string;
+  baseToken: string;
+  baseTokenPriceFeed: string;
+  reserveRate: number;
+  borrowMin: number;
+  targetReserves: number;
+  rates: NetworkRateConfiguration;
+  tracking: NetworkTrackingConfiguration;
+  assets: { [name: string]: NetworkAssetConfiguration };
+}
+
+interface InterestRateInfo {
+  kink: BigNumberish;
+  perYearInterestRateSlopeLow: BigNumberish;
+  perYearInterestRateSlopeHigh: BigNumberish;
+  perYearInterestRateBase: BigNumberish;
+}
+
+interface TrackingInfo {
+  trackingIndexScale: BigNumberish;
+  baseTrackingSupplySpeed: BigNumberish;
+  baseTrackingBorrowSpeed: BigNumberish;
+  baseMinForRewards: BigNumberish;
+}
+
+function getContractAddress(contractName: string, contractMap: ContractMap): string {
+  let remap = {
+    USDC: 'FiatTokenProxy',
+    'WBTC.e': 'BridgeToken',
+  };
+  let contract = contractMap[contractName];
+
+  if (!contract) {
+    if (remap[contractName]) {
+      return getContractAddress(remap[contractName], contractMap); // this is a hack, since pointers has weird names right now
+    } else {
+      throw new Error(
+        `Cannot find contract \`${contractName}\` in contract map with keys \`${Object.keys(
+          contractMap
+        ).join(', ')}\``
+      );
+    }
+  }
+
+  return contract.address;
+}
+
+function getInterestRateInfo(rates: NetworkRateConfiguration): InterestRateInfo {
+  return {
+    kink: percentage(rates.kink),
+    perYearInterestRateSlopeLow: percentage(rates.slopeLow),
+    perYearInterestRateSlopeHigh: percentage(rates.slopeHigh),
+    perYearInterestRateBase: percentage(rates.base),
+  };
+}
+
+function getTrackingInfo(tracking: NetworkTrackingConfiguration): TrackingInfo {
+  return {
+    trackingIndexScale: number(tracking.indexScale),
+    baseTrackingSupplySpeed: number(tracking.baseSupplySpeed),
+    baseTrackingBorrowSpeed: number(tracking.baseBorrowSpeed),
+    baseMinForRewards: number(tracking.baseMinForRewards),
+  };
+}
+
+function getAssetInfo(
+  assets: { [name: string]: NetworkAssetConfiguration },
+  contractMap: ContractMap
+): AssetInfoStruct[] {
+  return Object.entries(assets).map(([assetName, assetConfig]) => {
+    let assetAddress = getContractAddress(assetName, contractMap);
+
+    return {
+      asset: assetAddress,
+      borrowCollateralFactor: percentage(assetConfig.borrowCF),
+      liquidateCollateralFactor: percentage(assetConfig.liquidateCF),
+      supplyCap: number(assetConfig.supplyCap), // TODO: Decimals
+      priceFeed: address(assetConfig.priceFeed),
+      scale: number(assetConfig.scale),
+    };
+  });
+}
+
+function getNetworkConfigurationFilePath(network: string): string {
+  return path.join(__dirname, '..', '..', 'deployments', network, 'configuration.json');
+}
+
+export async function hasNetworkConfiguration(network: string): Promise<boolean> {
+  let configurationFile = getNetworkConfigurationFilePath(network);
+  return await fileExists(configurationFile);
+}
+
+async function loadNetworkConfiguration(network: string): Promise<NetworkConfiguration> {
+  let configurationFile = getNetworkConfigurationFilePath(network);
+  let configurationJson = await fs.readFile(configurationFile, 'utf8');
+  return JSON.parse(configurationJson) as NetworkConfiguration;
+}
+
+export async function getConfiguration(
+  network: string,
+  hre: HardhatRuntimeEnvironment
+): Promise<ConfigurationStruct> {
+  let networkConfiguration = await loadNetworkConfiguration(network);
+  let deploymentManager = new DeploymentManager(network, hre);
+  let contractMap: ContractMap = await deploymentManager.getContracts(); // TODO: Handle root aliases?
+
+  let baseToken = getContractAddress(networkConfiguration.baseToken, contractMap);
+  let baseTokenPriceFeed = address(networkConfiguration.baseTokenPriceFeed);
+  let governor = address(networkConfiguration.governor);
+  let pauseGuardian = address(networkConfiguration.pauseGuardian);
+  let reserveRate = percentage(networkConfiguration.reserveRate);
+  let baseBorrowMin = number(networkConfiguration.borrowMin); // TODO: in token units (?)
+  let targetReserves = number(networkConfiguration.targetReserves);
+
+  let interestRateInfo = getInterestRateInfo(networkConfiguration.rates);
+  let trackingInfo = getTrackingInfo(networkConfiguration.tracking);
+
+  let assetInfo = getAssetInfo(networkConfiguration.assets, contractMap);
+
+  return {
+    governor,
+    pauseGuardian,
+    baseToken,
+    baseTokenPriceFeed,
+    ...interestRateInfo,
+    reserveRate,
+    ...trackingInfo,
+    baseBorrowMin,
+    targetReserves,
+    assetInfo,
+  };
+}

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -1,0 +1,57 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { hasNetworkConfiguration } from './NetworkConfiguration';
+import { DeploymentManager, Roots } from '../../plugins/deployment_manager/DeploymentManager';
+import {
+  Comet__factory,
+  Comet,
+  FaucetToken__factory,
+  FaucetToken,
+  ProxyAdmin,
+  ProxyAdmin__factory,
+  ERC20,
+  TransparentUpgradeableProxy__factory,
+  TransparentUpgradeableProxy,
+} from '../../build/types';
+import { AssetInfoStruct, ConfigurationStruct } from '../../build/types/Comet';
+import { BigNumberish } from 'ethers';
+export { Comet } from '../../build/types';
+import { deployNetworkComet } from './Network';
+import { deployDevelopmentComet } from './Development';
+
+export interface CometConfigurationOverrides {
+  governor?: string;
+  pauseGuardian?: string;
+  priceOracle?: string;
+  baseToken?: string;
+  trackingIndexScale?: string;
+  baseMinForRewards?: BigNumberish;
+  baseTrackingSupplySpeed?: BigNumberish;
+  baseTrackingBorrowSpeed?: BigNumberish;
+  assetInfo?: AssetInfoStruct[];
+  kink?: BigNumberish;
+  perYearInterestRateBase?: BigNumberish;
+  perYearInterestRateSlopeLow?: BigNumberish;
+  perYearInterestRateSlopeHigh?: BigNumberish;
+  reserveRate?: BigNumberish;
+}
+
+export interface DeployedContracts {
+  comet: Comet;
+  proxy: TransparentUpgradeableProxy | null;
+  tokens?: ERC20[];
+}
+
+export async function deployComet(
+  deploymentManager: DeploymentManager,
+  deployProxy: boolean = true,
+  configurationOverrides: CometConfigurationOverrides = {}
+): Promise<DeployedContracts> {
+  // If we have a `configuration.json` for the network, use it.
+  // Otherwise, we do a "development"-style deploy, which deploys fake tokens, etc, and generally
+  // provides less value than a full-fledged test-net or mainnet fork.
+  if (await hasNetworkConfiguration(deploymentManager.deployment)) {
+    return await deployNetworkComet(deploymentManager, deployProxy, configurationOverrides);
+  } else {
+    return await deployDevelopmentComet(deploymentManager, deployProxy, configurationOverrides);
+  }
+}

--- a/tasks/migrate/task.ts
+++ b/tasks/migrate/task.ts
@@ -1,0 +1,40 @@
+import { task } from 'hardhat/config';
+import { Migration, loadMigrations } from '../../plugins/deployment_manager/Migration';
+import '../../plugins/scenario/type-extensions';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeploymentManager } from '../../plugins/deployment_manager/DeploymentManager';
+import * as types from 'hardhat/internal/core/params/argumentTypes'; // TODO harhdat argument types not from internal
+import * as path from 'path';
+
+async function runMigration<T>(deploymentManager: DeploymentManager, enact: boolean, migration: Migration<T>) {
+  let t: T = await migration.actions.prepare(deploymentManager);
+
+  if (enact) {
+    await migration.actions.enact(deploymentManager, t);
+  }
+}
+
+task('migrate', 'Runs migration')
+  .addParam('migration', 'name of migration')
+  .addFlag('prepare', 'runs preparation')
+  .addFlag('enact', 'enacts migration [implies prepare]')
+  .setAction(async ({migration: migrationName, prepare, enact}, env: HardhatRuntimeEnvironment) => {
+    let network = env.network.name;
+    let dm = new DeploymentManager(network, env, {
+      writeCacheToDisk: true,
+      debug: true,
+      verifyContracts: true,
+    });
+    let migrationsGlob = path.join('deployments', network, 'migrations', '**.ts');
+    let migrations = await loadMigrations(migrationsGlob);
+
+    let migration = migrations[migrationName];
+    if (!migration) {
+      throw new Error(`Unknown migration for network ${network}: \`${migrationName}\`. Known migrations: ${JSON.stringify(Object.keys(migrations))}`);
+    }
+    if (!prepare && !enact) {
+      console.error("Migration found. Please run with --prepare or --enact. Exiting...");
+    } else {
+      await runMigration(dm, enact, migration);
+    }
+  });

--- a/tasks/scenario/task.ts
+++ b/tasks/scenario/task.ts
@@ -25,9 +25,9 @@ function getBasesFromTaskArgs(givenBases: string | undefined, env: HardhatRuntim
 
 task('scenario', 'Runs scenario tests')
   .addOptionalParam('bases', 'Bases to run on [defaults to all]')
-  .addOptionalParam('noSpider', 'skip spider', false, types.boolean)
+  .addFlag('noSpider', 'skip spider')
+  .addFlag('sync', 'run synchronously')
   .addOptionalParam('workers', 'count of workers', 6, types.int)
-  .addOptionalParam('sync', 'run synchronously', false, types.boolean)
   .setAction(async (taskArgs, env: HardhatRuntimeEnvironment) => {
     let bases: ForkSpec[] = getBasesFromTaskArgs(taskArgs.bases, env);
 


### PR DESCRIPTION
This patch is an attempt at setting test-net configuration via a simple `configuration.json` file for each network to make it easy to set configuration parameters, tokens, etc, that we would like for each network.

The alternative is to just try to do some "migrations" or "migration scripts" code, though I'm not entirely sure this can't be an aid in that. In part, this all depends on how Configurator works.

Also, here we try to "clone" tokens from the associated "mainnet" (e.g. Avalanche tokens to Fuji), as that's a common desire for our test-nets.