### PR TITLE
Increase threshold for accrue test

### DIFF
--- a/test/accrue-test.ts
+++ b/test/accrue-test.ts
@@ -34,7 +34,7 @@ describe('accrue', function () {
     expect(await t0.baseBorrowIndex).to.be.equal(exp(1, 15));
     expect(await t0.totalSupplyBase).to.be.equal(0);
     expect(await t0.totalBorrowBase).to.be.equal(0);
-    expect(await t0.lastAccrualTime).to.be.approximately(Date.now() / 1000, 30);
+    expect(await t0.lastAccrualTime).to.be.approximately(Date.now() / 1000, 50);
 
     const a0 = await wait(comet.accrue());
     expect(await comet.baseMinForRewards()).to.be.equal(params.baseMinForRewards);


### PR DESCRIPTION
This gives a bit more leeway for the time-based accrue test to pass, which is currently causing our coverage runs to fail.
