### PR TITLE
[size reduction ✅ ] Shorten reason strings

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -1186,8 +1186,10 @@ contract Comet is CometMath, CometStorage {
         updateBaseBalance(totals, dst, dstUser, principalValue(totals, dstBalance));
 
         if (srcBalance < 0) {
-            require(uint104(-srcBalance) >= baseBorrowMin, "borrow too small");
-            require(isBorrowCollateralized(src), "borrow cannot be maintained");
+            // require(uint104(-srcBalance) >= baseBorrowMin, "borrow too small");
+            // require(isBorrowCollateralized(src), "borrow cannot be maintained");
+            require(uint104(-srcBalance) >= baseBorrowMin, "tb1");
+            require(isBorrowCollateralized(src), "tb2");
         }
     }
 
@@ -1207,7 +1209,7 @@ contract Comet is CometMath, CometStorage {
         updateAssetsIn(dst, asset, dstCollateral, dstCollateralNew);
 
         // Note: no accrue interest, BorrowCF < LiquidationCF covers small changes
-        require(isBorrowCollateralized(src), "borrow would not be maintained");
+        require(isBorrowCollateralized(src), "tb2");
     }
 
     /**
@@ -1281,8 +1283,10 @@ contract Comet is CometMath, CometStorage {
         updateBaseBalance(totals, src, srcUser, principalValue(totals, srcBalance));
 
         if (srcBalance < 0) {
-            require(uint104(-srcBalance) >= baseBorrowMin, "borrow too small");
-            require(isBorrowCollateralized(src), "borrow cannot be maintained");
+            // require(uint104(-srcBalance) >= baseBorrowMin, "borrow too small");
+            // require(isBorrowCollateralized(src), "borrow cannot be maintained");
+            require(uint104(-srcBalance) >= baseBorrowMin, "tb1");
+            require(isBorrowCollateralized(src), "tb2");
         }
 
         doTransferOut(baseToken, to, amount);
@@ -1304,7 +1308,7 @@ contract Comet is CometMath, CometStorage {
         updateAssetsIn(src, asset, srcCollateral, srcCollateralNew);
 
         // Note: no accrue interest, BorrowCF < LiquidationCF covers small changes
-        require(isBorrowCollateralized(src), "borrow would not be maintained");
+        require(isBorrowCollateralized(src), "tb2");
 
         doTransferOut(asset, to, amount);
     }


### PR DESCRIPTION
Forgive the messy changes, but this is just a quick proof of concept to show that shortening our reason strings can save us some kb of contract size. So far from going through ~50-70% of the reason strings, it's saved around ~0.321 kb. 

It's a bit confusing to me why we are getting savings from these since most of our reason strings already fit within a 32 byte word.

Contract size (left is main, right is branch):
![Screen Shot 2022-02-15 at 2 30 10 PM](https://user-images.githubusercontent.com/11236786/154160730-84378aa5-5555-47eb-8708-2ffcf865e2ef.png)
