### PR TITLE
[size reduction ✅ ] remove totalsBasic to reduce contract size

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -248,16 +248,15 @@ contract Comet is CometMath, CometStorage {
     // TODO: Remove me. Function while waiting for initializer
     // !! NOT FOR REUSE [YES FOR REFUSE] !!
     function XXX_REMOVEME_XXX_initialize() public {
-        require(totalsBasic.lastAccrualTime == 0, "already initialized");
+        require(lastAccrualTime == 0, "already initialized");
 
         // Initialize aggregates
-        totalsBasic.lastAccrualTime = getNow();
-        totalsBasic.baseSupplyIndex = baseIndexScale;
-        totalsBasic.baseBorrowIndex = baseIndexScale;
-        totalsBasic.trackingSupplyIndex = 0;
-        totalsBasic.trackingBorrowIndex = 0;
+        lastAccrualTime = getNow();
+        baseSupplyIndex = baseIndexScale;
+        baseBorrowIndex = baseIndexScale;
+        trackingSupplyIndex = 0;
+        trackingBorrowIndex = 0;
     }
-
 
     /**
      * @dev Gets the info for an asset or empty, for initialization
@@ -418,31 +417,30 @@ contract Comet is CometMath, CometStorage {
      * @notice Accrue interest (and rewards) in base token supply and borrows
      **/
     function accrue() public {
-        totalsBasic = accrue(totalsBasic);
+        accrueInternal();
     }
 
     /**
      * @notice Accrue interest (and rewards) in base token supply and borrows
      **/
-    function accrue(TotalsBasic memory totals) internal view returns (TotalsBasic memory) {
+    function accrueInternal() internal {
         uint40 now_ = getNow();
-        uint timeElapsed = now_ - totals.lastAccrualTime;
+        uint timeElapsed = now_ - lastAccrualTime;
         if (timeElapsed > 0) {
-            uint supplyRate = getSupplyRateInternal(totals);
-            uint borrowRate = getBorrowRateInternal(totals);
-            totals.baseSupplyIndex += safe64(mulFactor(totals.baseSupplyIndex, supplyRate * timeElapsed));
-            totals.baseBorrowIndex += safe64(mulFactor(totals.baseBorrowIndex, borrowRate * timeElapsed));
-            if (totals.totalSupplyBase >= baseMinForRewards) {
+            uint supplyRate = getSupplyRateInternal();
+            uint borrowRate = getBorrowRateInternal();
+            baseSupplyIndex += safe64(mulFactor(baseSupplyIndex, supplyRate * timeElapsed));
+            baseBorrowIndex += safe64(mulFactor(baseBorrowIndex, borrowRate * timeElapsed));
+            if (totalSupplyBase >= baseMinForRewards) {
                 uint supplySpeed = baseTrackingSupplySpeed;
-                totals.trackingSupplyIndex += safe64(divBaseWei(supplySpeed * timeElapsed, totals.totalSupplyBase));
+                trackingSupplyIndex += safe64(divBaseWei(supplySpeed * timeElapsed, totalSupplyBase));
             }
-            if (totals.totalBorrowBase >= baseMinForRewards) {
+            if (totalBorrowBase >= baseMinForRewards) {
                 uint borrowSpeed = baseTrackingBorrowSpeed;
-                totals.trackingBorrowIndex += safe64(divBaseWei(borrowSpeed * timeElapsed, totals.totalBorrowBase));
+                trackingBorrowIndex += safe64(divBaseWei(borrowSpeed * timeElapsed, totalBorrowBase));
             }
         }
-        totals.lastAccrualTime = now_;
-        return totals;
+        lastAccrualTime = now_;
     }
 
     /**
@@ -511,14 +509,14 @@ contract Comet is CometMath, CometStorage {
      * @return The current per second supply rate
      */
     function getSupplyRate() public view returns (uint64) {
-        return getSupplyRateInternal(totalsBasic);
+        return getSupplyRateInternal();
     }
 
     /**
      * @dev Calculate current per second supply rate given totals
      */
-    function getSupplyRateInternal(TotalsBasic memory totals) internal view returns (uint64) {
-        uint utilization = getUtilizationInternal(totals);
+    function getSupplyRateInternal() internal view returns (uint64) {
+        uint utilization = getUtilizationInternal();
         uint reserveScalingFactor = utilization * (factorScale - reserveRate) / factorScale;
         if (utilization <= kink) {
             // (interestRateBase + interestRateSlopeLow * utilization) * utilization * (1 - reserveRate)
@@ -533,14 +531,14 @@ contract Comet is CometMath, CometStorage {
      * @return The current per second borrow rate
      */
     function getBorrowRate() public view returns (uint64) {
-        return getBorrowRateInternal(totalsBasic);
+        return getBorrowRateInternal();
     }
 
     /**
      * @dev Calculate current per second borrow rate given totals
      */
-    function getBorrowRateInternal(TotalsBasic memory totals) internal view returns (uint64) {
-        uint utilization = getUtilizationInternal(totals);
+    function getBorrowRateInternal() internal view returns (uint64) {
+        uint utilization = getUtilizationInternal();
         if (utilization <= kink) {
             // interestRateBase + interestRateSlopeLow * utilization
             return safe64(perSecondInterestRateBase + mulFactor(perSecondInterestRateSlopeLow, utilization));
@@ -554,15 +552,15 @@ contract Comet is CometMath, CometStorage {
      * @return The utilization rate of the base asset
      */
     function getUtilization() public view returns (uint) {
-        return getUtilizationInternal(totalsBasic);
+        return getUtilizationInternal();
     }
 
     /**
      * @dev Calculate utilization rate of the base asset given totals
      */
-    function getUtilizationInternal(TotalsBasic memory totals) internal pure returns (uint) {
-        uint totalSupply = presentValueSupply(totals, totals.totalSupplyBase);
-        uint totalBorrow = presentValueBorrow(totals, totals.totalBorrowBase);
+    function getUtilizationInternal() internal view returns (uint) {
+        uint totalSupply = presentValueSupply(totalSupplyBase);
+        uint totalBorrow = presentValueBorrow(totalBorrowBase);
         if (totalSupply == 0) {
             return 0;
         } else {
@@ -584,10 +582,9 @@ contract Comet is CometMath, CometStorage {
      * @notice Gets the total amount of protocol reserves, denominated in the number of base tokens
      */
     function getReserves() public view returns (int) {
-        TotalsBasic memory totals = totalsBasic;
         uint balance = ERC20(baseToken).balanceOf(address(this));
-        uint104 totalSupply = presentValueSupply(totals, totals.totalSupplyBase);
-        uint104 totalBorrow = presentValueBorrow(totals, totals.totalBorrowBase);
+        uint104 totalSupply = presentValueSupply(totalSupplyBase);
+        uint104 totalBorrow = presentValueBorrow(totalBorrowBase);
         return signed256(balance) - signed104(totalSupply) + signed104(totalBorrow);
     }
 
@@ -599,10 +596,9 @@ contract Comet is CometMath, CometStorage {
     function isBorrowCollateralized(address account) public view returns (bool) {
         // XXX take in UserBasic and UserCollateral as arguments to reduce SLOADs
         uint16 assetsIn = userBasic[account].assetsIn;
-        TotalsBasic memory totals = totalsBasic;
 
         int liquidity = signedMulPrice(
-            presentValue(totals, userBasic[account].principal),
+            presentValue(userBasic[account].principal),
             getPrice(baseTokenPriceFeed),
             baseScale
         );
@@ -636,10 +632,9 @@ contract Comet is CometMath, CometStorage {
      */
     function getBorrowLiquidity(address account) public view returns (int) {
         uint16 assetsIn = userBasic[account].assetsIn;
-        TotalsBasic memory totals = totalsBasic;
 
         int liquidity = signedMulPrice(
-            presentValue(totals, userBasic[account].principal),
+            presentValue(userBasic[account].principal),
             getPrice(baseTokenPriceFeed),
             baseScale
         );
@@ -669,10 +664,9 @@ contract Comet is CometMath, CometStorage {
      */
     function isLiquidatable(address account) public view returns (bool) {
         uint16 assetsIn = userBasic[account].assetsIn;
-        TotalsBasic memory totals = totalsBasic;
 
         int liquidity = signedMulPrice(
-            presentValue(totals, userBasic[account].principal),
+            presentValue(userBasic[account].principal),
             getPrice(baseTokenPriceFeed),
             baseScale
         );
@@ -706,10 +700,9 @@ contract Comet is CometMath, CometStorage {
      */
     function getLiquidationMargin(address account) public view returns (int) {
         uint16 assetsIn = userBasic[account].assetsIn;
-        TotalsBasic memory totals = totalsBasic;
 
         int liquidity = signedMulPrice(
-            presentValue(totals, userBasic[account].principal),
+            presentValue(userBasic[account].principal),
             getPrice(baseTokenPriceFeed),
             baseScale
         );
@@ -735,51 +728,51 @@ contract Comet is CometMath, CometStorage {
     /**
      * @dev The positive present supply balance if positive or the negative borrow balance if negative
      */
-    function presentValue(TotalsBasic memory totals, int104 principalValue_) internal pure returns (int104) {
+    function presentValue(int104 principalValue_) internal view returns (int104) {
         if (principalValue_ >= 0) {
-            return signed104(presentValueSupply(totals, unsigned104(principalValue_)));
+            return signed104(presentValueSupply(unsigned104(principalValue_)));
         } else {
-            return -signed104(presentValueBorrow(totals, unsigned104(-principalValue_)));
+            return -signed104(presentValueBorrow(unsigned104(-principalValue_)));
         }
     }
 
     /**
      * @dev The principal amount projected forward by the supply index
      */
-    function presentValueSupply(TotalsBasic memory totals, uint104 principalValue_) internal pure returns (uint104) {
-        return uint104(uint(principalValue_) * totals.baseSupplyIndex / baseIndexScale);
+    function presentValueSupply(uint104 principalValue_) internal view returns (uint104) {
+        return uint104(uint(principalValue_) * baseSupplyIndex / baseIndexScale);
     }
 
     /**
      * @dev The principal amount projected forward by the borrow index
      */
-    function presentValueBorrow(TotalsBasic memory totals, uint104 principalValue_) internal pure returns (uint104) {
-        return uint104(uint(principalValue_) * totals.baseBorrowIndex / baseIndexScale);
+    function presentValueBorrow(uint104 principalValue_) internal view returns (uint104) {
+        return uint104(uint(principalValue_) * baseBorrowIndex / baseIndexScale);
     }
 
     /**
      * @dev The positive principal if positive or the negative principal if negative
      */
-    function principalValue(TotalsBasic memory totals, int104 presentValue_) internal pure returns (int104) {
+    function principalValue(int104 presentValue_) internal view returns (int104) {
         if (presentValue_ >= 0) {
-            return signed104(principalValueSupply(totals, unsigned104(presentValue_)));
+            return signed104(principalValueSupply(unsigned104(presentValue_)));
         } else {
-            return -signed104(principalValueBorrow(totals, unsigned104(-presentValue_)));
+            return -signed104(principalValueBorrow(unsigned104(-presentValue_)));
         }
     }
 
     /**
      * @dev The present value projected backward by the supply index
      */
-    function principalValueSupply(TotalsBasic memory totals, uint104 presentValue_) internal pure returns (uint104) {
-        return uint104(uint(presentValue_) * baseIndexScale / totals.baseSupplyIndex);
+    function principalValueSupply(uint104 presentValue_) internal view returns (uint104) {
+        return uint104(uint(presentValue_) * baseIndexScale / baseSupplyIndex);
     }
 
     /**
      * @dev The present value projected backwrd by the borrow index
      */
-    function principalValueBorrow(TotalsBasic memory totals, uint104 presentValue_) internal pure returns (uint104) {
-        return uint104(uint(presentValue_) * baseIndexScale / totals.baseBorrowIndex);
+    function principalValueBorrow(uint104 presentValue_) internal view returns (uint104) {
+        return uint104(uint(presentValue_) * baseIndexScale / baseBorrowIndex);
     }
 
     /**
@@ -817,7 +810,7 @@ contract Comet is CometMath, CometStorage {
     ) external {
         require(msg.sender == governor || msg.sender == pauseGuardian, "Unauthorized");
 
-        totalsBasic.pauseFlags =
+        pauseFlags =
             uint8(0) |
             (toUInt8(supplyPaused) << pauseSupplyOffset) |
             (toUInt8(transferPaused) << pauseTransferOffset) |
@@ -830,35 +823,35 @@ contract Comet is CometMath, CometStorage {
      * @return Whether or not supply actions are paused
      */
     function isSupplyPaused() public view returns (bool) {
-        return toBool(totalsBasic.pauseFlags & (uint8(1) << pauseSupplyOffset));
+        return toBool(pauseFlags & (uint8(1) << pauseSupplyOffset));
     }
 
     /**
      * @return Whether or not transfer actions are paused
      */
     function isTransferPaused() public view returns (bool) {
-        return toBool(totalsBasic.pauseFlags & (uint8(1) << pauseTransferOffset));
+        return toBool(pauseFlags & (uint8(1) << pauseTransferOffset));
     }
 
     /**
      * @return Whether or not withdraw actions are paused
      */
     function isWithdrawPaused() public view returns (bool) {
-        return toBool(totalsBasic.pauseFlags & (uint8(1) << pauseWithdrawOffset));
+        return toBool(pauseFlags & (uint8(1) << pauseWithdrawOffset));
     }
 
     /**
      * @return Whether or not absorb actions are paused
      */
     function isAbsorbPaused() public view returns (bool) {
-        return toBool(totalsBasic.pauseFlags & (uint8(1) << pauseAbsorbOffset));
+        return toBool(pauseFlags & (uint8(1) << pauseAbsorbOffset));
     }
 
     /**
      * @return Whether or not buy actions are paused
      */
     function isBuyPaused() public view returns (bool) {
-        return toBool(totalsBasic.pauseFlags & (uint8(1) << pauseBuyOffset));
+        return toBool(pauseFlags & (uint8(1) << pauseBuyOffset));
     }
 
     /**
@@ -925,22 +918,22 @@ contract Comet is CometMath, CometStorage {
     /**
      * @dev Write updated balance to store and tracking participation
      */
-    function updateBaseBalance(TotalsBasic memory totals, address account, UserBasic memory basic, int104 principalNew) internal {
+    function updateBaseBalance(address account, UserBasic memory basic, int104 principalNew) internal {
         int104 principal = basic.principal;
         basic.principal = principalNew;
 
         if (principal >= 0) {
-            uint indexDelta = totals.trackingSupplyIndex - basic.baseTrackingIndex;
+            uint indexDelta = trackingSupplyIndex - basic.baseTrackingIndex;
             basic.baseTrackingAccrued += safe64(uint104(principal) * indexDelta / baseIndexScale); // XXX decimals
         } else {
-            uint indexDelta = totals.trackingBorrowIndex - basic.baseTrackingIndex;
+            uint indexDelta = trackingBorrowIndex - basic.baseTrackingIndex;
             basic.baseTrackingAccrued += safe64(uint104(-principal) * indexDelta / baseIndexScale); // XXX decimals
         }
 
         if (principalNew >= 0) {
-            basic.baseTrackingIndex = totals.trackingSupplyIndex;
+            basic.baseTrackingIndex = trackingSupplyIndex;
         } else {
-            basic.baseTrackingIndex = totals.trackingBorrowIndex;
+            basic.baseTrackingIndex = trackingBorrowIndex;
         }
 
         userBasic[account] = basic;
@@ -952,7 +945,7 @@ contract Comet is CometMath, CometStorage {
      * @return The present day base balance of the account
      */
     function baseBalanceOf(address account) external view returns (int104) {
-        return presentValue(totalsBasic, userBasic[account].principal);
+        return presentValue(userBasic[account].principal);
     }
 
     /**
@@ -1030,14 +1023,13 @@ contract Comet is CometMath, CometStorage {
     function supplyBase(address from, address dst, uint104 amount) internal {
         doTransferIn(baseToken, from, amount);
 
-        TotalsBasic memory totals = totalsBasic;
-        totals = accrue(totals);
+        accrueInternal();
 
-        uint104 totalSupplyBalance = presentValueSupply(totals, totals.totalSupplyBase);
-        uint104 totalBorrowBalance = presentValueBorrow(totals, totals.totalBorrowBase);
+        uint104 totalSupplyBalance = presentValueSupply(totalSupplyBase);
+        uint104 totalBorrowBalance = presentValueBorrow(totalBorrowBase);
 
         UserBasic memory dstUser = userBasic[dst];
-        int104 dstBalance = presentValue(totals, dstUser.principal);
+        int104 dstBalance = presentValue(dstUser.principal);
 
         (uint104 repayAmount, uint104 supplyAmount) = repayAndSupplyAmount(dstBalance, amount);
 
@@ -1046,11 +1038,10 @@ contract Comet is CometMath, CometStorage {
 
         dstBalance += signed104(amount);
 
-        totals.totalSupplyBase = principalValueSupply(totals, totalSupplyBalance);
-        totals.totalBorrowBase = principalValueBorrow(totals, totalBorrowBalance);
-        totalsBasic = totals;
+        totalSupplyBase = principalValueSupply(totalSupplyBalance);
+        totalBorrowBase = principalValueBorrow(totalBorrowBalance);
 
-        updateBaseBalance(totals, dst, dstUser, principalValue(totals, dstBalance));
+        updateBaseBalance(dst, dstUser, principalValue(dstBalance));
     }
 
     /**
@@ -1112,15 +1103,14 @@ contract Comet is CometMath, CometStorage {
      */
     function transferBase(address src, address dst, uint104 amount) internal {
         require(src != dst, "self-transfer not allowed");
-        TotalsBasic memory totals = totalsBasic;
-        totals = accrue(totals);
-        uint104 totalSupplyBalance = presentValueSupply(totals, totals.totalSupplyBase);
-        uint104 totalBorrowBalance = presentValueBorrow(totals, totals.totalBorrowBase);
+        accrueInternal();
+        uint104 totalSupplyBalance = presentValueSupply(totalSupplyBase);
+        uint104 totalBorrowBalance = presentValueBorrow(totalBorrowBase);
 
         UserBasic memory srcUser = userBasic[src];
         UserBasic memory dstUser = userBasic[dst];
-        int104 srcBalance = presentValue(totals, srcUser.principal);
-        int104 dstBalance = presentValue(totals, dstUser.principal);
+        int104 srcBalance = presentValue(srcUser.principal);
+        int104 dstBalance = presentValue(dstUser.principal);
 
         (uint104 withdrawAmount, uint104 borrowAmount) = withdrawAndBorrowAmount(srcBalance, amount);
         (uint104 repayAmount, uint104 supplyAmount) = repayAndSupplyAmount(dstBalance, amount);
@@ -1131,12 +1121,11 @@ contract Comet is CometMath, CometStorage {
         srcBalance -= signed104(amount);
         dstBalance += signed104(amount);
 
-        totals.totalSupplyBase = principalValueSupply(totals, totalSupplyBalance);
-        totals.totalBorrowBase = principalValueBorrow(totals, totalBorrowBalance);
-        totalsBasic = totals;
+        totalSupplyBase = principalValueSupply(totalSupplyBalance);
+        totalBorrowBase = principalValueBorrow(totalBorrowBalance);
 
-        updateBaseBalance(totals, src, srcUser, principalValue(totals, srcBalance));
-        updateBaseBalance(totals, dst, dstUser, principalValue(totals, dstBalance));
+        updateBaseBalance(src, srcUser, principalValue(srcBalance));
+        updateBaseBalance(dst, dstUser, principalValue(dstBalance));
 
         if (srcBalance < 0) {
             require(uint104(-srcBalance) >= baseBorrowMin, "borrow too small");
@@ -1211,13 +1200,12 @@ contract Comet is CometMath, CometStorage {
      * @dev Withdraw an amount of base asset from src to `to`, borrowing if possible/necessary
      */
     function withdrawBase(address src, address to, uint104 amount) internal {
-        TotalsBasic memory totals = totalsBasic;
-        totals = accrue(totals);
-        uint104 totalSupplyBalance = presentValueSupply(totals, totals.totalSupplyBase);
-        uint104 totalBorrowBalance = presentValueBorrow(totals, totals.totalBorrowBase);
+        accrueInternal();
+        uint104 totalSupplyBalance = presentValueSupply(totalSupplyBase);
+        uint104 totalBorrowBalance = presentValueBorrow(totalBorrowBase);
 
         UserBasic memory srcUser = userBasic[src];
-        int104 srcBalance = presentValue(totals, srcUser.principal);
+        int104 srcBalance = presentValue(srcUser.principal);
 
         (uint104 withdrawAmount, uint104 borrowAmount) = withdrawAndBorrowAmount(srcBalance, amount);
 
@@ -1226,11 +1214,10 @@ contract Comet is CometMath, CometStorage {
 
         srcBalance -= signed104(amount);
 
-        totals.totalSupplyBase = principalValueSupply(totals, totalSupplyBalance);
-        totals.totalBorrowBase = principalValueBorrow(totals, totalBorrowBalance);
-        totalsBasic = totals;
+        totalSupplyBase = principalValueSupply(totalSupplyBalance);
+        totalBorrowBase = principalValueBorrow(totalBorrowBalance);
 
-        updateBaseBalance(totals, src, srcUser, principalValue(totals, srcBalance));
+        updateBaseBalance(src, srcUser, principalValue(srcBalance));
 
         if (srcBalance < 0) {
             require(uint104(-srcBalance) >= baseBorrowMin, "borrow too small");
@@ -1286,11 +1273,10 @@ contract Comet is CometMath, CometStorage {
     function absorbInternal(address account) internal {
         require(isLiquidatable(account), "account is not underwater");
 
-        TotalsBasic memory totals = totalsBasic;
-        totals = accrue(totals);
+        accrueInternal();
 
         UserBasic memory accountUser = userBasic[account];
-        int104 oldBalance = presentValue(totals, accountUser.principal);
+        int104 oldBalance = presentValue(accountUser.principal);
         uint16 assetsIn = accountUser.assetsIn;
 
         uint basePrice = getPrice(baseTokenPriceFeed);
@@ -1315,16 +1301,14 @@ contract Comet is CometMath, CometStorage {
         int104 newBalance = oldBalance + signed104(deltaBalance);
         // New balance will not be negative, all excess debt absorbed by reserves
         newBalance = newBalance < 0 ? int104(0) : newBalance;
-        updateBaseBalance(totals, account, accountUser, principalValue(totals, newBalance));
+        updateBaseBalance(account, accountUser, principalValue(newBalance));
 
         // Reserves are decreased by increasing total supply and decreasing borrows
         //  the amount of debt repaid by reserves is `newBalance - oldBalance`
         // Note: new balance must be non-negative due to the above thresholding
-        totals.totalSupplyBase += principalValueSupply(totals, unsigned104(newBalance));
+        totalSupplyBase += principalValueSupply(unsigned104(newBalance));
         // Note: old balance must be negative since the account is liquidatable
-        totals.totalBorrowBase -= principalValueBorrow(totals, unsigned104(-oldBalance));
-
-        totalsBasic = totals;
+        totalBorrowBase -= principalValueBorrow(unsigned104(-oldBalance));
     }
 
     /**

--- a/contracts/CometStorage.sol
+++ b/contracts/CometStorage.sol
@@ -21,6 +21,17 @@ contract CometStorage {
         uint8 pauseFlags;
     }
 
+    /// @notice Aggregate variables tracked for the entire market
+    uint64 internal baseSupplyIndex;
+    uint64 internal baseBorrowIndex;
+    uint64 internal trackingSupplyIndex;
+    uint64 internal trackingBorrowIndex;
+
+    uint104 internal totalSupplyBase;
+    uint104 internal totalBorrowBase;
+    uint40 internal lastAccrualTime;
+    uint8 internal pauseFlags;
+
     struct TotalsCollateral {
         uint128 totalSupplyAsset;
         uint128 _reserved;
@@ -46,8 +57,19 @@ contract CometStorage {
         uint32 _reserved;
     }
 
-    /// @notice Aggregate variables tracked for the entire market
-    TotalsBasic public totalsBasic;
+    // needed for ModernConstraint, UtilizationConstraint, tests
+    function totalsBasic() public view returns (TotalsBasic memory) {
+        return TotalsBasic({
+            baseSupplyIndex: baseSupplyIndex,
+            baseBorrowIndex: baseBorrowIndex,
+            trackingSupplyIndex: trackingSupplyIndex,
+            trackingBorrowIndex: trackingBorrowIndex,
+            totalSupplyBase: totalSupplyBase,
+            totalBorrowBase: totalBorrowBase,
+            lastAccrualTime: lastAccrualTime,
+            pauseFlags: pauseFlags
+        });
+    }
 
     /// @notice Aggregate variables tracked for each collateral asset
     mapping(address => TotalsCollateral) public totalsCollateral;

--- a/contracts/test/CometHarness.sol
+++ b/contracts/test/CometHarness.sol
@@ -17,7 +17,14 @@ contract CometHarness is Comet {
     }
 
     function setTotalsBasic(TotalsBasic memory totals) public {
-        totalsBasic = totals;
+        baseSupplyIndex = totals.baseSupplyIndex;
+        baseBorrowIndex = totals.baseBorrowIndex;
+        trackingSupplyIndex = totals.trackingSupplyIndex;
+        trackingBorrowIndex = totals.trackingBorrowIndex;
+        totalSupplyBase = totals.totalSupplyBase;
+        totalBorrowBase = totals.totalBorrowBase;
+        lastAccrualTime = totals.lastAccrualTime;
+        pauseFlags = totals.pauseFlags;
     }
 
     function setTotalsCollateral(address asset, TotalsCollateral memory totals) public {


### PR DESCRIPTION
Started looking at the output of `solc -o output --asm contracts/Comet.sol`:

https://gist.github.com/scott-silver/7363f13fa6ca24a4d852eb8010902126#file-gistfile1-txt-L7155

For some reason, the line `TotalsBasic memory totals = totalsBasic` generates 178 lines of opcodes.

To see how much this was contributing to our contract size, I created this PR where I flattened the contents of `totalsBasic` and has functions alter those storage values directly.

I'm not recommending this as an approach, just wanted to see what kind of savings we might be able to get by changing our approach. Turns out the answer is "about 2.5kb".

Contract Size:

![image](https://user-images.githubusercontent.com/2570291/152459319-3e23896b-408a-4e6b-ae56-2f9f44978e80.png)

`jflatow/protocol-on-liquidatable` on the left, this branch on the right (~24kb -> 21.5kb)

Gas:

![image](https://user-images.githubusercontent.com/2570291/152459414-de6886df-b5a6-4811-8a63-19ced82ffc3a.png)

increases in:
- `absorb`
- `accrue`
- `supplyTo`
- `withdraw`
- `withdrawTo`

decreases in:
- `buyCollateral`
- `transfer`
- `transferFrom`
- `withdrawFrom`
- deploying `CometHarness` 5,743,414 -> 5,238,073