### PR TITLE
The 5 Asset Borrow Test [Not by Tom Wolfe]

### DIFF
--- a/deployments/kovan/migrations/1644388553_deploy_kovan.ts
+++ b/deployments/kovan/migrations/1644388553_deploy_kovan.ts
@@ -3,94 +3,26 @@ import { migration } from '../../../plugins/deployment_manager/Migration';
 import { deployNetworkComet } from '../../../src/deploy/Network';
 import { DeployedContracts } from '../../../src/deploy/index';
 import { exp, wait } from '../../../test/helpers';
-import { ProxyAdmin, ProxyAdmin__factory } from '../../../build/types';
-
-let cloneNetwork = 'mainnet';
-let cloneAddr = {
-  usdcImplementation: '0xa2327a938Febf5FEC13baCFb16Ae10EcBc4cbDCF',
-  usdcProxy: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-  wbtc: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
-  weth: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-  comp: '0xc00e94cb662c3520282e6f5717214004a7f26888',
-  uni: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
-  link: '0x514910771af9ca656af840dff83e8264ecf986ca',
-};
+import {
+  deployUSDC,
+  deployWBTC,
+  deployWETH,
+  deployCOMP,
+  deployUNI,
+  deployLINK,
+} from '../../../src/deploy/mainnet/CloneTokens';
 
 migration('1644388553_deploy_kovan', {
   prepare: async (deploymentManager: DeploymentManager) => {
     let [signer] = await deploymentManager.hre.ethers.getSigners();
     let signerAddress = await signer.getAddress();
 
-    let usdcProxyAdminArgs: [] = [];
-    let usdcProxyAdmin = await deploymentManager.deploy<ProxyAdmin, ProxyAdmin__factory, []>(
-      'vendor/proxy/ProxyAdmin.sol',
-      usdcProxyAdminArgs
-    );
-
-    let usdcImplementation = await deploymentManager.clone(
-      cloneAddr.usdcImplementation,
-      [],
-      cloneNetwork
-    );
-
-    let usdc;
-    let usdcProxy = await deploymentManager.clone(
-      cloneAddr.usdcProxy,
-      [usdcImplementation.address],
-      cloneNetwork
-    );
-
-    await wait(await usdcProxy.changeAdmin(usdcProxyAdmin.address));
-    usdc = usdcImplementation.attach(usdcProxy.address);
-    // Give signer 10,000 USDC
-    await wait(
-      usdc.initialize(
-        'USD Coin',
-        'USDC',
-        'USD',
-        6,
-        signerAddress,
-        signerAddress,
-        signerAddress,
-        signerAddress
-      )
-    );
-    await wait(usdc.configureMinter(signerAddress, exp(10000, 6)));
-    await wait(usdc.mint(signerAddress, exp(10000, 6)));
-
-    let wbtc = await deploymentManager.clone(
-      cloneAddr.wbtc,
-      [],
-      cloneNetwork
-    );
-    // Give signer 1000 WBTC
-    await wait(wbtc.mint(signerAddress, exp(1000, 8)));
-
-    let weth = await deploymentManager.clone(
-      cloneAddr.weth,
-      [],
-      cloneNetwork
-    );
-    // Give admin 0.01 WETH tokens [this is a precious resource here!]
-    await wait(weth.deposit({ value: exp(0.01, 18) }));
-
-    let comp = await deploymentManager.clone(
-      cloneAddr.comp,
-      [signerAddress],
-      cloneNetwork
-    );
-
-    let uni = await deploymentManager.clone(
-      cloneAddr.uni,
-      [signerAddress, signerAddress, 99999999999],
-      cloneNetwork
-    );
-
-    let link = await deploymentManager.clone(
-      cloneAddr.link,
-      [],
-      cloneNetwork
-    );
+    let usdc = await deployUSDC(deploymentManager, signerAddress);
+    let wbtc = await deployWBTC(deploymentManager, signerAddress);
+    let weth = await deployWETH(deploymentManager, signerAddress);
+    let comp = await deployCOMP(deploymentManager, signerAddress);
+    let uni = await deployUNI(deploymentManager, signerAddress);
+    let link = await deployLINK(deploymentManager, signerAddress);
 
     // Contracts referenced in `configuration.json`.
     let contracts = new Map([
@@ -115,10 +47,10 @@ migration('1644388553_deploy_kovan', {
     };
   },
   enact: async (deploymentManager: DeploymentManager, contracts) => {
-    console.log("You should set roots.json to:");
-    console.log("");
-    console.log("");
+    console.log('You should set roots.json to:');
+    console.log('');
+    console.log('');
     console.log(JSON.stringify(contracts, null, 4));
-    console.log("");
+    console.log('');
   },
 });

--- a/plugins/deployment_manager/DeploymentManager.ts
+++ b/plugins/deployment_manager/DeploymentManager.ts
@@ -25,7 +25,7 @@ interface DeploymentManagerConfig {
   debug?: boolean;
 }
 
-function getNetwork(deployment: string): string {
+export function getNetwork(deployment: string): string {
   return deployment; // TODO: Handle deployments that don't map correctly
 }
 

--- a/plugins/scenario/Runner.ts
+++ b/plugins/scenario/Runner.ts
@@ -102,7 +102,7 @@ export class Runner<T, U> {
         numSolutionSets++;
       } catch (e) {
         // TODO: Include the specific solution (set of states) that failed in the result
-        return this.generateResult(base, scenario, startTime, numSolutionSets, e);
+        return this.generateResult(base, scenario, startTime, cumulativeGas, numSolutionSets, e);
       } finally {
         contextSnapshot = await world._revertAndSnapshot(contextSnapshot);
       }

--- a/scenario/GasScenario.ts
+++ b/scenario/GasScenario.ts
@@ -1,0 +1,25 @@
+import { CometProperties, scenario } from './context/CometContext';
+import { expect } from 'chai';
+import { exp, wait } from '../test/helpers';
+
+scenario.only(
+  'has reasonable gas for 5 collateral assets',
+  { remote_token: { mainnet: ['WBTC'] }, utilization: 0.5, defaultBaseAmount: 5000 },
+  async ({ comet, assets, actors }, world, context) => {
+    let tokenAmounts = {
+      'WBTC': 1
+    };
+    let primary = context.primaryActor();
+    for (let [token, amount] of Object.entries(tokenAmounts)) {
+      let asset = assets[token]!;
+      await context.sourceTokens(world, amount, asset, primary);
+      await asset.approve(primary, comet);
+      await comet.connect(primary.signer).supply(asset.address, exp(amount, await asset.decimals()));
+      console.log("gas", token, asset, await primary.getCollateralBalance(asset));
+    }
+
+    await comet.connect(primary.signer).withdraw(await comet.baseToken(), exp(10, 6));
+    let tx = await wait(comet.connect(primary.signer).withdraw(await comet.baseToken(), exp(1500, 6)));
+    console.log({tx})
+  }
+);

--- a/scenario/constraints/RemoteTokenConstraint.ts
+++ b/scenario/constraints/RemoteTokenConstraint.ts
@@ -1,25 +1,33 @@
+import { DeploymentManager, getNetwork } from '../../plugins/deployment_manager/DeploymentManager';
+import { Contract } from 'ethers';
 import { Constraint, Scenario, Solution, World } from '../../plugins/scenario';
 import { CometContext } from '../context/CometContext';
 import { requireString, requireList } from './utils';
+import * as Mainnet from '../../src/deploy/mainnet/CloneTokens';
+import { getPriceFeed } from '../../src/deploy';
+import { upgradeComet } from './ModernConstraint';
+import { exp, wait } from '../../test/helpers';
+
+const networks: {
+  [network: string]: (
+    name: string,
+    deploymentManager: DeploymentManager,
+    signerAddress: string
+  ) => Promise<Contract>;
+} = {
+  mainnet: Mainnet.deployToken,
+};
 
 interface RemoteTokenConfig {
-  network: string;
-  address: string;
-  args: any[];
+  [network: string]: string[];
 }
 
 function getRemoteTokenConfig(requirements: object): RemoteTokenConfig | null {
-  let remoteToken = requirements['remote_token'];
+  let remoteToken = requirements['remote_token'] as RemoteTokenConfig;
   if (!remoteToken) {
     return null;
   }
-  return {
-    network: requireString(remoteToken, 'network', 'network required in remote token config'),
-    address: requireString(remoteToken, 'address', 'address required in remote token config'),
-    args: remoteToken['args']
-      ? requireList<any>(remoteToken, 'args', 'must be list if present')
-      : [],
-  };
+  return remoteToken;
 }
 
 export class RemoteTokenConstraint<T extends CometContext> implements Constraint<T> {
@@ -28,11 +36,37 @@ export class RemoteTokenConstraint<T extends CometContext> implements Constraint
     if (parsedRequirements === null) {
       return null;
     }
-    let { network, address, args } = parsedRequirements;
-
     return async (context: T) => {
-      let buildFile = await context.deploymentManager.import(address, network);
-      context.remoteToken = await context.deploymentManager.deployBuild(buildFile, args);
+      let currentAssets = context.assets;
+      let assetConfigs = await context.getAssetConfigs();
+
+      for (let [network, tokens] of Object.entries(parsedRequirements)) {
+        let fn = networks[network];
+        if (typeof fn !== 'function') {
+          throw new Error(`Unknown network for remote token: ${network}`);
+        }
+        for (let symbol of tokens) {
+          if (currentAssets[symbol]) {
+            console.log(`Comet already registered ${symbol}`);
+          } else {
+            console.log(`Registered remote token ${network} ${symbol}`);
+            let token = await fn(symbol, context.deploymentManager, context.primaryActor().address);
+            let decimals = await token.decimals();
+
+            assetConfigs.push({
+              asset: token.address,
+              priceFeed: getPriceFeed(symbol, getNetwork(context.deploymentManager.deployment)),
+              decimals,
+              borrowCollateralFactor: exp(1, 18),
+              liquidateCollateralFactor: exp(1, 18),
+              liquidationFactor: exp(1, 18),
+              supplyCap: exp(1000, decimals)
+            });
+          }
+        }
+
+        await upgradeComet(context, world, { assetConfigs });
+      }
     };
   }
 

--- a/scenario/context/CometActor.ts
+++ b/scenario/context/CometActor.ts
@@ -136,6 +136,12 @@ export default class CometActor {
       .allowBySig(owner, manager, isAllowed, nonce, expiry, signature.v, signature.r, signature.s)).wait();
   }
 
+  async getCollateralBalance(asset: AddressLike) {
+    let assetAddress = await resolveAddress(asset);
+    let comet = await this.context.getComet();
+    return await comet.userCollateral(this.address, assetAddress);
+  }
+
   async show() {
     return console.log(`Actor#${this.name}{${JSON.stringify(this.info)}}`);
   }

--- a/scenario/context/CometAsset.ts
+++ b/scenario/context/CometAsset.ts
@@ -40,4 +40,8 @@ export default class CometAsset {
     let finalAmount = amount ?? constants.MaxUint256;
     await wait(this.token.connect(from.signer).approve(spenderAddress, finalAmount));
   }
+
+  async decimals(): Promise<number> {
+    return this.token.decimals();
+  }
 }

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -11,6 +11,16 @@ import { BigNumberish } from 'ethers';
 import { deployNetworkComet } from './Network';
 import { deployDevelopmentComet } from './Development';
 
+let priceFeeds = {
+  kovan: {
+    comp: '0xECF93D14d25E02bA2C13698eeDca9aA98348EFb6',
+    wbtc: '0x6135b13325bfC4B00278B4abC5e20bbce2D6580e',
+    weth: '0x9326BFA02ADD2366b30bacB125260Af641031331',
+    uni: '0xDA5904BdBfB4EF12a3955aEcA103F51dc87c7C39',
+    link: '0x396c5E36DD0a0F5a5D33dae44368D4193f69a1F0',
+  },
+};
+
 export interface ProtocolConfiguration {
   symbol?: string;
   governor?: string;
@@ -51,4 +61,16 @@ export async function deployComet(
   } else {
     return await deployDevelopmentComet(deploymentManager, deployProxy, configurationOverrides);
   }
+}
+
+export function getPriceFeed(name: string, network: string): string {
+  let networkFeeds = priceFeeds[network];
+  if (!networkFeeds) {
+    throw new Error(`No known price feeds for network ${network}`);
+  }
+  let priceFeed = networkFeeds[name.toLowerCase()];
+  if (!priceFeed) {
+    throw new Error(`No known price feeds for ${name} on network ${network}`);
+  }
+  return priceFeed;
 }

--- a/src/deploy/mainnet/CloneTokens.ts
+++ b/src/deploy/mainnet/CloneTokens.ts
@@ -1,0 +1,129 @@
+import { DeploymentManager } from '../../../plugins/deployment_manager/DeploymentManager';
+import { ERC20, ProxyAdmin, ProxyAdmin__factory } from '../../../build/types';
+import { exp, wait } from '../../../test/helpers';
+import { Contract } from 'ethers';
+
+let cloneNetwork = 'mainnet';
+let cloneAddr = {
+  usdcImplementation: '0xa2327a938Febf5FEC13baCFb16Ae10EcBc4cbDCF',
+  usdcProxy: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  wbtc: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+  weth: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  comp: '0xc00e94cb662c3520282e6f5717214004a7f26888',
+  uni: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+  link: '0x514910771af9ca656af840dff83e8264ecf986ca',
+};
+
+export async function deployUSDC(
+  deploymentManager: DeploymentManager,
+  signerAddress: string
+): Promise<ERC20> {
+  let usdcProxyAdminArgs: [] = [];
+  let usdcProxyAdmin = await deploymentManager.deploy<ProxyAdmin, ProxyAdmin__factory, []>(
+    'vendor/proxy/ProxyAdmin.sol',
+    usdcProxyAdminArgs
+  );
+
+  let usdcImplementation = await deploymentManager.clone(
+    cloneAddr.usdcImplementation,
+    [],
+    cloneNetwork
+  );
+
+  let usdcProxy = await deploymentManager.clone(
+    cloneAddr.usdcProxy,
+    [usdcImplementation.address],
+    cloneNetwork
+  );
+
+  await wait(await usdcProxy.changeAdmin(usdcProxyAdmin.address));
+  let usdc = usdcImplementation.attach(usdcProxy.address);
+
+  // Give signer 10,000 USDC
+  await wait(
+    usdc.initialize(
+      'USD Coin',
+      'USDC',
+      'USD',
+      6,
+      signerAddress,
+      signerAddress,
+      signerAddress,
+      signerAddress
+    )
+  );
+  await wait(usdc.configureMinter(signerAddress, exp(10000, 6)));
+  await wait(usdc.mint(signerAddress, exp(10000, 6)));
+
+  return usdc as ERC20;
+}
+
+export async function deployWBTC(
+  deploymentManager: DeploymentManager,
+  signerAddress: string
+): Promise<ERC20> {
+  let wbtc = await deploymentManager.clone(cloneAddr.wbtc, [], cloneNetwork);
+  // Give signer 1000 WBTC
+  await wait(wbtc.mint(signerAddress, exp(1000, 8)));
+
+  return wbtc as ERC20;
+}
+
+export async function deployWETH(
+  deploymentManager: DeploymentManager,
+  signerAddress: string
+): Promise<ERC20> {
+  let weth = await deploymentManager.clone(cloneAddr.weth, [], cloneNetwork);
+  // Give admin 0.01 WETH tokens [this is a precious resource here!]
+  await wait(weth.deposit({ value: exp(0.01, 18) }));
+
+  return weth as ERC20;
+}
+
+export async function deployCOMP(
+  deploymentManager: DeploymentManager,
+  signerAddress: string
+): Promise<ERC20> {
+  return await deploymentManager.clone(cloneAddr.comp, [signerAddress], cloneNetwork);
+}
+
+export async function deployUNI(
+  deploymentManager: DeploymentManager,
+  signerAddress: string
+): Promise<ERC20> {
+  return await deploymentManager.clone(
+    cloneAddr.uni,
+    [signerAddress, signerAddress, 99999999999],
+    cloneNetwork
+  );
+}
+
+export async function deployLINK(
+  deploymentManager: DeploymentManager,
+  signerAddress: string
+): Promise<ERC20> {
+  return await deploymentManager.clone(cloneAddr.link, [], cloneNetwork);
+}
+
+export async function deployToken(
+  name: string,
+  deploymentManager: DeploymentManager,
+  signerAddress: string
+): Promise<ERC20> {
+  switch (name.toLowerCase()) {
+    case 'usdc':
+      return await deployUSDC(deploymentManager, signerAddress);
+    case 'wbtc':
+      return await deployWBTC(deploymentManager, signerAddress);
+    case 'weth':
+      return await deployWETH(deploymentManager, signerAddress);
+    case 'comp':
+      return await deployCOMP(deploymentManager, signerAddress);
+    case 'uni':
+      return await deployUNI(deploymentManager, signerAddress);
+    case 'link':
+      return await deployLINK(deploymentManager, signerAddress);
+    default:
+      throw new Error(`Do not know how to clone mainnet token: ${name}`);
+  }
+}


### PR DESCRIPTION
This patch sets up a gas scenario to test the 5 asset borrow test, which is to compare a mainnet transaction with a hyper-similar test-net transaction to test what the expected gas would be for Comet. The goal is to take a transaction that is 200-300K gas on mainnet, and see if the similar one could be about 100K in Comet.

We libraryify a lot of things in this patch. This is just refactoring to allow us to re-use code. Things like `deployments/kovan/configuration.json` probably should be dropped in support of nicer libraries, etc, but this is just a start in that direction. For instance, our `deploy_kovan` migration now uses libraries so other code-spots can use "clone token" which was being done in that migration. We similarly share `upgradeComet` from ModernConstraint.

Initial reports are showing that the trx cost from v2 dropped from 254,584 gas to 143,351 gas, which represents a 43.70% reduction in gas costs.