### PR TITLE
Pack AssetConfigs in Configurator

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -204,10 +204,12 @@ contract Comet is CometMath, CometStorage {
             assembly {
                 c := mload(add(add(packedAssetConfigs, 0x20), mul(i, 0x20)))
             }
-        return PackedAssetConfig({
-            word_a: uint256(0),
-            word_b: uint256(0)
-        });
+        else {
+            c = PackedAssetConfig({
+                word_a: uint256(0),
+                word_b: uint256(0)
+            });
+        }
     }
 
     /**
@@ -311,7 +313,7 @@ contract Comet is CometMath, CometStorage {
                 return assetInfo;
             }
         }
-        revert("bad asset");
+        revert("bad asset"); // XXX HERE
     }
 
     /**

--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -121,39 +121,6 @@ contract Comet is CometMath, CometStorage {
     uint256 internal immutable asset14_a;
     uint256 internal immutable asset14_b;
 
-    /** Internal constants **/
-
-    /// @dev The max number of assets this contract is hardcoded to support
-    ///  Do not change this variable without updating all the fields throughout the contract,
-    //    including the size of UserBasic.assetsIn and corresponding integer conversions.
-    uint8 internal constant MAX_ASSETS = 15;
-
-    /// @dev The max number of decimals base token can have
-    ///  Note this cannot just be increased arbitrarily.
-    uint8 internal constant MAX_BASE_DECIMALS = 18;
-
-    /// @dev Offsets for specific actions in the pause flag bit array
-    uint8 internal constant PAUSE_SUPPLY_OFFSET = 0;
-    uint8 internal constant PAUSE_TRANSFER_OFFSET = 1;
-    uint8 internal constant PAUSE_WITHDRAW_OFFSET = 2;
-    uint8 internal constant PAUSE_ABSORB_OFFSET = 3;
-    uint8 internal constant PAUSE_BUY_OFFSET = 4;
-
-    /// @dev The decimals required for a price feed
-    uint8 internal constant PRICE_FEED_DECIMALS = 8;
-
-    /// @dev 365 days * 24 hours * 60 minutes * 60 seconds
-    uint64 internal constant SECONDS_PER_YEAR = 31_536_000;
-
-    /// @dev The scale for base index (depends on time/rate scales, not base token)
-    uint64 internal constant BASE_INDEX_SCALE = 1e15;
-
-    /// @dev The scale for factors
-    uint64 internal constant FACTOR_SCALE = 1e18;
-
-    /// @dev The scale for prices (in USD)
-    uint64 internal constant PRICE_SCALE = 1e8;
-
     /**
      * @notice Construct a new protocol instance
      * @param config The mapping of initial/constant parameters

--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -162,7 +162,7 @@ contract Comet is CometMath, CometStorage {
         // Sanity checks
         uint decimals = ERC20(config.baseToken).decimals();
         require(decimals <= MAX_BASE_DECIMALS, "too many decimals");
-        require(config.assetConfigs.length <= MAX_ASSETS, "too many assets");
+        require(config.packedAssetConfigs.length <= MAX_ASSETS, "too many assets");
         require(config.baseMinForRewards > 0, "bad rewards min");
         require(AggregatorV3Interface(config.baseTokenPriceFeed).decimals() == PRICE_FEED_DECIMALS, "bad decimals");
         // XXX other sanity checks? for rewards?
@@ -192,23 +192,23 @@ contract Comet is CometMath, CometStorage {
         reserveRate = config.reserveRate;
 
         // Set asset info
-        numAssets = uint8(config.assetConfigs.length);
+        numAssets = uint8(config.packedAssetConfigs.length);
 
-        (asset00_a, asset00_b) = _getPackedAsset(config.assetConfigs, 0);
-        (asset01_a, asset01_b) = _getPackedAsset(config.assetConfigs, 1);
-        (asset02_a, asset02_b) = _getPackedAsset(config.assetConfigs, 2);
-        (asset03_a, asset03_b) = _getPackedAsset(config.assetConfigs, 3);
-        (asset04_a, asset04_b) = _getPackedAsset(config.assetConfigs, 4);
-        (asset05_a, asset05_b) = _getPackedAsset(config.assetConfigs, 5);
-        (asset06_a, asset06_b) = _getPackedAsset(config.assetConfigs, 6);
-        (asset07_a, asset07_b) = _getPackedAsset(config.assetConfigs, 7);
-        (asset08_a, asset08_b) = _getPackedAsset(config.assetConfigs, 8);
-        (asset09_a, asset09_b) = _getPackedAsset(config.assetConfigs, 9);
-        (asset10_a, asset10_b) = _getPackedAsset(config.assetConfigs, 10);
-        (asset11_a, asset11_b) = _getPackedAsset(config.assetConfigs, 11);
-        (asset12_a, asset12_b) = _getPackedAsset(config.assetConfigs, 12);
-        (asset13_a, asset13_b) = _getPackedAsset(config.assetConfigs, 13);
-        (asset14_a, asset14_b) = _getPackedAsset(config.assetConfigs, 14);
+        (asset00_a, asset00_b) = _getPackedAsset(config.packedAssetConfigs, 0);
+        (asset01_a, asset01_b) = _getPackedAsset(config.packedAssetConfigs, 1);
+        (asset02_a, asset02_b) = _getPackedAsset(config.packedAssetConfigs, 2);
+        (asset03_a, asset03_b) = _getPackedAsset(config.packedAssetConfigs, 3);
+        (asset04_a, asset04_b) = _getPackedAsset(config.packedAssetConfigs, 4);
+        (asset05_a, asset05_b) = _getPackedAsset(config.packedAssetConfigs, 5);
+        (asset06_a, asset06_b) = _getPackedAsset(config.packedAssetConfigs, 6);
+        (asset07_a, asset07_b) = _getPackedAsset(config.packedAssetConfigs, 7);
+        (asset08_a, asset08_b) = _getPackedAsset(config.packedAssetConfigs, 8);
+        (asset09_a, asset09_b) = _getPackedAsset(config.packedAssetConfigs, 9);
+        (asset10_a, asset10_b) = _getPackedAsset(config.packedAssetConfigs, 10);
+        (asset11_a, asset11_b) = _getPackedAsset(config.packedAssetConfigs, 11);
+        (asset12_a, asset12_b) = _getPackedAsset(config.packedAssetConfigs, 12);
+        (asset13_a, asset13_b) = _getPackedAsset(config.packedAssetConfigs, 13);
+        (asset14_a, asset14_b) = _getPackedAsset(config.packedAssetConfigs, 14);
 
         // Initialize storage
         initialize_storage();
@@ -232,25 +232,23 @@ contract Comet is CometMath, CometStorage {
     /**
      * @dev Gets the info for an asset or empty, for initialization
      */
-    function _getAssetConfig(AssetConfig[] memory assetConfigs, uint i) internal pure returns (AssetConfig memory c) {
-        if (i < assetConfigs.length) {
+    function _getAssetConfig(PackedAssetConfig[] memory packedAssetConfigs, uint i) internal pure returns (PackedAssetConfig memory c) {
+        if (i < packedAssetConfigs.length)
             assembly {
-                c := mload(add(add(assetConfigs, 0x20), mul(i, 0x20)))
+                c := mload(add(add(packedAssetConfigs, 0x20), mul(i, 0x20)))
             }
-        } else {
-            c = AssetConfig({
-                word_a: uint256(0),
-                word_b: uint256(0)
-            });
-        }
+        return PackedAssetConfig({
+            word_a: uint256(0),
+            word_b: uint256(0)
+        });
     }
 
     /**
      * @dev Checks and gets the packed asset info for storage
      */
-    function _getPackedAsset(AssetConfig[] memory assetConfigs, uint i) internal pure returns (uint256, uint256) {
-        AssetConfig memory assetConfig = _getAssetConfig(assetConfigs, i);
-        return (assetConfig.word_a, assetConfig.word_b);
+    function _getPackedAsset(PackedAssetConfig[] memory packedAssetConfigs, uint i) internal pure returns (uint256, uint256) {
+        PackedAssetConfig memory packedAssetConfig = _getAssetConfig(packedAssetConfigs, i);
+        return (packedAssetConfig.word_a, packedAssetConfig.word_b);
     }
 
     /**

--- a/contracts/CometConfiguration.sol
+++ b/contracts/CometConfiguration.sol
@@ -26,11 +26,47 @@ contract CometConfiguration {
         uint104 baseBorrowMin;
         uint104 targetReserves;
 
+        PackedAssetConfig[] packedAssetConfigs;
+    }
+
+    // Configuration params passed to the Configurator.
+    // The only distinction between the Comet configuration is
+    // that the assets are not packed when passed into the 
+    // Configurator.
+    struct ConfiguratorConfiguration {
+        address governor;
+        address pauseGuardian;
+        address baseToken;
+        address baseTokenPriceFeed;
+        address extensionDelegate;
+
+        uint64 kink;
+        uint64 perYearInterestRateSlopeLow;
+        uint64 perYearInterestRateSlopeHigh;
+        uint64 perYearInterestRateBase;
+        uint64 reserveRate;
+        uint64 trackingIndexScale;
+        uint64 baseTrackingSupplySpeed;
+        uint64 baseTrackingBorrowSpeed;
+        uint104 baseMinForRewards;
+        uint104 baseBorrowMin;
+        uint104 targetReserves;
+
         AssetConfig[] assetConfigs;
     }
 
-    struct AssetConfig {
+    struct PackedAssetConfig {
         uint256 word_a;
         uint256 word_b;
+    }
+
+    struct AssetConfig {
+        address asset;
+        address priceFeed;
+        uint8 decimals;
+        uint64 borrowCollateralFactor;
+        uint64 liquidateCollateralFactor;
+        uint64 liquidationFactor;
+        uint128 supplyCap;
     }
 }

--- a/contracts/CometConfiguration.sol
+++ b/contracts/CometConfiguration.sol
@@ -7,6 +7,8 @@ pragma solidity ^0.8.11;
  * @author Compound
  */
 contract CometConfiguration {
+    // XXX Find a way to share common configuration parameters
+    // between Configurator and Comet constructor
     struct Configuration {
         address governor;
         address pauseGuardian;

--- a/contracts/CometProxyAdmin.sol
+++ b/contracts/CometProxyAdmin.sol
@@ -25,7 +25,7 @@ contract CometProxyAdmin is ProxyAdmin, CometConfiguration {
      *
      * - This contract must be the admin of `proxy`.
      */
-    function setConfiguration(TransparentUpgradeableFactoryProxy proxy, Configuration memory config) public virtual onlyOwner {
+    function setConfiguration(TransparentUpgradeableFactoryProxy proxy, ConfiguratorConfiguration memory config) public virtual onlyOwner {
         proxy.setConfiguration(config);
     }
 

--- a/contracts/CometStorage.sol
+++ b/contracts/CometStorage.sol
@@ -9,8 +9,41 @@ import "./CometConfiguration.sol";
  * @author Compound
  */
 contract CometStorage is CometConfiguration {
+    
+    /// ====== Internal Constants ======
 
-    /// ====== START OF PARAM STORAGE ======
+    /// @dev The max number of assets this contract is hardcoded to support
+    ///  Do not change this variable without updating all the fields throughout the contract,
+    //    including the size of UserBasic.assetsIn and corresponding integer conversions.
+    uint8 internal constant MAX_ASSETS = 15;
+
+    /// @dev The max number of decimals base token can have
+    ///  Note this cannot just be increased arbitrarily.
+    uint8 internal constant MAX_BASE_DECIMALS = 18;
+
+    /// @dev Offsets for specific actions in the pause flag bit array
+    uint8 internal constant PAUSE_SUPPLY_OFFSET = 0;
+    uint8 internal constant PAUSE_TRANSFER_OFFSET = 1;
+    uint8 internal constant PAUSE_WITHDRAW_OFFSET = 2;
+    uint8 internal constant PAUSE_ABSORB_OFFSET = 3;
+    uint8 internal constant PAUSE_BUY_OFFSET = 4;
+
+    /// @dev The decimals required for a price feed
+    uint8 internal constant PRICE_FEED_DECIMALS = 8;
+
+    /// @dev 365 days * 24 hours * 60 minutes * 60 seconds
+    uint64 internal constant SECONDS_PER_YEAR = 31_536_000;
+
+    /// @dev The scale for base index (depends on time/rate scales, not base token)
+    uint64 internal constant BASE_INDEX_SCALE = 1e15;
+
+    /// @dev The scale for factors
+    uint64 internal constant FACTOR_SCALE = 1e18;
+
+    /// @dev The scale for prices (in USD)
+    uint64 internal constant PRICE_SCALE = 1e8;
+
+    /// ====== Configurator Parameters ======
 
     /// @notice Configuration settings used to deploy new Comet instances
     /// by the configurator
@@ -37,7 +70,7 @@ contract CometStorage is CometConfiguration {
 
     AssetConfig[] public assetConfigsParam;
 
-    /// ====== END OF PARAM STORAGE ======
+    /// ====== Comet Storage ======
 
     // 512 bits total = 2 slots
     struct TotalsBasic {

--- a/contracts/CometStorage.sol
+++ b/contracts/CometStorage.sol
@@ -8,13 +8,36 @@ import "./CometConfiguration.sol";
  * @dev Versions can enforce append-only storage slots via inheritance.
  * @author Compound
  */
-contract CometStorage is CometConfiguration{
+contract CometStorage is CometConfiguration {
+
+    /// ====== START OF PARAM STORAGE ======
+
     /// @notice Configuration settings used to deploy new Comet instances
     /// by the configurator
     /// @dev This needs to be internal to avoid a `CompilerError: Stack too deep
     /// when compiling inline assembly` error that is caused by the default
     /// getters created for public variables.
-    Configuration internal configuratorParams;
+    address public governorParam;
+    address public pauseGuardianParam;
+    address public baseTokenParam;
+    address public baseTokenPriceFeedParam;
+    address public extensionDelegateParam;
+
+    uint64 public kinkParam;
+    uint64 public perYearInterestRateSlopeLowParam;
+    uint64 public perYearInterestRateSlopeHighParam;
+    uint64 public perYearInterestRateBaseParam;
+    uint64 public reserveRateParam;
+    uint64 public trackingIndexScaleParam;
+    uint64 public baseTrackingSupplySpeedParam;
+    uint64 public baseTrackingBorrowSpeedParam;
+    uint104 public baseMinForRewardsParam;
+    uint104 public baseBorrowMinParam;
+    uint104 public targetReservesParam;
+
+    AssetConfig[] public assetConfigsParam;
+
+    /// ====== END OF PARAM STORAGE ======
 
     // 512 bits total = 2 slots
     struct TotalsBasic {

--- a/contracts/TransparentUpgradeableFactoryProxy.sol
+++ b/contracts/TransparentUpgradeableFactoryProxy.sol
@@ -143,7 +143,7 @@ contract TransparentUpgradeableFactoryProxy is TransparentUpgradeableProxy, Come
     }
 
     function _getPackedAssets(AssetConfig[] memory assetConfigs) internal view returns (PackedAssetConfig[] memory) {
-        PackedAssetConfig[] memory packedAssetConfigs;
+        PackedAssetConfig[] memory packedAssetConfigs = new PackedAssetConfig[](MAX_ASSETS);
         for (uint256 i = 0; i < MAX_ASSETS; i++) {
             (uint word_a, uint word_b) = _getPackedAssetHelper(assetConfigs, i);
             PackedAssetConfig memory packedAssetConfig = PackedAssetConfig({ word_a: word_a, word_b: word_b });

--- a/contracts/TransparentUpgradeableFactoryProxy.sol
+++ b/contracts/TransparentUpgradeableFactoryProxy.sol
@@ -120,8 +120,6 @@ contract TransparentUpgradeableFactoryProxy is TransparentUpgradeableProxy, Come
         // require(assetConfig.liquidateCollateralFactor <= maxCollateralFactor, "liquidate CF too high");
 
         // Keep 4 decimals for each factor
-        // XXX Where to define FACTOR_SCALE and make sure it matches that of Comet?
-        uint FACTOR_SCALE = 1e18;
         uint descale = FACTOR_SCALE / 1e4;
         uint16 borrowCollateralFactor = uint16(assetConfig.borrowCollateralFactor / descale);
         uint16 liquidateCollateralFactor = uint16(assetConfig.liquidateCollateralFactor / descale);
@@ -145,7 +143,6 @@ contract TransparentUpgradeableFactoryProxy is TransparentUpgradeableProxy, Come
     }
 
     function _getPackedAssets(AssetConfig[] memory assetConfigs) internal view returns (PackedAssetConfig[] memory) {
-        uint MAX_ASSETS = 16; // XXX WHERE TO DEFINE THIS?
         PackedAssetConfig[] memory packedAssetConfigs;
         for (uint256 i = 0; i < MAX_ASSETS; i++) {
             (uint word_a, uint word_b) = _getPackedAssetHelper(assetConfigs, i);

--- a/contracts/TransparentUpgradeableFactoryProxy.sol
+++ b/contracts/TransparentUpgradeableFactoryProxy.sol
@@ -99,7 +99,7 @@ contract TransparentUpgradeableFactoryProxy is TransparentUpgradeableProxy, Come
     /**
      * @dev Checks and gets the packed asset info for storage
      */
-    function _getPackedAssetHelper(AssetConfig[] memory assetConfigs, uint i) internal view returns (uint, uint) {
+    function _getPackedAssetHelper(AssetConfig[] memory assetConfigs, uint i) internal pure returns (uint, uint) {
         AssetConfig memory assetConfig = _getAssetConfig(assetConfigs, i);
         address asset = assetConfig.asset;
         address priceFeed = assetConfig.priceFeed;
@@ -143,15 +143,14 @@ contract TransparentUpgradeableFactoryProxy is TransparentUpgradeableProxy, Come
     }
 
     function _getPackedAssets(AssetConfig[] memory assetConfigs) internal view returns (PackedAssetConfig[] memory) {
-        PackedAssetConfig[] memory packedAssetConfigs = new PackedAssetConfig[](MAX_ASSETS);
-        for (uint256 i = 0; i < MAX_ASSETS; i++) {
+        PackedAssetConfig[] memory packedAssetConfigs = new PackedAssetConfig[](assetConfigs.length);
+        for (uint256 i = 0; i < assetConfigs.length; i++) {
             (uint word_a, uint word_b) = _getPackedAssetHelper(assetConfigs, i);
             PackedAssetConfig memory packedAssetConfig = PackedAssetConfig({ word_a: word_a, word_b: word_b });
             packedAssetConfigs[i] = packedAssetConfig;
         }
         return packedAssetConfigs;
     }
-
 
     // XXX Define other setters for setting params
     function setGovernor(address governor) external ifAdmin {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -102,7 +102,7 @@ const config: HardhatUserConfig = {
         enabled: true,
         runs: 1,
       },
-      // viaIR: true,
+      viaIR: true,
     },
   },
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -102,7 +102,7 @@ const config: HardhatUserConfig = {
         enabled: true,
         runs: 1,
       },
-      viaIR: true,
+      // viaIR: true,
     },
   },
 

--- a/test/configurator-test.ts
+++ b/test/configurator-test.ts
@@ -1,1 +1,25 @@
-// XXX SETUP PROXIES IN UNIT TEST
+import { ethers, expect, makeConfigurator, wait } from './helpers';
+
+describe('configurator', function () {
+  it('sets configuration params correctly', async () => {
+  });
+
+  it.only('deploys Comet', async () => {
+    const { governor, configurator, proxyAdmin, comet } = await makeConfigurator();
+
+    expect(await proxyAdmin.getProxyImplementation(configurator.address)).to.be.equal(comet.address);
+    
+    await wait(proxyAdmin.connect(governor).deployAndUpgrade(configurator.address));
+
+    expect(await proxyAdmin.getProxyImplementation(configurator.address)).to.not.be.equal(comet.address);
+  });
+
+  it('deploys Comet with new configuration', async () => {
+  });
+
+  it('reverts if deploy is called from non-governor', async () => {
+  });
+
+  it('packs asset configs correctly', async () => {
+  });
+});

--- a/test/configurator-test.ts
+++ b/test/configurator-test.ts
@@ -1,25 +1,79 @@
-import { ethers, expect, makeConfigurator, wait } from './helpers';
+import { ethers, exp, expect, makeConfigurator, wait } from './helpers';
+import { CometFactory, Comet__factory } from '../build/types';
 
 describe('configurator', function () {
-  it('sets configuration params correctly', async () => {
-  });
-
-  it.only('deploys Comet', async () => {
+  it('deploys Comet', async () => {
     const { governor, configurator, proxyAdmin, comet } = await makeConfigurator();
 
     expect(await proxyAdmin.getProxyImplementation(configurator.address)).to.be.equal(comet.address);
-    
+
     await wait(proxyAdmin.connect(governor).deployAndUpgrade(configurator.address));
 
     expect(await proxyAdmin.getProxyImplementation(configurator.address)).to.not.be.equal(comet.address);
   });
 
-  it('deploys Comet with new configuration', async () => {
+  it.skip('sets entire Configuration and deploys Comet with new configuration', async () => {
   });
 
-  it('reverts if deploy is called from non-governor', async () => {
+  it('sets governor and deploys Comet with new configuration', async () => {
+    const { governor, configurator, proxyAdmin, users: [alice] } = await makeConfigurator();
+
+    expect(await configurator.governorParam()).to.be.equal(governor.address);
+
+    await wait(proxyAdmin.connect(governor).setGovernor(configurator.address, alice.address));
+    await wait(proxyAdmin.connect(governor).deployAndUpgrade(configurator.address));
+
+    expect(await configurator.governorParam()).to.be.equal(alice.address);
+  });
+
+  it.skip('adds asset and deploys Comet with new configuration', async () => {
   });
 
   it('packs asset configs correctly', async () => {
+    const { governor, configurator, proxyAdmin, comet, tokens, users: [alice] } = await makeConfigurator({
+      assets: {
+        USDC: { decimals: 6 },
+        COMP: {
+          initial: 1e7,
+          decimals: 18,
+          initialPrice: 1,
+          borrowCF: exp(0.9, 18),
+          liquidateCF: exp(0.95, 18),
+          liquidationFactor: exp(0.95, 18),
+          supplyCap: exp(1_000_000, 18),
+        },
+      },
+    });
+
+    await wait(proxyAdmin.connect(governor).deployAndUpgrade(configurator.address));
+
+    // Verify Comet address has changed
+    const newCometAddress = await proxyAdmin.getProxyImplementation(configurator.address);
+    expect(newCometAddress).to.not.be.equal(comet.address);
+
+    const CometFactory = (await ethers.getContractFactory('Comet')) as Comet__factory;
+    const newComet = CometFactory.attach(newCometAddress);
+
+    // Verify assets are correctly set
+    const cometNumAssets = await newComet.numAssets();
+    expect(cometNumAssets).to.be.equal(1);
+    const assetInfo00 = await comet.getAssetInfo(0);
+    expect(assetInfo00.asset).to.be.equal(tokens['COMP'].address);
+    expect(assetInfo00.scale).to.equal(exp(1, 18));
+    expect(assetInfo00.borrowCollateralFactor).to.equal(exp(0.9, 18));
+    expect(assetInfo00.liquidateCollateralFactor).to.equal(exp(0.95, 18));
+    expect(assetInfo00.supplyCap).to.equal(exp(1_000_000, 18));
+  });
+
+  it('reverts if deploy is called from non-governor', async () => {
+    const { configurator, proxyAdmin, users: [alice] } = await makeConfigurator();
+
+    await expect(proxyAdmin.connect(alice).deployAndUpgrade(configurator.address)).to.be.revertedWith('Ownable: caller is not the owner');
+  });
+
+  it('reverts if deploy is called directly in Configurator instead of from ProxyAdmin', async () => {
+    const { configurator, users: [alice] } = await makeConfigurator();
+
+    await expect(configurator.connect(alice).deployAndUpgrade()).to.be.revertedWith(`function selector was not recognized and there's no fallback function`);
   });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -83,7 +83,11 @@ export type Configurator = {
   configurator: TransparentUpgradeableFactoryProxy,
   proxyAdmin: CometProxyAdmin,
   cometFactory: CometFactory,
-  comet: Comet
+  comet: Comet,
+  tokens: {
+    [symbol: string]: FaucetToken;
+  },
+  users: SignerWithAddress[]
 }
 
 export function dfn<T>(x: T | undefined | null, dflt: T): T {
@@ -244,7 +248,9 @@ export async function makeConfigurator(opts: ProtocolOpts = {}): Promise<Configu
     configurator,
     proxyAdmin,
     cometFactory,
-    comet
+    comet,
+    tokens,
+    users
   };
 }
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -5,12 +5,18 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import {
   CometExt,
   CometExt__factory as CometExt__factory,
+  CometFactory,
+  CometFactory__factory,
   CometHarness as Comet,
   CometHarness__factory as Comet__factory,
+  CometProxyAdmin,
+  CometProxyAdmin__factory,
   FaucetToken,
   FaucetToken__factory,
   SimplePriceFeed,
   SimplePriceFeed__factory,
+  TransparentUpgradeableFactoryProxy,
+  TransparentUpgradeableFactoryProxy__factory,
 } from '../build/types';
 import { BigNumber } from 'ethers';
 import { TransactionReceipt, TransactionResponse } from '@ethersproject/abstract-provider';
@@ -72,6 +78,14 @@ export type Protocol = {
   };
 };
 
+export type Configurator = {
+  governor: SignerWithAddress,
+  configurator: TransparentUpgradeableFactoryProxy,
+  proxyAdmin: CometProxyAdmin,
+  cometFactory: CometFactory,
+  comet: Comet
+}
+
 export function dfn<T>(x: T | undefined | null, dflt: T): T {
   return x == undefined ? dflt : x;
 }
@@ -132,6 +146,106 @@ export const ZERO = factor(0);
 export async function getBlock(n?: number): Promise<Block> {
   const blockNumber = n === undefined ? await ethers.provider.getBlockNumber() : n;
   return ethers.provider.getBlock(blockNumber);
+}
+
+// Only for testing configurator. Non-configurator tests need to deploy the CometHarness instead.
+export async function makeConfigurator(opts: ProtocolOpts = {}): Promise<Configurator> {
+  const signers = await ethers.getSigners();
+
+  const assets = opts.assets || defaultAssets();
+  let priceFeeds = {};
+  for (const asset in assets) {
+    const PriceFeedFactory = (await ethers.getContractFactory(
+      'SimplePriceFeed'
+    )) as SimplePriceFeed__factory;
+    const initialPrice = exp(assets[asset].initialPrice || 1, 8);
+    const priceFeedDecimals = assets[asset].priceFeedDecimals || 8;
+    const priceFeed = await PriceFeedFactory.deploy(initialPrice, priceFeedDecimals);
+    await priceFeed.deployed();
+    priceFeeds[asset] = priceFeed;
+  }
+
+  const governor = opts.governor || signers[0];
+  const pauseGuardian = opts.pauseGuardian || signers[1];
+  const users = signers.slice(2); // guaranteed to not be governor or pause guardian
+  const base = opts.base || 'USDC';
+  const reward = opts.reward || 'COMP';
+  const kink = dfn(opts.kink, exp(8, 17)); // 0.8
+  const perYearInterestRateBase = dfn(opts.interestRateBase, exp(5, 15)); // 0.005
+  const perYearInterestRateSlopeLow = dfn(opts.interestRateSlopeLow, exp(1, 17)); // 0.1
+  const perYearInterestRateSlopeHigh = dfn(opts.interestRateSlopeHigh, exp(3, 18)); // 3.0
+  const reserveRate = dfn(opts.reserveRate, exp(1, 17)); // 0.1
+  const trackingIndexScale = opts.trackingIndexScale || exp(1, 15);
+  const baseTrackingSupplySpeed = dfn(opts.baseTrackingSupplySpeed, trackingIndexScale);
+  const baseTrackingBorrowSpeed = dfn(opts.baseTrackingBorrowSpeed, trackingIndexScale);
+  const baseMinForRewards = dfn(opts.baseMinForRewards, exp(1, assets[base].decimals));
+  const baseBorrowMin = dfn(opts.baseBorrowMin, exp(1, assets[base].decimals));
+  const targetReserves = dfn(opts.targetReserves, 0);
+
+  const {tokens, comet, extensionDelegate } = await makeProtocol(opts);
+
+  if (opts.start) await ethers.provider.send('evm_setNextBlockTimestamp', [opts.start]);
+
+  // Deploy CometFactory
+  const CometFactoryFactory = (await ethers.getContractFactory('CometFactory')) as CometFactory__factory;
+  const cometFactory = await CometFactoryFactory.deploy();
+  await cometFactory.deployed();
+
+  // Deploy CometProxyAdmin
+  const CometProxyAdminFactory = (await ethers.getContractFactory('CometProxyAdmin')) as CometProxyAdmin__factory;
+  const proxyAdmin = await CometProxyAdminFactory.connect(governor).deploy();
+  await proxyAdmin.deployed();
+
+  // Deploy Configurator
+  const ConfiguratorFactory = (await ethers.getContractFactory('TransparentUpgradeableFactoryProxy')) as TransparentUpgradeableFactoryProxy__factory;
+  const configurator = await ConfiguratorFactory.deploy(
+    cometFactory.address,
+    comet.address,
+    proxyAdmin.address,
+    []
+  );
+  await configurator.deployed();
+
+  await wait(proxyAdmin.setConfiguration(configurator.address, {
+    governor: governor.address,
+    pauseGuardian: pauseGuardian.address,
+    extensionDelegate: extensionDelegate.address,
+    baseToken: tokens[base].address,
+    baseTokenPriceFeed: priceFeeds[base].address,
+    kink,
+    perYearInterestRateBase,
+    perYearInterestRateSlopeLow,
+    perYearInterestRateSlopeHigh,
+    reserveRate,
+    trackingIndexScale,
+    baseTrackingSupplySpeed,
+    baseTrackingBorrowSpeed,
+    baseMinForRewards,
+    baseBorrowMin,
+    targetReserves,
+    assetConfigs: Object.entries(assets).reduce((acc, [symbol, config], i) => {
+      if (symbol != base) {
+        acc.push({
+          asset: tokens[symbol].address,
+          priceFeed: priceFeeds[symbol].address,
+          decimals: dfn(assets[symbol].decimals, 18),
+          borrowCollateralFactor: dfn(config.borrowCF, ONE - 1n),
+          liquidateCollateralFactor: dfn(config.liquidateCF, ONE),
+          liquidationFactor: dfn(config.liquidationFactor, ONE),
+          supplyCap: dfn(config.supplyCap, exp(100, dfn(config.decimals, 18))),
+        });
+      }
+      return acc;
+    }, []),
+  }));
+
+  return {
+    governor,
+    configurator,
+    proxyAdmin,
+    cometFactory,
+    comet
+  };
 }
 
 export async function makeProtocol(opts: ProtocolOpts = {}): Promise<Protocol> {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -207,7 +207,7 @@ export async function makeProtocol(opts: ProtocolOpts = {}): Promise<Protocol> {
     baseMinForRewards,
     baseBorrowMin,
     targetReserves,
-    assetConfigs: Object.entries(assets).reduce((acc, [symbol, config], i) => {
+    packedAssetConfigs: Object.entries(assets).reduce((acc, [symbol, config], i) => {
       const descale = factorScale / (10n**4n);
       const decimals = BigInt(dfn(config.decimals, 18));
       const borrowCF = BigInt(dfn(config.borrowCF, ONE - 1n));


### PR DESCRIPTION
Turning this branch into a draft PR so we can more easily leave comments on these changes.

This builds on top of #176, where `AssetConfig` in Comet is now pre-packed into `word_a, word_b`. This PR allows the Configurator to take in the unpacked `AssetConfig`s and pack them before passing them into the Comet constructor.