### PR TITLE
more gas measures

### DIFF
--- a/scenario/GasScenario.ts
+++ b/scenario/GasScenario.ts
@@ -1,13 +1,14 @@
 import { CometProperties, scenario } from './context/CometContext';
 import { expect } from 'chai';
 import { exp, wait } from '../test/helpers';
+import { opCodesForTransaction } from "../test/trace";
 
 scenario.only(
   'has reasonable gas for 5 collateral assets',
   { remote_token: { mainnet: ['WBTC'] }, utilization: 0.5, defaultBaseAmount: 5000 },
   async ({ comet, assets, actors }, world, context) => {
     let tokenAmounts = {
-      'WBTC': exp(10, 8),
+      'WBTC': exp(.07, 8),
       'WETH': exp(0.01, 18),
       'UNI': exp(100, 18),
     };
@@ -24,11 +25,20 @@ scenario.only(
         amount
       );
       await comet.connect(primary.signer).supply(asset.address, amount);
-      console.log("gas", token, asset, await primary.getCollateralBalance(asset));
+      // console.log("gas", token, asset, await primary.getCollateralBalance(asset));
     }
 
     await comet.connect(primary.signer).withdraw(await comet.baseToken(), exp(10, 6));
     let tx = await wait(comet.connect(primary.signer).withdraw(await comet.baseToken(), exp(1500, 6)));
     console.log({tx})
+
+    const { totalGasCost, orderedOpcodeCounts, opcodeGasTotal } = await opCodesForTransaction(
+      world.hre.network.provider,
+      tx
+    );
+    console.log(`totalGasCost: ${totalGasCost}`);
+    console.log(`opcodeGasTotal: ${opcodeGasTotal}`);
+    console.log(orderedOpcodeCounts);
+
   }
 );

--- a/test/supply-test.ts
+++ b/test/supply-test.ts
@@ -1,6 +1,21 @@
 import { Comet, ethers, event, expect, exp, makeProtocol, portfolio, wait } from './helpers';
+import { opCodesForTransaction } from "./trace";
 
 describe('supplyTo', function () {
+  it.only('gas test', async () => {
+    const {comet, users: [alice], tokens} = await makeProtocol();
+    const { USDC } = tokens;
+
+    await USDC.allocateTo(alice.address, 100e6);
+    await USDC.connect(alice).approve(comet.address, 100e6);
+
+    const tx = await wait(comet.connect(alice).supply(USDC.address, 100e6));
+
+    const { totalGasCost, orderedOpcodeCounts } = await opCodesForTransaction(tx);
+    console.log(`totalGasCost: ${totalGasCost}`);
+    console.log(orderedOpcodeCounts);
+  });
+
   it('supplies base from sender if the asset is base', async () => {
     const protocol = await makeProtocol({base: 'USDC'});
     const { comet, tokens, users: [alice, bob] } = protocol;

--- a/test/trace.ts
+++ b/test/trace.ts
@@ -1,0 +1,35 @@
+import { ethers, TransactionResponseExt } from './helpers';
+
+type OpcodeCount = {
+  calls: number;
+  totalGasCost: number;
+}
+
+export async function opCodesForTransaction(provider, tx: TransactionResponseExt) {
+  const trace = await provider.send("debug_traceTransaction", [tx.hash]);
+  const { structLogs } = trace;
+  let opcodeCounts: {[opcode: string]: OpcodeCount} = {};
+
+  let opcodeGasTotal = 0;
+
+  structLogs.forEach(structLog => {
+    opcodeGasTotal += structLog.gasCost;
+
+    if (opcodeCounts[structLog.op]) {
+      opcodeCounts[structLog.op].calls += 1;
+      opcodeCounts[structLog.op].totalGasCost += structLog.gasCost;
+    } else {
+      opcodeCounts[structLog.op] = {
+        calls: 1,
+        totalGasCost: structLog.gasCost
+      }
+    };
+  });
+
+  return {
+    totalGasCost: trace.gas,
+    opcodeGasTotal,
+    opcodeCounts: opcodeCounts,
+    orderedOpcodeCounts: Object.entries(opcodeCounts).sort((a, b) => b[1].totalGasCost - a[1].totalGasCost)
+  };
+}


### PR DESCRIPTION
This is basically the same change as #244 , but with the basic trace function from #246 and some additional tweaking of the asset allocations.

My hope was to find a configuration of token assets that would result in multiple loops during `isBorrowCollateralized`. The way we had been testing it before, it's extremely likely that the borrow was collateralized by the `WBTC` alone, and so no additional loops were needed to measure liquidity:

```
let tokenAmounts = {
  'WBTC': exp(10, 8),
  'WETH': exp(0.01, 18),
  'UNI': exp(100, 18),
};

totalGasCost: 144612
debug_traceTransaction structLogs: [
  [ 'STATICCALL', { calls: 4, totalGasCost: 243848 } ],
  [ 'DELEGATECALL', { calls: 2, totalGasCost: 137939 } ],
  [ 'SLOAD', { calls: 66, totalGasCost: 56600 } ],
  //...
```

So you end up with a total gas cost of 144,612.

If you crank the amount of `WBTC` down (but not down so low that the borrow is no longer collateralized ) then you can get that figure up to 198,906:

```
let tokenAmounts = {
  'WBTC': exp(.07, 8),
  'WETH': exp(0.01, 18),
  'UNI': exp(100, 18),
};

totalGasCost: 198906
debug_traceTransaction structLogs: [
  [ 'STATICCALL', { calls: 8, totalGasCost: 700738 } ],
  [ 'DELEGATECALL', { calls: 2, totalGasCost: 192208 } ],
  [ 'SLOAD', { calls: 82, totalGasCost: 86200 } ],
  [ 'CALL', { calls: 1, totalGasCost: 29229 } ],
  // ...
```
