### PR TITLE
disable ethers logging

### DIFF
--- a/tasks/scenario/task.ts
+++ b/tasks/scenario/task.ts
@@ -27,10 +27,15 @@ task('scenario', 'Runs scenario tests')
   .addOptionalParam('bases', 'Bases to run on [defaults to all]')
   .addFlag('noSpider', 'skip spider')
   .addFlag('sync', 'run synchronously')
+  .addFlag('quiet', 'set Ethers log level to OFF')
   .addOptionalParam('stall', 'milliseconds to wait until we fail for stalling', 120000, types.int)
   .addOptionalParam('workers', 'count of workers', 6, types.int)
   .setAction(async (taskArgs, env: HardhatRuntimeEnvironment) => {
     let bases: ForkSpec[] = getBasesFromTaskArgs(taskArgs.bases, env);
+
+    if (taskArgs.quiet) {
+      env.ethers.utils.Logger.setLogLevel(env.ethers.utils.Logger.levels.OFF);
+    }
 
     if (!taskArgs.noSpider) {
       await env.run('scenario:spider', taskArgs);


### PR DESCRIPTION
Our scenario output is dominated by `duplicate definition - //... `

We can turn that off using `ethers.utils.Logger.setLogLevel`.

Not sure if we'd be losing other useful information, but it makes things a lot more readable:

Before:

<img width="749" alt="image" src="https://user-images.githubusercontent.com/2570291/159557749-50a55387-06ef-4bce-9e19-303dc98a7c55.png">


After:

<img width="780" alt="image" src="https://user-images.githubusercontent.com/2570291/159557589-15dc1ec0-14cd-4557-a6ce-425159b3fe28.png">



source: https://github.com/ethers-io/ethers.js/issues/379#issuecomment-664704703