### PR TITLE
reward safety threshold proof-of-concept

### DIFF
--- a/test/rewards-test.ts
+++ b/test/rewards-test.ts
@@ -1,0 +1,30 @@
+import { ethers, expect, makeProtocol } from './helpers';
+
+describe.only('CometRewards', () => {
+  it('does not overflow when calculating trackingSupplyIndex', async () => {
+    const {
+      comet,
+      tokens: { USDC },
+      users: [alice],
+    } = await makeProtocol({
+      baseMinForRewards: 1 // lowest threshold for earning rewards
+    });
+
+    // allocate and approve transfers
+    await USDC.allocateTo(alice.address, 2e6);
+    await USDC.connect(alice).approve(comet.address, 2e6);
+
+    // supply once
+    await comet.connect(alice).supply(USDC.address, 1e6);
+
+    const oneYear = 60 * 60 * 24 * 365;
+    await ethers.provider.send('evm_increaseTime', [oneYear]);
+
+    await expect(comet.accrue()).to.not.be.reverted;
+
+    // should work on repeat accrues
+    for (let i = 0; i < 100; i++) {
+      await expect(comet.accrue()).to.not.be.reverted;
+    }
+  });
+});


### PR DESCRIPTION
One idea on how to approach the `trackingSupplyIndex` overflow issue:

https://www.desmos.com/calculator/mcmzmvx2u7
(blue line = our existing algorithm; purple line = safety threshold algorithm)

Basically, create a minimum number that the rewards will be divided by. So even if there's only 1 nominal, the rewards would be divided up as if there are 5000 units (or whatever value `REWARD_SAFETY_MULTIPLIER` is set to).

If I've done the math right, setting this value to 5,000 should mean that it takes over 3 years to elapse before the `trackingSupplyIndex` calculation overflows, even when there is just 1 nominal unit of base. Setting it to 10,000 gets you almost 6 years with 1 unit of base. (Our current calculation overflows after ~18K seconds/5 hrs with 1 unit of base).