### PR TITLE
basic trace function

### DIFF
--- a/test/trace.ts
+++ b/test/trace.ts
@@ -1,0 +1,30 @@
+import { ethers, TransactionResponseExt } from './helpers';
+
+type OpcodeCount = {
+  calls: number;
+  totalGasCost: number;
+}
+
+export async function opCodesForTransaction(tx: TransactionResponseExt) {
+  const trace = await ethers.provider.send("debug_traceTransaction", [tx.hash]);
+  const { structLogs } = trace;
+  let opcodeCounts: {[opcode: string]: OpcodeCount} = {};
+
+  structLogs.forEach(structLog => {
+    if (opcodeCounts[structLog.op]) {
+      opcodeCounts[structLog.op].calls += 1;
+      opcodeCounts[structLog.op].totalGasCost += structLog.gasCost;
+    } else {
+      opcodeCounts[structLog.op] = {
+        calls: 1,
+        totalGasCost: structLog.gasCost
+      }
+    };
+  });
+
+  return {
+    totalGasCost: trace.gas,
+    opcodeCounts: opcodeCounts,
+    orderedOpcodeCounts: Object.entries(opcodeCounts).sort((a, b) => b[1].totalGasCost - a[1].totalGasCost)
+  };
+}


### PR DESCRIPTION
I'm digging into the possibilities around tracing, but I thought it might be useful to add an extremely simple transaction trace for use in the short-term.

This function will give you a set of the Opcodes used in a transaction, ordered by how much gas they cost (in total).

So adding something like this in a unit test:

```
  it('gas test', async () => {
    const {comet, users: [alice], tokens} = await makeProtocol();
    const { USDC } = tokens;

    await USDC.allocateTo(alice.address, 100e6);
    await USDC.connect(alice).approve(comet.address, 100e6);

    const tx = await wait(comet.connect(alice).supply(USDC.address, 100e6));

    console.log((await opCodesForTransaction(tx)).totalGasCost);
    console.log((await opCodesForTransaction(tx)).orderedOpcodeCounts);
  });
```

would log this:


```
101547
[
  [ 'CALL', { calls: 1, totalGasCost: 10822798 } ],
  [ 'SSTORE', { calls: 9, totalGasCost: 51900 } ],
  [ 'SLOAD', { calls: 37, totalGasCost: 17700 } ],
  [ 'LOG3', { calls: 2, totalGasCost: 3512 } ],
  [ 'PUSH1', { calls: 604, totalGasCost: 1812 } ],
  [ 'JUMP', { calls: 214, totalGasCost: 1712 } ],
  [ 'JUMPI', { calls: 162, totalGasCost: 1620 } ],
  [ 'PUSH2', { calls: 388, totalGasCost: 1164 } ],
  [ 'SWAP1', { calls: 243, totalGasCost: 729 } ],
  [ 'POP', { calls: 236, totalGasCost: 472 } ],
  [ 'EXP', { calls: 8, totalGasCost: 430 } ],
  [ 'AND', { calls: 142, totalGasCost: 426 } ],
  [ 'SHA3', { calls: 10, totalGasCost: 420 } ],
  [ 'SHL', { calls: 128, totalGasCost: 384 } ],
  [ 'SUB', { calls: 125, totalGasCost: 375 } ],
  [ 'DUP1', { calls: 118, totalGasCost: 354 } ],
  [ 'DUP3', { calls: 102, totalGasCost: 306 } ],
  [ 'ISZERO', { calls: 101, totalGasCost: 303 } ],
  [ 'JUMPDEST', { calls: 297, totalGasCost: 297 } ],
  [ 'DIV', { calls: 55, totalGasCost: 275 } ],
  [ 'DUP2', { calls: 89, totalGasCost: 267 } ],
  [ 'EQ', { calls: 73, totalGasCost: 219 } ],
  [ 'DUP4', { calls: 72, totalGasCost: 216 } ],
  [ 'SWAP2', { calls: 70, totalGasCost: 210 } ],
  [ 'PUSH4', { calls: 69, totalGasCost: 207 } ],
  [ 'MSTORE', { calls: 39, totalGasCost: 165 } ],
  [ 'MUL', { calls: 30, totalGasCost: 150 } ],
  [ 'SWAP3', { calls: 49, totalGasCost: 147 } ],
  [ 'SWAP4', { calls: 47, totalGasCost: 141 } ],
  [ 'DUP6', { calls: 38, totalGasCost: 114 } ],
  [ 'GT', { calls: 38, totalGasCost: 114 } ],
  [ 'ADD', { calls: 33, totalGasCost: 99 } ],
  [ 'NOT', { calls: 32, totalGasCost: 96 } ],
  [ 'DUP5', { calls: 29, totalGasCost: 87 } ],
  [ 'MLOAD', { calls: 21, totalGasCost: 63 } ],
  [ 'SIGNEXTEND', { calls: 11, totalGasCost: 55 } ],
  [ 'PUSH32', { calls: 14, totalGasCost: 42 } ],
  [ 'DUP7', { calls: 13, totalGasCost: 39 } ],
  [ 'LT', { calls: 12, totalGasCost: 36 } ],
  [ 'SLT', { calls: 12, totalGasCost: 36 } ],
  [ 'SWAP5', { calls: 12, totalGasCost: 36 } ],
  [ 'PUSH7', { calls: 10, totalGasCost: 30 } ],
  [ 'OR', { calls: 10, totalGasCost: 30 } ],
  [ 'CALLDATALOAD', { calls: 7, totalGasCost: 21 } ],
  [ 'DUP8', { calls: 6, totalGasCost: 18 } ],
  [ 'PUSH8', { calls: 6, totalGasCost: 18 } ],
  [ 'PUSH5', { calls: 5, totalGasCost: 15 } ],
  [ 'SWAP6', { calls: 5, totalGasCost: 15 } ],
  [ 'CALLER', { calls: 5, totalGasCost: 10 } ],
  [ 'SWAP7', { calls: 3, totalGasCost: 9 } ],
  [ 'CALLDATASIZE', { calls: 4, totalGasCost: 8 } ],
  [ 'SHR', { calls: 2, totalGasCost: 6 } ],
  [ 'CODECOPY', { calls: 1, totalGasCost: 6 } ],
  [ 'DUP9', { calls: 2, totalGasCost: 6 } ],
  [ 'SWAP8', { calls: 2, totalGasCost: 6 } ],
  [ 'DUP10', { calls: 2, totalGasCost: 6 } ],
  [ 'CALLVALUE', { calls: 2, totalGasCost: 4 } ],
  [ 'TIMESTAMP', { calls: 2, totalGasCost: 4 } ],
  [ 'SGT', { calls: 1, totalGasCost: 3 } ],
  [ 'ADDRESS', { calls: 1, totalGasCost: 2 } ],
  [ 'GAS', { calls: 1, totalGasCost: 2 } ],
  [ 'RETURNDATASIZE', { calls: 1, totalGasCost: 2 } ],
  [ 'RETURN', { calls: 1, totalGasCost: 0 } ],
  [ 'STOP', { calls: 1, totalGasCost: 0 } ]
]
```

It's crude, but could be useful while we're building out more advanced tracing.

Also, note that the gas cost of the "CALL" operation itself is greater than the total gas cost of the transaction.