### PR TITLE
[ChainSecurity 5.2] Fix borrowBalanceOf bug and strengthen unit tests

### DIFF
--- a/contracts/CometExt.sol
+++ b/contracts/CometExt.sol
@@ -120,7 +120,7 @@ contract CometExt is CometCore {
      */
     function borrowBalanceOf(address account) external view returns (uint256) {
         int104 principal = userBasic[account].principal;
-        return principal < 0 ? presentValueBorrow(baseSupplyIndex, unsigned104(-principal)) : 0;
+        return principal < 0 ? presentValueBorrow(baseBorrowIndex, unsigned104(-principal)) : 0;
     }
 
      /**

--- a/test/absorb-test.ts
+++ b/test/absorb-test.ts
@@ -1,4 +1,4 @@
-import { Comet, ethers, expect, exp, factor, defaultAssets, makeProtocol, portfolio, wait } from './helpers';
+import { Comet, ethers, expect, exp, factor, defaultAssets, makeProtocol, portfolio, wait, setTotalsBasic } from './helpers';
 
 describe('absorb', function () {
   it('reverts if total borrows underflows', async () => {
@@ -17,10 +17,7 @@ describe('absorb', function () {
     const protocol = await makeProtocol(params);
     const { comet, users: [absorber, underwater] } = protocol;
 
-    const t0 = Object.assign({}, await comet.totalsBasic(), {
-      totalBorrowBase: 100n,
-    });
-    await wait(comet.setTotalsBasic(t0));
+    await setTotalsBasic(comet, { totalBorrowBase: 100n });
 
     await comet.setBasePrincipal(underwater.address, -100);
 
@@ -74,10 +71,7 @@ describe('absorb', function () {
     const protocol = await makeProtocol(params);
     const { comet, users: [absorber, underwater1, underwater2] } = protocol;
 
-    const t0 = Object.assign({}, await comet.totalsBasic(), {
-      totalBorrowBase: 2000n,
-    });
-    await wait(comet.setTotalsBasic(t0));
+    await setTotalsBasic(comet, { totalBorrowBase: 2000n });
 
     const r0 = await comet.getReserves();
 
@@ -136,11 +130,10 @@ describe('absorb', function () {
     const { comet, tokens, users: [absorber, underwater1, underwater2, underwater3] } = protocol;
     const { COMP, USDC, WBTC, WETH } = tokens;
 
-    const t0 = Object.assign({}, await comet.totalsBasic(), {
+    await setTotalsBasic(comet, {
       totalBorrowBase: exp(3e15, 6),
       totalSupplyBase: exp(4e15, 6),
     });
-    await wait(comet.setTotalsBasic(t0));
 
     const r0 = await comet.getReserves();
 
@@ -231,10 +224,9 @@ describe('absorb', function () {
     const { COMP, USDC, WBTC, WETH } = tokens;
 
     const debt = 1n - (exp(41000, 6) + exp(3000, 6) + exp(175, 6));
-    const t0 = Object.assign({}, await comet.totalsBasic(), {
+    await setTotalsBasic(comet, {
       totalBorrowBase: -debt,
     });
-    await wait(comet.setTotalsBasic(t0));
 
     const r0 = await comet.getReserves();
 
@@ -320,10 +312,7 @@ describe('absorb', function () {
 
     const borrowAmount = exp(4000, 6); // borrow of $4k > collateral of $3k + $175
     await comet.setBasePrincipal(underwater.address, -borrowAmount);
-    const totalsBasic = Object.assign({}, await comet.totalsBasic(), {
-      totalBorrowBase: borrowAmount,
-    });
-    await wait(comet.setTotalsBasic(totalsBasic));
+    const totalsBasic = await setTotalsBasic(comet, { totalBorrowBase: borrowAmount });
 
     const isLiquidatable = await comet.isLiquidatable(underwater.address);
 

--- a/test/accrue-test.ts
+++ b/test/accrue-test.ts
@@ -1,4 +1,4 @@
-import { Comet, ethers, expect, exp, fastForward, getBlock, makeProtocol, wait } from './helpers';
+import { Comet, ethers, expect, exp, fastForward, getBlock, makeProtocol, wait, setTotalsBasic } from './helpers';
 
 function projectBaseIndex(index, rate, time, factorScale = exp(1, 18)) {
   return index.add(index.mul(rate.mul(time)).div(factorScale));
@@ -48,13 +48,13 @@ describe('accrue', function () {
     const baseIndexScale = await comet.baseIndexScale();
 
     const now = Math.floor(Date.now() / 1000);
-    const f0 = await wait(comet.setNow(now));
+    const f0 = await wait(comet.setNow(now)); // this freezes the timestamp for the entire test
 
     const totals = {
       trackingSupplyIndex: 0,
       trackingBorrowIndex: 0,
-      baseSupplyIndex: baseIndexScale,
-      baseBorrowIndex: baseIndexScale,
+      baseSupplyIndex: 2e15,
+      baseBorrowIndex: 3e15,
       totalSupplyBase: 1000n,
       totalBorrowBase: 1000n,
       lastAccrualTime: 0,
@@ -93,12 +93,10 @@ describe('accrue', function () {
     };
     const { comet } = await makeProtocol(params);
 
-    const t0 = await comet.totalsBasic();
-    const t1 = Object.assign({}, t0, {
+    const t1 = await setTotalsBasic(comet, {
       totalSupplyBase: 11000n,
       totalBorrowBase: 11000n,
     });
-    const s0 = await wait(comet.setTotalsBasic(t1));
 
     const supplyRate = await comet.getSupplyRate();
     expect(supplyRate).to.be.equal(19549086756);
@@ -134,11 +132,10 @@ describe('accrue', function () {
     const { comet } = await makeProtocol(params);
 
     const t0 = await comet.totalsBasic();
-    const t1 = Object.assign({}, t0, {
+    const t1  = await setTotalsBasic(comet, {
       totalSupplyBase: exp(14000, 6),
       totalBorrowBase: exp(13000, 6),
     });
-    const s0 = await wait(comet.setTotalsBasic(t1));
 
     const supplyRate = await comet.getSupplyRate();
     expect(supplyRate).to.be.equal(12474082097);

--- a/test/erc20-test.ts
+++ b/test/erc20-test.ts
@@ -1,4 +1,4 @@
-import { ethers, event, expect, makeProtocol, wait } from './helpers';
+import { ethers, event, expect, makeProtocol, setTotalsBasic, wait } from './helpers';
 
 describe('erc20', function () {
   it('has correct name', async () => {
@@ -22,11 +22,10 @@ describe('erc20', function () {
   it('has correct totalSupply', async () => {
     const { comet } = await makeProtocol();
 
-    let totalsBasic = await comet.totalsBasic();
-    totalsBasic = Object.assign({}, totalsBasic, {
-      totalSupplyBase: 100e6,
+    await setTotalsBasic(comet, {
+      baseSupplyIndex: 2e15,
+      totalSupplyBase: 50e6,
     });
-    await comet.setTotalsBasic(totalsBasic);
 
     const totalSupply = await comet.totalSupply();
 
@@ -43,10 +42,9 @@ describe('erc20', function () {
       await comet.setBasePrincipal(user.address, 100e6);
 
       let totalsBasic = await comet.totalsBasic();
-      totalsBasic = Object.assign({}, totalsBasic, {
+      await setTotalsBasic(comet, {
         baseSupplyIndex: totalsBasic.baseSupplyIndex.mul(2),
       });
-      await comet.setTotalsBasic(totalsBasic);
 
       const balanceOf = await comet.balanceOf(user.address);
       expect(balanceOf).to.eq(200e6);
@@ -73,7 +71,10 @@ describe('erc20', function () {
 
     expect(await comet.baseBalanceOf(bob.address)).to.eq(0);
 
-    await comet.setBasePrincipal(alice.address, 100e6);
+    await comet.setBasePrincipal(alice.address, 50e6);
+    await setTotalsBasic(comet, {
+      baseSupplyIndex: 2e15,
+    });
 
     const tx = await wait(comet.connect(alice).transfer(bob.address, 100e6));
 
@@ -95,7 +96,10 @@ describe('erc20', function () {
         users: [alice, bob],
       } = await makeProtocol();
 
-      await comet.setBasePrincipal(alice.address, 100e6);
+      await comet.setBasePrincipal(alice.address, 50e6);
+      await setTotalsBasic(comet, {
+        baseSupplyIndex: 2e15,
+      });
 
       await comet.connect(alice).transferFrom(alice.address, bob.address, 100e6)
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -27,9 +27,11 @@ import {
   CometFactory__factory,
   Configurator,
   Configurator__factory,
+  CometHarnessInterface,
 } from '../build/types';
 import { BigNumber } from 'ethers';
 import { TransactionReceipt, TransactionResponse } from '@ethersproject/abstract-provider';
+import { TotalsBasicStructOutput } from '../build/types/CometHarness';
 
 export { Comet, ethers, expect, hre };
 
@@ -453,6 +455,13 @@ export async function makeRewards(opts: RewardsOpts = {}): Promise<Rewards> {
     governor,
     rewards
   };
+}
+
+export async function setTotalsBasic(comet: CometHarnessInterface, overrides = {}): Promise<TotalsBasicStructOutput> {
+  const t0 = await comet.totalsBasic();
+  const t1 = Object.assign({}, t0, overrides);
+  await wait(comet.setTotalsBasic(t1));
+  return t1;
 }
 
 export function objectify(arrayObject) {

--- a/test/interest-rate-test.ts
+++ b/test/interest-rate-test.ts
@@ -23,16 +23,15 @@ describe('interest rates', function () {
       reserveRate: exp(1, 17) // 0.1
     };
     const { comet } = await makeProtocol(params);
-    const baseIndexScale = await comet.baseIndexScale();
 
     // 10% utilization
     const totals = {
       trackingSupplyIndex: 0,
       trackingBorrowIndex: 0,
-      baseSupplyIndex: baseIndexScale,
-      baseBorrowIndex: baseIndexScale,
-      totalSupplyBase: 100n,
-      totalBorrowBase: 10n,
+      baseSupplyIndex: 2e15,
+      baseBorrowIndex: 4e15,
+      totalSupplyBase: 500n,
+      totalBorrowBase: 25n,
       lastAccrualTime: 0,
       pauseFlags: 0,
     };
@@ -62,16 +61,15 @@ describe('interest rates', function () {
       reserveRate: exp(1, 17) // 0.1
     };
     const { comet } = await makeProtocol(params);
-    const baseIndexScale = await comet.baseIndexScale();
 
     // 90% utilization
     const totals = {
       trackingSupplyIndex: 0,
       trackingBorrowIndex: 0,
-      baseSupplyIndex: baseIndexScale,
-      baseBorrowIndex: baseIndexScale,
-      totalSupplyBase: 100n,
-      totalBorrowBase: 90n,
+      baseSupplyIndex: 2e15,
+      baseBorrowIndex: 3e15,
+      totalSupplyBase: 50n,
+      totalBorrowBase: 30n,
       lastAccrualTime: 0,
       pauseFlags: 0,
     };
@@ -101,16 +99,15 @@ describe('interest rates', function () {
       reserveRate: 0
     };
     const { comet } = await makeProtocol(params);
-    const baseIndexScale = await comet.baseIndexScale();
 
     // 10% utilization
     const totals = {
       trackingSupplyIndex: 0,
       trackingBorrowIndex: 0,
-      baseSupplyIndex: baseIndexScale,
-      baseBorrowIndex: baseIndexScale,
-      totalSupplyBase: 100n,
-      totalBorrowBase: 10n,
+      baseSupplyIndex: 4e15,
+      baseBorrowIndex: 2e15,
+      totalSupplyBase: 25n,
+      totalBorrowBase: 5n,
       lastAccrualTime: 0,
       pauseFlags: 0,
     };
@@ -140,15 +137,14 @@ describe('interest rates', function () {
       reserveRate: exp(1, 17) // 0.1
     };
     const { comet } = await makeProtocol(params);
-    const baseIndexScale = await comet.baseIndexScale();
 
     // 0% utilization
     const totals = {
       trackingSupplyIndex: 0,
       trackingBorrowIndex: 0,
-      baseSupplyIndex: baseIndexScale,
-      baseBorrowIndex: baseIndexScale,
-      totalSupplyBase: 100n,
+      baseSupplyIndex: 2e15,
+      baseBorrowIndex: 3e15,
+      totalSupplyBase: 50n,
       totalBorrowBase: 0,
       lastAccrualTime: 0,
       pauseFlags: 0,

--- a/test/reserves-test.ts
+++ b/test/reserves-test.ts
@@ -1,4 +1,4 @@
-import { expect, makeProtocol, wait } from './helpers';
+import { expect, makeProtocol, setTotalsBasic, wait } from './helpers';
 
 describe('getReserves', function () {
   it('calculates 0 reserves', async () => {
@@ -7,12 +7,12 @@ describe('getReserves', function () {
     const { USDC } = tokens;
     await USDC.allocateTo(comet.address, 100);
 
-    const t0 = await comet.totalsBasic();
-    const t1 = Object.assign({}, t0, {
-        totalSupplyBase: 100n,
-        totalBorrowBase: 0n,
+    await setTotalsBasic(comet, {
+      baseSupplyIndex: 4e15,
+      baseBorrowIndex: 3e15,
+      totalSupplyBase: 25n,
+      totalBorrowBase: 0n,
     });
-    await wait(comet.setTotalsBasic(t1));
 
     const reserves = await comet.getReserves();
 
@@ -25,12 +25,12 @@ describe('getReserves', function () {
     const { USDC } = tokens;
     await USDC.allocateTo(comet.address, 100);
 
-    const t0 = await comet.totalsBasic();
-    const t1 = Object.assign({}, t0, {
-        totalSupplyBase: 100n,
-        totalBorrowBase: 50n,
+    await setTotalsBasic(comet, {
+      baseSupplyIndex: 2e15,
+      baseBorrowIndex: 5e15,
+      totalSupplyBase: 50n,
+      totalBorrowBase: 10n,
     });
-    await wait(comet.setTotalsBasic(t1));
 
     const reserves = await comet.getReserves();
 
@@ -44,12 +44,12 @@ describe('getReserves', function () {
 
     // Protocol holds no USDC
 
-    const t0 = await comet.totalsBasic();
-    const t1 = Object.assign({}, t0, {
-        totalSupplyBase: 100n,
-        totalBorrowBase: 0n,
+    await setTotalsBasic(comet, {
+      baseSupplyIndex: 2e15,
+      baseBorrowIndex: 3e15,
+      totalSupplyBase: 50n,
+      totalBorrowBase: 0n,
     });
-    await wait(comet.setTotalsBasic(t1));
 
     const reserves = await comet.getReserves();
 

--- a/test/supply-test.ts
+++ b/test/supply-test.ts
@@ -1,4 +1,4 @@
-import { ethers, event, expect, exp, makeProtocol, portfolio, ReentryAttack, wait } from './helpers';
+import { ethers, event, expect, exp, makeProtocol, portfolio, ReentryAttack, setTotalsBasic, wait } from './helpers';
 import { EvilToken, EvilToken__factory } from '../build/types';
 
 describe('supplyTo', function () {
@@ -110,11 +110,10 @@ describe('supplyTo', function () {
     const baseAsB = USDC.connect(bob);
     const cometAsB = comet.connect(bob);
 
-    let totals0 = await comet.totalsBasic();
-    totals0 = Object.assign({}, await comet.totalsBasic(), {
+    const totals0 = await setTotalsBasic(comet, {
       baseSupplyIndex: 2e15,
     });
-    await wait(comet.setTotalsBasic(totals0));
+
     const alice0 = await portfolio(protocol, alice.address);
     const bob0 = await portfolio(protocol, bob.address);
     const aliceBasic0 = await comet.userBasic(alice.address);

--- a/test/tracking-index-bounds-test.ts
+++ b/test/tracking-index-bounds-test.ts
@@ -1,4 +1,4 @@
-import { Comet, ethers, expect, exp, factor, defaultAssets, fastForward, makeProtocol, portfolio, wait, toYears } from './helpers';
+import { Comet, ethers, expect, exp, factor, defaultAssets, fastForward, makeProtocol, portfolio, setTotalsBasic, wait, toYears } from './helpers';
 import { BigNumber } from 'ethers';
 
 describe('total tracking index bounds', function () {
@@ -21,10 +21,9 @@ describe('total tracking index bounds', function () {
     const expectedYearsUntilOverflow = 5.85;
     expect(toYears(secondsUntilOverflow)).to.be.approximately(expectedYearsUntilOverflow, 0.01);
 
-    const t0 = Object.assign({}, await comet.totalsBasic(), {
+    await setTotalsBasic(comet, {
       totalSupplyBase: BigNumber.from(baseMinForRewards), // 10k USDC base units
     });
-    await wait(comet.setTotalsBasic(t0));
 
     await fastForward(secondsUntilOverflow-1);
 
@@ -54,10 +53,9 @@ describe('total tracking index bounds', function () {
     const expectedYearsUntilOverflow = 5.85;
     expect(toYears(secondsUntilOverflow)).to.be.approximately(expectedYearsUntilOverflow, 0.01);
 
-    const t0 = Object.assign({}, await comet.totalsBasic(), {
+    await setTotalsBasic(comet, {
       totalBorrowBase: BigNumber.from(baseMinForRewards), // 10k USDC base units
     });
-    await wait(comet.setTotalsBasic(t0));
 
     await fastForward(secondsUntilOverflow-1);
 
@@ -77,10 +75,9 @@ describe('total tracking index bounds', function () {
     const protocol = await makeProtocol(params);
     const { comet } = protocol;
 
-    const t0 = Object.assign({}, await comet.totalsBasic(), {
+    const t0 = await setTotalsBasic(comet, {
       totalSupplyBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()), // 1e15 base units
     });
-    await wait(comet.setTotalsBasic(t0));
 
     await comet.accrue();
     const t1 = await comet.totalsBasic();
@@ -88,10 +85,9 @@ describe('total tracking index bounds', function () {
     // Tracking index should properly accrue
     expect(t1.trackingSupplyIndex).to.not.be.equal(t0.trackingSupplyIndex);
 
-    const t2 = Object.assign({}, await comet.totalsBasic(), {
+    const t2 = await setTotalsBasic(comet, {
       totalSupplyBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()).mul(3), // 3e15 base units
     });
-    await wait(comet.setTotalsBasic(t2));
 
     await comet.accrue();
     const t3 = await comet.totalsBasic();
@@ -109,10 +105,9 @@ describe('total tracking index bounds', function () {
     const protocol = await makeProtocol(params);
     const { comet } = protocol;
 
-    const t0 = Object.assign({}, await comet.totalsBasic(), {
+    const t0 = await setTotalsBasic(comet, {
       totalBorrowBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()), // 1e15 base units
     });
-    await wait(comet.setTotalsBasic(t0));
 
     await comet.accrue();
     const t1 = await comet.totalsBasic();
@@ -120,10 +115,9 @@ describe('total tracking index bounds', function () {
     // Tracking index should properly accrue
     expect(t1.trackingBorrowIndex).to.not.be.equal(t0.trackingBorrowIndex);
 
-    const t2 = Object.assign({}, await comet.totalsBasic(), {
+    const t2 = await setTotalsBasic(comet, {
       totalBorrowBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()).mul(3), // 3e15 base units
     });
-    await wait(comet.setTotalsBasic(t2));
 
     await comet.accrue();
     const t3 = await comet.totalsBasic();

--- a/test/transfer-test.ts
+++ b/test/transfer-test.ts
@@ -1,4 +1,4 @@
-import { event, expect, exp, makeProtocol, portfolio, wait } from './helpers';
+import { event, expect, exp, makeProtocol, portfolio, setTotalsBasic, wait } from './helpers';
 import { BigNumber } from "ethers";
 
 describe('transfer', function () {
@@ -84,11 +84,9 @@ describe('transfer', function () {
     await comet.setBasePrincipal(bob.address, 50e6); // 100e6 in present value
     const cometAsB = comet.connect(bob);
 
-    let totals0 = await comet.totalsBasic();
-    totals0 = Object.assign({}, await comet.totalsBasic(), {
+    const totals0 = await setTotalsBasic(comet, {
       baseSupplyIndex: 2e15,
     });
-    await wait(comet.setTotalsBasic(totals0));
 
     const alice0 = await portfolio(protocol, alice.address);
     const bob0 = await portfolio(protocol, bob.address);
@@ -142,10 +140,9 @@ describe('transfer', function () {
     const baseIndexScale = await comet.baseIndexScale();
 
     let t0 = await comet.totalsBasic();
-    t0 = Object.assign({}, t0, {
+    t0 = await setTotalsBasic(comet, {
       baseBorrowIndex: t0.baseBorrowIndex.mul(2),
     });
-    await comet.setTotalsBasic(t0);
 
     await comet.connect(alice).transferAsset(bob.address, USDC.address, 100e6);
 

--- a/test/withdraw-reserves-test.ts
+++ b/test/withdraw-reserves-test.ts
@@ -1,4 +1,4 @@
-import { expect, makeProtocol, wait } from './helpers';
+import { expect, makeProtocol, setTotalsBasic, wait } from './helpers';
 
 describe('withdrawReserves', function () {
   it('withdraws reserves from the protocol', async () => {
@@ -53,12 +53,10 @@ describe('withdrawReserves', function () {
 
     const totalsBasic = await comet.totalsBasic();
 
-    await wait(
-      comet.setTotalsBasic({
-        ...totalsBasic,
-        totalSupplyBase: 100n,
-      })
-    );
+    await setTotalsBasic(comet, {
+      baseSupplyIndex: 2e15,
+      totalSupplyBase: 50n,
+    });
 
     expect(await comet.getReserves()).to.be.equal(100);
 

--- a/test/withdraw-test.ts
+++ b/test/withdraw-test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from "ethers";
 import { EvilToken, EvilToken__factory, FaucetToken } from '../build/types';
-import { ethers, event, expect, exp, makeProtocol, portfolio, ReentryAttack, wait } from './helpers';
+import { ethers, event, expect, exp, makeProtocol, portfolio, ReentryAttack, setTotalsBasic, wait } from './helpers';
 
 describe('withdrawTo', function () {
   it('withdraws base from sender if the asset is base', async () => {
@@ -9,10 +9,9 @@ describe('withdrawTo', function () {
     const { USDC } = tokens;
 
     const i0 = await USDC.allocateTo(comet.address, 100e6);
-    const t0 = Object.assign({}, await comet.totalsBasic(), {
+    const t0 = await setTotalsBasic(comet, {
       totalSupplyBase: 100e6,
     });
-    const b0 = await wait(comet.setTotalsBasic(t0));
 
     const i1 = await comet.setBasePrincipal(bob.address, 100e6);
     const cometAsB = comet.connect(bob);
@@ -114,11 +113,10 @@ describe('withdrawTo', function () {
     const { USDC } = tokens;
 
     await USDC.allocateTo(comet.address, 100e6);
-    const totals0 = Object.assign({}, await comet.totalsBasic(), {
+    const totals0 = await setTotalsBasic(comet, {
       baseSupplyIndex: 2e15,
       totalSupplyBase: 50e6, // 100e6 in present value
     });
-    await wait(comet.setTotalsBasic(totals0));
 
     await comet.setBasePrincipal(bob.address, 50e6); // 100e6 in present value
     const cometAsB = comet.connect(bob);
@@ -200,10 +198,9 @@ describe('withdrawTo', function () {
     await comet.setCollateralBalance(alice.address, WETH.address, exp(1,18));
 
     let t0 = await comet.totalsBasic();
-    t0 = Object.assign({}, t0, {
+    t0 = await setTotalsBasic(comet, {
       baseBorrowIndex: t0.baseBorrowIndex.mul(2),
     });
-    await comet.setTotalsBasic(t0);
 
     await comet.connect(alice).withdrawTo(bob.address, USDC.address, 1e6);
 
@@ -222,10 +219,9 @@ describe('withdraw', function () {
     const { USDC } = tokens;
 
     const i0 = await USDC.allocateTo(comet.address, 100e6);
-    const t0 = Object.assign({}, await comet.totalsBasic(), {
+    const t0 = await setTotalsBasic(comet, {
       totalSupplyBase: 100e6,
     });
-    const b0 = await wait(comet.setTotalsBasic(t0));
 
     const i1 = await comet.setBasePrincipal(bob.address, 100e6);
     const cometAsB = comet.connect(bob);


### PR DESCRIPTION
Fixes bug 5.2 caught in the ChainSecurity audit, where the wrong index was used to calculate `borrowBalanceOf` in `CometExt.sol`. This bug slipped through our unit tests because our unit tests were using the same default values of `1e15` for both `baseSupplyIndex` and `baseBorrowIndex`. This PR modifies the base indices for many of the existing unit tests.

This PR also refactors the `setTotalsBasic` logic used throughout our unit tests into a separate helper function. 