### PR TITLE
Enforce strict type for requirements object used in scenario constraints

### DIFF
--- a/plugins/scenario/Loader.ts
+++ b/plugins/scenario/Loader.ts
@@ -2,8 +2,8 @@ import fg from 'fast-glob';
 import * as path from 'path';
 import { Scenario, ScenarioFlags, Property, Initializer, Forker, Constraint, Transformer } from './Scenario';
 
-class Loader<T, U> {
-  scenarios: { [name: string]: Scenario<T, U> };
+class Loader<T, U, R> {
+  scenarios: { [name: string]: Scenario<T, U, R> };
 
   constructor() {
     this.scenarios = {};
@@ -11,18 +11,18 @@ class Loader<T, U> {
 
   addScenario(
     name: string,
-    requirements: object,
+    requirements: R,
     property: Property<T, U>,
     initializer: Initializer<T>,
     transformer: Transformer<T, U>,
     forker: Forker<T>,
-    constraints: Constraint<T>[],
+    constraints: Constraint<T, R>[],
     flags: ScenarioFlags = null
   ) {
     if (this.scenarios[name]) {
       throw new Error(`Duplicate scenarios by name: ${name}`);
     }
-    this.scenarios[name] = new Scenario<T, U>(
+    this.scenarios[name] = new Scenario<T, U, R>(
       name,
       requirements,
       property,
@@ -34,31 +34,31 @@ class Loader<T, U> {
     );
   }
 
-  getScenarios(): { [name: string]: Scenario<T, U> } {
+  getScenarios(): { [name: string]: Scenario<T, U, R> } {
     return this.scenarios;
   }
 }
 
 let loader: any;
 
-function setupLoader<T, U>() {
+function setupLoader<T, U, R>() {
   if (loader) {
     throw new Error('Loader already initialized');
   }
 
-  loader = new Loader<T, U>();
+  loader = new Loader<T, U, R>();
 }
 
-export function getLoader<T, U>(): Loader<T, U> {
+export function getLoader<T, U, R>(): Loader<T, U, R> {
   if (!loader) {
     throw new Error('Loader not initialized');
   }
 
-  return <Loader<T, U>>loader;
+  return <Loader<T, U, R>>loader;
 }
 
-export async function loadScenarios<T, U>(glob: string): Promise<{ [name: string]: Scenario<T, U> }> {
-  setupLoader<T, U>();
+export async function loadScenarios<T, U, R>(glob: string): Promise<{ [name: string]: Scenario<T, U, R> }> {
+  setupLoader<T, U, R>();
 
   const entries = await fg(glob); // Grab all potential scenario files
 

--- a/plugins/scenario/Runner.ts
+++ b/plugins/scenario/Runner.ts
@@ -5,7 +5,7 @@ import { AssertionError } from 'chai';
 
 export type Address = string;
 
-export type ResultFn<T, U> = (base: ForkSpec, scenario: Scenario<T, U>, err?: any) => void;
+export type ResultFn<T, U, R> = (base: ForkSpec, scenario: Scenario<T, U, R>, err?: any) => void;
 
 export interface Config<T> {
   base: ForkSpec;
@@ -45,7 +45,7 @@ function mapSolution<T>(s: Solution<T> | Solution<T>[] | null): Solution<T>[] {
   }
 }
 
-export class Runner<T, U> {
+export class Runner<T, U, R> {
   config: Config<T>;
   worldSnapshot: string;
 
@@ -53,7 +53,7 @@ export class Runner<T, U> {
     this.config = config;
   }
 
-  async run(scenario: Scenario<T, U>): Promise<Result> {
+  async run(scenario: Scenario<T, U, R>): Promise<Result> {
     const { config } = this;
     const { base, world } = config;
     const { constraints = [] } = scenario;
@@ -113,7 +113,7 @@ export class Runner<T, U> {
 
   private generateResult(
     base: ForkSpec,
-    scenario: Scenario<T, U>,
+    scenario: Scenario<T, U, R>,
     startTime: number,
     totalGas: number,
     numSolutionSets: number,

--- a/plugins/scenario/Scenario.ts
+++ b/plugins/scenario/Scenario.ts
@@ -7,13 +7,13 @@ export type Solution<T> = (T, World) => Promise<T | void>;
 // A constraint is capable of producing solutions for a context and world *like* the ones provided.
 // A constraint can also check a given context and world to see if they *actually* satisfy it.
 // Note: `solve` and `check` are expected to treat the context and world as immutable.
-export interface Constraint<T> {
+export interface Constraint<T, R> {
   solve(
-    requirements: object,
+    requirements: R,
     context: T,
     world: World
   ): Promise<Solution<T> | Solution<T>[] | null>;
-  check(requirements: object, context: T, world: World): Promise<void>;
+  check(requirements: R, context: T, world: World): Promise<void>;
 }
 
 export type Property<T, U> = (properties: U, world: World, context: T) => Promise<any>;
@@ -23,15 +23,15 @@ export type Forker<T> = (T) => Promise<T>;
 
 export type ScenarioFlags = null | 'only' | 'skip';
 
-export class Scenario<T, U> {
+export class Scenario<T, U, R> {
   name: string;
   file: string | null;
-  requirements: object;
+  requirements: R;
   property: Property<T, U>;
   initializer: Initializer<T>;
   transformer: Transformer<T, U>;
   forker: Forker<T>;
-  constraints: Constraint<T>[];
+  constraints: Constraint<T, R>[];
   flags: ScenarioFlags;
 
   constructor(name, requirements, property, initializer, transformer, forker, constraints, flags) {

--- a/plugins/scenario/index.ts
+++ b/plugins/scenario/index.ts
@@ -9,20 +9,20 @@ type ScenarioFn<T, U> = (
   property: Property<T, U>
 ) => Promise<void>;
 
-interface ScenarioBuilder<T, U> {
-  (name: string, requirements: object, property: Property<T, U>): void;
-  only: (name: string, requirements: object, property: Property<T, U>) => void;
-  skip: (name: string, requirements: object, property: Property<T, U>) => void;
+interface ScenarioBuilder<T, U, R> {
+  (name: string, requirements: R, property: Property<T, U>): void;
+  only: (name: string, requirements: R, property: Property<T, U>) => void;
+  skip: (name: string, requirements: R, property: Property<T, U>) => void;
 }
 
-export function addScenario<T, U>(
+export function addScenario<T, U, R>(
   name: string,
-  requirements: object,
+  requirements: R,
   property: Property<T, U>,
   initializer: Initializer<T>,
   transformer: Transformer<T, U>,
   forker: Forker<T>,
-  constraints: Constraint<T>[],
+  constraints: Constraint<T, R>[],
   flags: ScenarioFlags = null
 ) {
   getLoader().addScenario(
@@ -37,15 +37,15 @@ export function addScenario<T, U>(
   );
 }
 
-export function buildScenarioFn<T, U>(
+export function buildScenarioFn<T, U, R>(
   initializer: Initializer<T>,
   transformer: Transformer<T, U>,
   forker: Forker<T>,
-  constraints: Constraint<T>[]
+  constraints: Constraint<T, R>[]
 ) {
   let addScenarioWithOpts =
-    (flags: ScenarioFlags) => (name: string, requirements: object, property: Property<T, U>) => {
-      addScenario<T, U>(
+    (flags: ScenarioFlags) => (name: string, requirements: R, property: Property<T, U>) => {
+      addScenario<T, U, R>(
         name,
         requirements,
         property,
@@ -57,7 +57,7 @@ export function buildScenarioFn<T, U>(
       );
     };
 
-  let res: ScenarioBuilder<T, U> = Object.assign(addScenarioWithOpts(null), {
+  let res: ScenarioBuilder<T, U, R> = Object.assign(addScenarioWithOpts(null), {
     only: addScenarioWithOpts('only'),
     skip: addScenarioWithOpts('skip'),
   });

--- a/plugins/scenario/worker/Worker.ts
+++ b/plugins/scenario/worker/Worker.ts
@@ -48,8 +48,8 @@ function postMessage(worker: SimpleWorker | undefined, message: any) {
   }
 }
 
-export async function run<T, U>({ scenarioConfig, bases, config, worker }: WorkerData) {
-  let scenarios: { [name: string]: Scenario<T, U> };
+export async function run<T, U, R>({ scenarioConfig, bases, config, worker }: WorkerData) {
+  let scenarios: { [name: string]: Scenario<T, U, R> };
   let runners = {};
 
   if (!worker) {
@@ -57,7 +57,7 @@ export async function run<T, U>({ scenarioConfig, bases, config, worker }: Worke
     createContext(...config);
     scenarios = await loadScenarios(scenarioGlob);
   } else {
-    scenarios = getLoader<T, U>().getScenarios();
+    scenarios = getLoader<T, U, R>().getScenarios();
   }
 
   for (let base of bases) {

--- a/scenario/constraints/BalanceConstraint.ts
+++ b/scenario/constraints/BalanceConstraint.ts
@@ -3,6 +3,7 @@ import { sourceTokens } from '../../plugins/scenario/utils/TokenSourcer';
 import { CometContext } from '../context/CometContext';
 
 import { expect } from 'chai';
+import { Requirements } from './Requirements';
 
 function matchGroup(str, patterns) {
   for (const k in patterns) {
@@ -32,9 +33,9 @@ function parseAmount(amount) {
   }
 }
 
-export class BalanceConstraint<T extends CometContext> implements Constraint<T> {
-  async solve(requirements: object, context: T, world: World) {
-    const assetsByActor = requirements['balances'];
+export class BalanceConstraint<T extends CometContext, R extends Requirements> implements Constraint<T, R> {
+  async solve(requirements: R, context: T, world: World) {
+    const assetsByActor = requirements.balances;
     if (assetsByActor) {
       const actorsByAsset = Object.entries(assetsByActor).reduce((a, [actor, assets]) => {
         return Object.entries(assets).reduce((a, [asset, rawAmount]) => {
@@ -88,7 +89,7 @@ export class BalanceConstraint<T extends CometContext> implements Constraint<T> 
     }
   }
 
-  async check(requirements: object, context: T, world: World) {
+  async check(requirements: R, context: T, world: World) {
     const assetsByActor = requirements['balances'];
     if (assetsByActor) {
       for (const [actorName, assets] of Object.entries(assetsByActor)) {

--- a/scenario/constraints/BaseTokenProtocolBalanceConstraint.ts
+++ b/scenario/constraints/BaseTokenProtocolBalanceConstraint.ts
@@ -1,10 +1,11 @@
 import { Constraint, World } from '../../plugins/scenario';
 import { CometContext } from '../context/CometContext';
 import { expect } from 'chai';
+import { Requirements } from './Requirements';
 
-export class BaseTokenProtocolBalanceConstraint<T extends CometContext> implements Constraint<T> {
-  async solve(requirements: object, context: T, world: World) {
-    const baseTokenRequirements = requirements['baseToken'];
+export class BaseTokenProtocolBalanceConstraint<T extends CometContext, R extends Requirements> implements Constraint<T, R> {
+  async solve(requirements: R, context: T, world: World) {
+    const baseTokenRequirements = requirements.baseToken;
     if (!baseTokenRequirements) {
       return null;
     }
@@ -19,8 +20,8 @@ export class BaseTokenProtocolBalanceConstraint<T extends CometContext> implemen
     }
   }
 
-  async check(requirements: object, context: T, world: World) {
-    const baseTokenRequirements = requirements['baseToken'];
+  async check(requirements: R, context: T, world: World) {
+    const baseTokenRequirements = requirements.baseToken;
     if (!baseTokenRequirements) {
       return null;
     }

--- a/scenario/constraints/Fuzzing.ts
+++ b/scenario/constraints/Fuzzing.ts
@@ -1,3 +1,5 @@
+import { Requirements } from "./Requirements";
+
 export enum FuzzType {
   INT64,
   UINT64
@@ -78,7 +80,7 @@ export function getFuzzedValues(fuzzConfig: FuzzConfig): any[] {
   }
 }
 
-export function getFuzzedRequirements(requirements: object): object[] {
+export function getFuzzedRequirements(requirements: Requirements): Requirements[] {
   let fuzzedRequirements = [];
   let keyValues: KV[][] = [];
   // Create a list of fuzzed values for each key that needs to be fuzzed.

--- a/scenario/constraints/ModernConstraint.ts
+++ b/scenario/constraints/ModernConstraint.ts
@@ -4,30 +4,31 @@ import { ProtocolConfiguration, deployComet } from '../../src/deploy';
 import { getFuzzedRequirements } from './Fuzzing';
 import CometAsset from '../context/CometAsset';
 import { Contract } from 'ethers';
+import { Requirements } from './Requirements';
 
 interface ModernConfig {
   upgrade: boolean;
   cometConfig: ProtocolConfiguration;
 }
 
-function getModernConfigs(requirements: object): ModernConfig[] | null {
+function getModernConfigs(requirements: Requirements): ModernConfig[] | null {
   let fuzzedConfigs = getFuzzedRequirements(requirements).map((r) => ({
-    upgrade: r['upgrade'],
-    cometConfig: r['cometConfig'],
+    upgrade: r.upgrade,
+    cometConfig: r.cometConfig,
   }));
 
   return fuzzedConfigs;
 }
 
-export class ModernConstraint<T extends CometContext> implements Constraint<T> {
-  async solve(requirements: object, context: T, world: World) {
+export class ModernConstraint<T extends CometContext, R extends Requirements> implements Constraint<T, R> {
+  async solve(requirements: R, context: T, world: World) {
     let modernConfigs = getModernConfigs(requirements);
 
     let solutions = [];
     // XXX Inefficient log. Can be removed later
     console.log(
       'Comet config overrides to upgrade with are: ',
-      modernConfigs.map((c) => c['cometConfig'])
+      modernConfigs.map((c) => c.cometConfig)
     );
     for (let config of modernConfigs) {
       if (config.upgrade) {
@@ -59,7 +60,7 @@ export class ModernConstraint<T extends CometContext> implements Constraint<T> {
     return solutions;
   }
 
-  async check(requirements: object, context: T, world: World) {
+  async check(requirements: R, context: T, world: World) {
     return; // XXX
   }
 }

--- a/scenario/constraints/PauseConstraint.ts
+++ b/scenario/constraints/PauseConstraint.ts
@@ -1,10 +1,11 @@
 import { Constraint, World } from '../../plugins/scenario';
 import { CometContext } from '../context/CometContext';
 import { expect } from 'chai';
+import { Requirements } from './Requirements';
 
-export class PauseConstraint<T extends CometContext> implements Constraint<T> {
-  async solve(requirements: object, context: T, world: World) {
-    const pauseRequirements = requirements['pause'];
+export class PauseConstraint<T extends CometContext, R extends Requirements> implements Constraint<T, R> {
+  async solve(requirements: R, context: T, world: World) {
+    const pauseRequirements = requirements.pause;
     if (!pauseRequirements) {
       return null;
     }
@@ -43,8 +44,8 @@ export class PauseConstraint<T extends CometContext> implements Constraint<T> {
     }
   }
 
-  async check(requirements: object, context: T, world: World) {
-    const pauseRequirements = requirements['pause'];
+  async check(requirements: R, context: T, world: World) {
+    const pauseRequirements = requirements.pause;
     if (!pauseRequirements) {
       return;
     }

--- a/scenario/constraints/RemoteTokenConstraint.ts
+++ b/scenario/constraints/RemoteTokenConstraint.ts
@@ -1,5 +1,6 @@
 import { Constraint, Scenario, Solution, World } from '../../plugins/scenario';
 import { CometContext } from '../context/CometContext';
+import { Requirements } from './Requirements';
 import { requireString, requireList } from './utils';
 
 interface RemoteTokenConfig {
@@ -8,8 +9,8 @@ interface RemoteTokenConfig {
   args: any[];
 }
 
-function getRemoteTokenConfig(requirements: object): RemoteTokenConfig | null {
-  let remoteToken = requirements['remote_token'];
+function getRemoteTokenConfig(requirements: Requirements): RemoteTokenConfig | null {
+  let remoteToken = requirements.remoteToken;
   if (!remoteToken) {
     return null;
   }
@@ -22,8 +23,8 @@ function getRemoteTokenConfig(requirements: object): RemoteTokenConfig | null {
   };
 }
 
-export class RemoteTokenConstraint<T extends CometContext> implements Constraint<T> {
-  async solve(requirements: object, context: T, world: World) {
+export class RemoteTokenConstraint<T extends CometContext, R extends Requirements> implements Constraint<T, R> {
+  async solve(requirements: R, context: T, world: World) {
     let parsedRequirements = getRemoteTokenConfig(requirements);
     if (parsedRequirements === null) {
       return null;
@@ -36,7 +37,7 @@ export class RemoteTokenConstraint<T extends CometContext> implements Constraint
     };
   }
 
-  async check(requirements: object, context: T, world: World) {
+  async check(requirements: R, context: T, world: World) {
     return; // XXX
   }
 }

--- a/scenario/constraints/Requirements.ts
+++ b/scenario/constraints/Requirements.ts
@@ -1,0 +1,10 @@
+// XXX Define strict types for these objects
+export interface Requirements {
+    balances?: object, // XXX Balance constraint
+    upgrade?: boolean, // Modern constraint
+    cometConfig?: object, // XXX Modern constraint
+    pause?: object, // XXX Pause constraint
+    remoteToken?: object, // XXX Remote token constraint
+    utilization?: number, // Utilization constraint
+    baseToken?: object, // XXX Base token protocol balance constraint
+};

--- a/scenario/constraints/UtilizationConstraint.ts
+++ b/scenario/constraints/UtilizationConstraint.ts
@@ -4,6 +4,7 @@ import { deployComet } from '../../src/deploy';
 import { optionalNumber } from './utils';
 import { defactor, exp, factor, factorScale, ZERO } from '../../test/helpers';
 import { expect } from 'chai';
+import { Requirements } from './Requirements';
 
 /**
   # Utilization Constraint
@@ -52,8 +53,8 @@ else
   -> borrows / target = (supply+X)
   -> ( borrows / target ) - supply = X
 */
-export class UtilizationConstraint<T extends CometContext> implements Constraint<T> {
-  async solve(requirements: object, context: T, world: World) {
+export class UtilizationConstraint<T extends CometContext, R extends Requirements> implements Constraint<T, R> {
+  async solve(requirements: R, context: T, world: World) {
     let { utilization } = getUtilizationConfig(requirements);
 
     if (!utilization) {
@@ -149,7 +150,7 @@ export class UtilizationConstraint<T extends CometContext> implements Constraint
     }
   }
 
-  async check(requirements: object, context: T, world: World) {
+  async check(requirements: R, context: T, world: World) {
     let { utilization } = getUtilizationConfig(requirements);
 
     if (utilization) {

--- a/scenario/context/CometContext.ts
+++ b/scenario/context/CometContext.ts
@@ -18,6 +18,7 @@ import { Comet, CometInterface, ProxyAdmin, ERC20, ERC20__factory } from '../../
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { sourceTokens } from '../../plugins/scenario/utils/TokenSourcer';
 import { AddressLike, getAddressFromNumber, resolveAddress } from './Address';
+import { Requirements } from '../constraints/Requirements';
 
 type ActorMap = { [name: string]: CometActor };
 type AssetMap = { [name: string]: CometAsset };
@@ -261,4 +262,4 @@ export const constraints = [
   new BaseTokenProtocolBalanceConstraint(),
 ];
 
-export const scenario = buildScenarioFn<CometContext, CometProperties>(getInitialContext, getContextProperties, forkContext, constraints);
+export const scenario = buildScenarioFn<CometContext, CometProperties, Requirements>(getInitialContext, getContextProperties, forkContext, constraints);


### PR DESCRIPTION
This should prevent bugs that would arise from using an arbitrary `object` type for `requirements`, such as writing or reading the wrong properties from `requirements`. Also makes developing scenarios a bit easier (e.g. there is autocomplete for `requirements` now).