### PR TITLE
Add tracking index boundary unit tests

### DIFF
--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -111,6 +111,10 @@ export function annualize(n: bigint | BigNumber, secondsPerYear = 31536000n): nu
   return defactor(toBigInt(n) * secondsPerYear);
 }
 
+export function toYears(seconds: number, secondsPerYear = 31536000): number {
+  return seconds / secondsPerYear;
+}
+
 export function defaultAssets(overrides = {}) {
   return {
     COMP: Object.assign({

--- a/test/tracking-index-bounds-test.ts
+++ b/test/tracking-index-bounds-test.ts
@@ -1,0 +1,139 @@
+import { Comet, ethers, expect, exp, factor, defaultAssets, makeProtocol, portfolio, wait, toYears } from './helpers';
+import { BigNumber } from 'ethers';
+
+describe('total tracking index bounds', function () {
+  it('upper bound hit on tracking supply index', async () => {
+    const baseMinForRewards = exp(10_000, 6); // 10k USDC
+    const params = {
+      trackingIndexScale: exp(1, 15),
+      baseTrackingSupplySpeed: exp(1, 15),
+      baseTrackingBorrowSpeed: exp(1, 15),
+      baseMinForRewards
+    };
+    const protocol = await makeProtocol(params);
+    const { comet } = protocol;
+
+    const baseScale = (await comet.baseScale()).toBigInt();
+    // Formula: MAX_UINT64 / (baseTrackingSupplySpeed * baseScale / baseMinForRewards)
+    const secondsUntilOverflow = Number(2n**64n * (baseMinForRewards / baseScale) / params.baseTrackingSupplySpeed);
+
+    // Assert there are at least 5.85 years until tracking index can overflow
+    const expectedYearsUntilOverflow = 5.85;
+    expect(toYears(secondsUntilOverflow)).to.be.approximately(expectedYearsUntilOverflow, 0.01);
+
+    const t0 = Object.assign({}, await comet.totalsBasic(), {
+      totalSupplyBase: BigNumber.from(baseMinForRewards), // 10k USDC base units
+    });
+    await wait(comet.setTotalsBasic(t0));
+
+    await ethers.provider.send('evm_increaseTime', [secondsUntilOverflow-1]);
+
+    // First accrue is successful without overflow
+    await comet.accrue();
+
+    // Second accrue should overflow
+    await expect(comet.accrue()).to.be.revertedWith('code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)');
+  });
+
+  it('upper bound hit on borrow supply index', async () => {
+    const baseMinForRewards = exp(10_000, 6); // 10k USDC
+    const params = {
+      trackingIndexScale: exp(1, 15),
+      baseTrackingSupplySpeed: exp(1, 15),
+      baseTrackingBorrowSpeed: exp(1, 15),
+      baseMinForRewards
+    };
+    const protocol = await makeProtocol(params);
+    const { comet } = protocol;
+
+    const baseScale = (await comet.baseScale()).toBigInt();
+    // Formula: MAX_UINT64 / (baseTrackingBorrowSpeed * baseScale / baseMinForRewards)
+    const secondsUntilOverflow = Number(2n**64n * (baseMinForRewards / baseScale) / params.baseTrackingBorrowSpeed);
+
+    // Assert there are at least 5.85 years until tracking index can overflow
+    const expectedYearsUntilOverflow = 5.85;
+    expect(toYears(secondsUntilOverflow)).to.be.approximately(expectedYearsUntilOverflow, 0.01);
+
+    const t0 = Object.assign({}, await comet.totalsBasic(), {
+      totalBorrowBase: BigNumber.from(baseMinForRewards), // 10k USDC base units
+    });
+    await wait(comet.setTotalsBasic(t0));
+
+    await ethers.provider.send('evm_increaseTime', [secondsUntilOverflow-1]);
+
+    // First accrue is successful without overflow
+    await comet.accrue();
+
+    // Second accrue should overflow
+    await expect(comet.accrue()).to.be.revertedWith('code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)');
+  });
+
+  it('lower bound hit on tracking supply index', async () => {
+    const params = {
+      trackingIndexScale: exp(1, 15),
+      baseTrackingSupplySpeed: exp(1, 15),
+      baseTrackingBorrowSpeed: exp(1, 15),
+    };
+    const protocol = await makeProtocol(params);
+    const { comet } = protocol;
+
+    const t0 = Object.assign({}, await comet.totalsBasic(), {
+      totalSupplyBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()), // 1e15 base units
+    });
+    await wait(comet.setTotalsBasic(t0));
+
+    await comet.accrue();
+    const t1 = await comet.totalsBasic();
+
+    // Tracking index should properly accrue
+    expect(t1.trackingSupplyIndex).to.not.be.equal(t0.trackingSupplyIndex);
+
+    const t2 = Object.assign({}, await comet.totalsBasic(), {
+      totalSupplyBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()).mul(3), // 3e15 base units
+    });
+    await wait(comet.setTotalsBasic(t2));
+    
+    await comet.accrue();
+    const t3 = await comet.totalsBasic();
+
+    // Lower bound has hit and tracking index no longer accrues
+    expect(t3.trackingSupplyIndex).to.be.equal(t2.trackingSupplyIndex);
+  });
+
+  it('lower bound hit on tracking borrow index', async () => {
+    const params = {
+      trackingIndexScale: exp(1, 15),
+      baseTrackingSupplySpeed: exp(1, 15),
+      baseTrackingBorrowSpeed: exp(1, 15),
+    };
+    const protocol = await makeProtocol(params);
+    const { comet } = protocol;
+
+    const t0 = Object.assign({}, await comet.totalsBasic(), {
+      totalBorrowBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()), // 1e15 base units
+    });
+    await wait(comet.setTotalsBasic(t0));
+
+    await comet.accrue();
+    const t1 = await comet.totalsBasic();
+
+    // Tracking index should properly accrue
+    expect(t1.trackingBorrowIndex).to.not.be.equal(t0.trackingBorrowIndex);
+
+    const t2 = Object.assign({}, await comet.totalsBasic(), {
+      totalBorrowBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()).mul(3), // 3e15 base units
+    });
+    await wait(comet.setTotalsBasic(t2));
+    
+    await comet.accrue();
+    const t3 = await comet.totalsBasic();
+
+    // Lower bound has hit and tracking index no longer accrues
+    expect(t3.trackingBorrowIndex).to.be.equal(t2.trackingBorrowIndex);
+  });
+});
+
+
+describe('user tracking index bounds', function () {
+  // XXX test if small supply/borrow causes users to not accrue rewards
+});


### PR DESCRIPTION
This PR adds unit tests to check the upper and lower bounds for the tracking indices in `TotalsBasic`. A follow-up PR will add coverage for user tracking indices.