### PR TITLE
Don't initialize storage in constructor

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -223,9 +223,6 @@ contract Comet is CometCore {
         (asset12_a, asset12_b) = _getPackedAsset(config.assetConfigs, 12);
         (asset13_a, asset13_b) = _getPackedAsset(config.assetConfigs, 13);
         (asset14_a, asset14_b) = _getPackedAsset(config.assetConfigs, 14);
-
-        // Initialize storage
-        initializeStorage();
     }
 
     /**

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -204,8 +204,6 @@ export async function makeProtocol(opts: ProtocolOpts = {}): Promise<Protocol> {
     await extensionDelegate.deployed();
   }
 
-  if (opts.start) await ethers.provider.send('evm_setNextBlockTimestamp', [opts.start]);
-
   const CometFactory = (await ethers.getContractFactory('CometHarness')) as CometHarness__factory;
   const comet = await CometFactory.deploy({
     governor: governor.address,
@@ -241,6 +239,9 @@ export async function makeProtocol(opts: ProtocolOpts = {}): Promise<Protocol> {
     }, []),
   });
   await comet.deployed();
+
+  if (opts.start) await ethers.provider.send('evm_setNextBlockTimestamp', [opts.start]);
+  await comet.initializeStorage();
 
   const baseTokenBalance = opts.baseTokenBalance;
   if (baseTokenBalance) {


### PR DESCRIPTION
The constructor initialization was only used when deploying stand-alone and not in the normal proxy setup anyway. This saves 200 bytes on the factory size as well as decreases gas costs for make param changes using Configurator.