### PR TITLE
Fix bug in scenario error reporting

### DIFF
--- a/plugins/scenario/Runner.ts
+++ b/plugins/scenario/Runner.ts
@@ -102,7 +102,7 @@ export class Runner<T, U> {
         numSolutionSets++;
       } catch (e) {
         // TODO: Include the specific solution (set of states) that failed in the result
-        return this.generateResult(base, scenario, startTime, 0, numSolutionSets, e);
+        return this.generateResult(base, scenario, startTime, 0, ++numSolutionSets, e);
       } finally {
         contextSnapshot = await world._revertAndSnapshot(contextSnapshot);
       }


### PR DESCRIPTION
Add a missing parameter to `generateResult` for the error case. Also, `numSolutionSets` should always return a value `>=1` now if a solution set was attempted.