### PR TITLE
[size reduction ✅ ] Use full word uints for immutables/constants

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -527,43 +527,43 @@ contract Comet is CometMath, CometStorage {
     /**
      * @return The current per second supply rate
      */
-    function getSupplyRate() public view returns (uint64) {
+    function getSupplyRate() public view returns (uint) {
         return getSupplyRateInternal(totalsBasic);
     }
 
     /**
      * @dev Calculate current per second supply rate given totals
      */
-    function getSupplyRateInternal(TotalsBasic memory totals) internal view returns (uint64) {
+    function getSupplyRateInternal(TotalsBasic memory totals) internal view returns (uint) {
         uint utilization = getUtilizationInternal(totals);
         uint reserveScalingFactor = utilization * (factorScale - reserveRate) / factorScale;
         if (utilization <= kink) {
             // (interestRateBase + interestRateSlopeLow * utilization) * utilization * (1 - reserveRate)
-            return safe64(mulFactor(reserveScalingFactor, (perSecondInterestRateBase + mulFactor(perSecondInterestRateSlopeLow, utilization))));
+            return mulFactor(reserveScalingFactor, (perSecondInterestRateBase + mulFactor(perSecondInterestRateSlopeLow, utilization)));
         } else {
             // (interestRateBase + interestRateSlopeLow * kink + interestRateSlopeHigh * (utilization - kink)) * utilization * (1 - reserveRate)
-            return safe64(mulFactor(reserveScalingFactor, (perSecondInterestRateBase + mulFactor(perSecondInterestRateSlopeLow, kink) + mulFactor(perSecondInterestRateSlopeHigh, (utilization - kink)))));
+            return mulFactor(reserveScalingFactor, (perSecondInterestRateBase + mulFactor(perSecondInterestRateSlopeLow, kink) + mulFactor(perSecondInterestRateSlopeHigh, (utilization - kink))));
         }
     }
 
     /**
      * @return The current per second borrow rate
      */
-    function getBorrowRate() public view returns (uint64) {
+    function getBorrowRate() public view returns (uint) {
         return getBorrowRateInternal(totalsBasic);
     }
 
     /**
      * @dev Calculate current per second borrow rate given totals
      */
-    function getBorrowRateInternal(TotalsBasic memory totals) internal view returns (uint64) {
+    function getBorrowRateInternal(TotalsBasic memory totals) internal view returns (uint) {
         uint utilization = getUtilizationInternal(totals);
         if (utilization <= kink) {
             // interestRateBase + interestRateSlopeLow * utilization
-            return safe64(perSecondInterestRateBase + mulFactor(perSecondInterestRateSlopeLow, utilization));
+            return perSecondInterestRateBase + mulFactor(perSecondInterestRateSlopeLow, utilization);
         } else {
             // interestRateBase + interestRateSlopeLow * kink + interestRateSlopeHigh * (utilization - kink)
-            return safe64(perSecondInterestRateBase + mulFactor(perSecondInterestRateSlopeLow, kink) + mulFactor(perSecondInterestRateSlopeHigh, (utilization - kink)));
+            return perSecondInterestRateBase + mulFactor(perSecondInterestRateSlopeLow, kink) + mulFactor(perSecondInterestRateSlopeHigh, (utilization - kink));
         }
     }
 


### PR DESCRIPTION
This experimental PR changes most immutables/constants to be full word uints, which decreases the number of downcasts (both explicit and implicit) needed throughout the contract. It also gets rid of some downcasts that might not be necessary (e.g. casting the interest rates to uint64s).

This results in a contract size reduction of ~0.603 kb, as well as some small gas savings (e.g. `absorb` from 155.3k to 154.2k).

Contract size comparison (main on left, branch on right):
![Screen Shot 2022-02-14 at 5 03 55 PM](https://user-images.githubusercontent.com/11236786/153972887-b2037b32-7575-4d5d-af2d-0c444b6d7777.png)

Gas comparison (main on left, branch on right):
![Screen Shot 2022-02-14 at 4 39 18 PM](https://user-images.githubusercontent.com/11236786/153970702-6a7fc453-1c39-42ca-b4d0-96421a832c7e.png)

