### PR TITLE
Add basic informational events

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -17,9 +17,9 @@ contract Comet is CometCore {
     event Transfer(address indexed from, address indexed to, uint256 amount);
     event Withdraw(address indexed src, address indexed to, uint256 amount);
 
-    event Supply(address indexed from, address indexed dst, address indexed asset, uint256 amount);
-    event Transfer(address indexed from, address indexed to, address indexed asset, uint256 amount);
-    event Withdraw(address indexed src, address indexed to, address indexed asset, uint256 amount);
+    event SupplyCollateral(address indexed from, address indexed dst, address indexed asset, uint256 amount);
+    event TransferCollateral(address indexed from, address indexed to, address indexed asset, uint256 amount);
+    event WithdrawCollateral(address indexed src, address indexed to, address indexed asset, uint256 amount);
 
     /** Custom errors **/
 
@@ -900,7 +900,7 @@ contract Comet is CometCore {
 
         updateAssetsIn(dst, asset, dstCollateral, dstCollateralNew);
 
-        emit Supply(from, dst, asset, amount);
+        emit SupplyCollateral(from, dst, asset, amount);
     }
 
     /**
@@ -1017,7 +1017,7 @@ contract Comet is CometCore {
         // Note: no accrue interest, BorrowCF < LiquidationCF covers small changes
         if (!isBorrowCollateralized(src)) revert NotCollateralized();
 
-        emit Transfer(src, dst, asset, amount);
+        emit TransferCollateral(src, dst, asset, amount);
     }
 
     /**
@@ -1115,7 +1115,7 @@ contract Comet is CometCore {
 
         doTransferOut(asset, to, amount);
 
-        emit Withdraw(src, to, asset, amount);
+        emit WithdrawCollateral(src, to, asset, amount);
     }
 
     /**

--- a/contracts/CometInterface.sol
+++ b/contracts/CometInterface.sol
@@ -10,6 +10,13 @@ import "./ERC20.sol";
  * @author Compound
  */
 abstract contract CometInterface is CometCore, ERC20 {
+    event Supply(address indexed from, address indexed dst, uint256 amount);
+    event Withdraw(address indexed src, address indexed to, uint256 amount);
+
+    event SupplyCollateral(address indexed from, address indexed dst, address indexed asset, uint256 amount);
+    event TransferCollateral(address indexed from, address indexed to, address indexed asset, uint256 amount);
+    event WithdrawCollateral(address indexed src, address indexed to, address indexed asset, uint256 amount);
+
     function allow(address manager, bool isAllowed) virtual external;
     function allowBySig(address owner, address manager, bool isAllowed, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) virtual external;
 

--- a/test/supply-test.ts
+++ b/test/supply-test.ts
@@ -1,4 +1,4 @@
-import { Comet, ethers, expect, exp, makeProtocol, portfolio, wait } from './helpers';
+import { Comet, ethers, event, expect, exp, makeProtocol, portfolio, wait } from './helpers';
 
 describe('supplyTo', function () {
   it('supplies base from sender if the asset is base', async () => {
@@ -18,6 +18,21 @@ describe('supplyTo', function () {
     const t1 = await comet.totalsBasic();
     const p1 = await portfolio(protocol, alice.address)
     const q1 = await portfolio(protocol, bob.address)
+
+    expect(event(s0, 0)).to.be.deep.equal({
+      Transfer: {
+        from: bob.address,
+        to: comet.address,
+        amount: BigInt(100e6),
+      }
+    });
+    expect(event(s0, 1)).to.be.deep.equal({
+      Supply: {
+        from: bob.address,
+        dst: alice.address,
+        amount: BigInt(100e6),
+      }
+    });
 
     expect(p0.internal).to.be.deep.equal({USDC: 0n, COMP: 0n, WETH: 0n, WBTC: 0n});
     expect(p0.external).to.be.deep.equal({USDC: 0n, COMP: 0n, WETH: 0n, WBTC: 0n});
@@ -50,6 +65,22 @@ describe('supplyTo', function () {
     const t1 = await comet.totalsCollateral(COMP.address);
     const p1 = await portfolio(protocol, alice.address)
     const q1 = await portfolio(protocol, bob.address)
+
+    expect(event(s0, 0)).to.be.deep.equal({
+      Transfer: {
+        from: bob.address,
+        to: comet.address,
+        amount: BigInt(8e8),
+      }
+    });
+    expect(event(s0, 1)).to.be.deep.equal({
+      SupplyCollateral: {
+        from: bob.address,
+        dst: alice.address,
+        asset: COMP.address,
+        amount: BigInt(8e8),
+      }
+    });
 
     expect(p0.internal).to.be.deep.equal({USDC: 0n, COMP: 0n, WETH: 0n, WBTC: 0n});
     expect(p0.external).to.be.deep.equal({USDC: 0n, COMP: 0n, WETH: 0n, WBTC: 0n});

--- a/test/transfer-test.ts
+++ b/test/transfer-test.ts
@@ -1,4 +1,4 @@
-import { expect, exp, makeProtocol, portfolio, wait } from './helpers';
+import { event, expect, exp, makeProtocol, portfolio, wait } from './helpers';
 
 describe('transfer', function () {
   it('transfers base from sender if the asset is base', async () => {
@@ -20,6 +20,14 @@ describe('transfer', function () {
     const t1 = await comet.totalsBasic();
     const p1 = await portfolio(protocol, alice.address);
     const q1 = await portfolio(protocol, bob.address);
+
+    expect(event(s0, 0)).to.be.deep.equal({
+      Transfer: {
+        from: bob.address,
+        to: alice.address,
+        amount: BigInt(100e6),
+      }
+    });
 
     expect(p0.internal).to.be.deep.equal({ USDC: 0n, COMP: 0n, WETH: 0n, WBTC: 0n });
     expect(q0.internal).to.be.deep.equal({ USDC: exp(100, 6), COMP: 0n, WETH: 0n, WBTC: 0n });
@@ -50,6 +58,15 @@ describe('transfer', function () {
     const t1 = await comet.totalsCollateral(COMP.address);
     const p1 = await portfolio(protocol, alice.address);
     const q1 = await portfolio(protocol, bob.address);
+
+    expect(event(s0, 0)).to.be.deep.equal({
+      TransferCollateral: {
+        from: bob.address,
+        to: alice.address,
+        asset: COMP.address,
+        amount: BigInt(8e8),
+      }
+    });
 
     expect(p0.internal).to.be.deep.equal({ USDC: 0n, COMP: 0n, WETH: 0n, WBTC: 0n });
     expect(q0.internal).to.be.deep.equal({ USDC: 0n, COMP: exp(8, 8), WETH: 0n, WBTC: 0n });

--- a/test/withdraw-test.ts
+++ b/test/withdraw-test.ts
@@ -1,4 +1,4 @@
-import { Comet, ethers, expect, exp, makeProtocol, portfolio, wait } from './helpers';
+import { Comet, ethers, event, expect, exp, makeProtocol, portfolio, wait } from './helpers';
 
 describe('withdrawTo', function () {
   it('withdraws base from sender if the asset is base', async () => {
@@ -21,6 +21,21 @@ describe('withdrawTo', function () {
     const t1 = await comet.totalsBasic();
     const p1 = await portfolio(protocol, alice.address)
     const q1 = await portfolio(protocol, bob.address)
+
+    expect(event(s0, 0)).to.be.deep.equal({
+      Transfer: {
+        from: comet.address,
+        to: alice.address,
+        amount: BigInt(100e6),
+      }
+    });
+    expect(event(s0, 1)).to.be.deep.equal({
+      Withdraw: {
+        src: bob.address,
+        to: alice.address,
+        amount: BigInt(100e6),
+      }
+    });
 
     expect(p0.internal).to.be.deep.equal({USDC: 0n, COMP: 0n, WETH: 0n, WBTC: 0n});
     expect(p0.external).to.be.deep.equal({USDC: 0n, COMP: 0n, WETH: 0n, WBTC: 0n});
@@ -56,6 +71,22 @@ describe('withdrawTo', function () {
     const t1 = await comet.totalsCollateral(COMP.address);
     const p1 = await portfolio(protocol, alice.address)
     const q1 = await portfolio(protocol, bob.address)
+
+    expect(event(s0, 0)).to.be.deep.equal({
+      Transfer: {
+        from: comet.address,
+        to: alice.address,
+        amount: BigInt(8e8),
+      }
+    });
+    expect(event(s0, 1)).to.be.deep.equal({
+      WithdrawCollateral: {
+        src: bob.address,
+        to: alice.address,
+        asset: COMP.address,
+        amount: BigInt(8e8),
+      }
+    });
 
     expect(p0.internal).to.be.deep.equal({USDC: 0n, COMP: 0n, WETH: 0n, WBTC: 0n});
     expect(p0.external).to.be.deep.equal({USDC: 0n, COMP: 0n, WETH: 0n, WBTC: 0n});


### PR DESCRIPTION
Currently added Supply, Transfer, and Withdraw events for both base and collateral. This barely fits contract size using 1 optimizer run, and doesn't fit with 200 runs. It would be 16 bytes cheaper to have only Supply/4 and Withdraw/4 versions of the events, but since we need Transfer/3 for ERC20 compatibility, I kept them all consistent.

If we want events to track collateral seized / debt repaid (in absorb), it'll be a bunch more expensive. Likewise for when collateral is purchased from the protocol.