### PR TITLE
Uncheck some constant math to save a few bytes

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -985,6 +985,8 @@ contract Comet is CometCore {
             if (uint104(-srcBalance) < baseBorrowMin) revert BorrowTooSmall();
             if (!isBorrowCollateralized(src)) revert NotCollateralized();
         }
+
+        emit Transfer(src, dst, amount);
     }
 
     /**

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -275,10 +275,15 @@ export async function wait(
   };
 }
 
-export function filterEvent(data, eventName) {
-  return data.receipt.events?.filter((x) => {
-    return x.event == eventName;
-  })[0];
+export function event(tx, index) {
+  const ev = tx.receipt.events[index], args = {};
+  for (const k in ev.args) {
+    const v = ev.args[k];
+    if (isNaN(Number(k))) {
+      args[k] = v._isBigNumber ? BigInt(v) : v;
+    }
+  }
+  return { [ev.event]: args };
 }
 
 export function inCoverage() {

--- a/test/withdraw-reserves-test.ts
+++ b/test/withdraw-reserves-test.ts
@@ -1,4 +1,4 @@
-import { expect, makeProtocol, wait, filterEvent } from './helpers';
+import { expect, makeProtocol, wait } from './helpers';
 
 describe('withdrawReserves', function () {
   it('withdraws reserves from the protocol', async () => {


### PR DESCRIPTION
As far as I can tell unchecking the loop variables doesn't save anything. Take other safe ones from #175.