### PR TITLE
Run contract linter only on modified contracts

### DIFF
--- a/.github/workflows/run-contract-linter.yaml
+++ b/.github/workflows/run-contract-linter.yaml
@@ -11,8 +11,9 @@ jobs:
       SNOWTRACE_KEY: ${{ secrets.SNOWTRACE_KEY }}
       INFURA_KEY: ${{ secrets.INFURA_KEY }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v2
         with:
@@ -21,5 +22,5 @@ jobs:
       - name: Install packages
         run: yarn install --non-interactive --frozen-lockfile && yarn build
 
-      - name: Run linter
-        run: yarn lint-contracts
+      - name: Run linter on modified contracts
+        run: git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep ^contracts/ | xargs yarn solhint


### PR DESCRIPTION
Updating the contract linter Github Action to only run against contracts that are modified in that PR