### PR TITLE
[ChainSecurity 5.4] add check for zero address in allowBySig

### DIFF
--- a/contracts/CometExt.sol
+++ b/contracts/CometExt.sol
@@ -223,6 +223,7 @@ contract CometExt is CometCore {
         bytes32 structHash = keccak256(abi.encode(AUTHORIZATION_TYPEHASH, owner, manager, isAllowed_, nonce, expiry));
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
         address signatory = ecrecover(digest, v, r, s);
+        if (signatory == address(0)) revert BadSignatory();
         if (owner != signatory) revert BadSignatory();
         if (nonce != userNonce[signatory]++) revert BadNonce();
         if (block.timestamp >= expiry) revert SignatureExpired();


### PR DESCRIPTION
> ecrecover returns 0 on error. This error value is not checked correctly within the allowBySig function. As a result anyone can call allowBySig with owner == 0 and thereby set approvals in the name of the 0-address. Since transfers to the 0-address are possible in the contract, falsely sent funds to this address could be recovered by an attacker.
