### PR TITLE
[size reduction ✅ ] move pause flags into variables

### DIFF
--- a/contracts/CometMath.sol
+++ b/contracts/CometMath.sol
@@ -55,12 +55,4 @@ contract CometMath {
         require(n >= 0, "number is negative");
         return uint256(n);
     }
-
-    function toUInt8(bool x) internal pure returns (uint8) {
-        return x ? 1 : 0;
-    }
-
-    function toBool(uint8 x) internal pure returns (bool) {
-        return x != 0;
-    }
 }

--- a/contracts/CometStorage.sol
+++ b/contracts/CometStorage.sol
@@ -18,7 +18,6 @@ contract CometStorage {
         uint104 totalSupplyBase;
         uint104 totalBorrowBase;
         uint40 lastAccrualTime;
-        uint8 pauseFlags;
     }
 
     struct TotalsCollateral {
@@ -66,4 +65,10 @@ contract CometStorage {
 
     /// @notice Mapping of magic liquidator points
     mapping(address => LiquidatorPoints) public liquidatorPoints;
+
+    bool public isSupplyPaused = false;
+    bool public isTransferPaused = false;
+    bool public isWithdrawPaused = false;
+    bool public isAbsorbPaused = false;
+    bool public isBuyPaused = false;
 }


### PR DESCRIPTION
~.5kb savings if we break `pauseFlags` out of `TotalsBasic` and store the individual flags as separate variables:

(main on left, this branch on right)

<img width="703" alt="image" src="https://user-images.githubusercontent.com/2570291/153992676-7b35ef54-7eee-4284-8bc9-617378de866e.png">

Comes at a cost, though. Gas:

<img width="1692" alt="image" src="https://user-images.githubusercontent.com/2570291/153993014-149757b8-0656-4b6b-ab64-b783bf1b09cf.png">

Increased:
- absorb
- accrue
- allowBySig
- buyCollateral
- pause (significant)
- setBasePrincipal
- setCollateralBalance
- setNow
- supply
- supplyTo
- transfer
- withdraw
- withdrawFrom
- withdrawTo
- 

Decreased:
- setTotalsBasic
- supplyFrom
- deploying CometHarness