### PR TITLE
Add Transfer events to supplyBase and withdrawBase

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -886,6 +886,7 @@ contract Comet is CometCore {
         updateBaseBalance(dst, dstUser, principalValue(dstBalance));
 
         emit Supply(from, dst, amount);
+        emit Transfer(address(0), dst, amount);
     }
 
     /**
@@ -1103,6 +1104,7 @@ contract Comet is CometCore {
         doTransferOut(baseToken, to, amount);
 
         emit Withdraw(src, to, amount);
+        emit Transfer(src, address(0), amount);
     }
 
     /**

--- a/test/supply-test.ts
+++ b/test/supply-test.ts
@@ -33,6 +33,13 @@ describe('supplyTo', function () {
         amount: BigInt(100e6),
       }
     });
+    expect(event(s0, 2)).to.be.deep.equal({
+      Transfer: {
+        from: ethers.constants.AddressZero,
+        to: alice.address,
+        amount: BigInt(100e6),
+      }
+    });
 
     expect(p0.internal).to.be.deep.equal({USDC: 0n, COMP: 0n, WETH: 0n, WBTC: 0n});
     expect(p0.external).to.be.deep.equal({USDC: 0n, COMP: 0n, WETH: 0n, WBTC: 0n});

--- a/test/withdraw-test.ts
+++ b/test/withdraw-test.ts
@@ -38,6 +38,13 @@ describe('withdrawTo', function () {
         amount: BigInt(100e6),
       }
     });
+    expect(event(s0, 2)).to.be.deep.equal({
+      Transfer: {
+        from: bob.address,
+        to: ethers.constants.AddressZero,
+        amount: BigInt(100e6),
+      }
+    });
 
     expect(p0.internal).to.be.deep.equal({USDC: 0n, COMP: 0n, WETH: 0n, WBTC: 0n});
     expect(p0.external).to.be.deep.equal({USDC: 0n, COMP: 0n, WETH: 0n, WBTC: 0n});


### PR DESCRIPTION
This follows the convention for ERC20 and allows token holder and balance info to show correctly on Etherscan.

Example Etherscan token page for Comet on Kovan:
https://kovan.etherscan.io/token/0x3c185Ee11C08f5DdA7419FFbAde30d8b39878CCb 