### PR TITLE
rename Configurator admin to governor

### DIFF
--- a/contracts/Configurator.sol
+++ b/contracts/Configurator.sol
@@ -9,7 +9,7 @@ contract Configurator is ConfiguratorStorage {
 
     /// @notice An event emitted when a new version Comet is deployed.
     event CometDeployed(address newCometAddress); // XXX Get rid of uses of the `Comet` name
-    event AdminTransferred(address oldAdmin, address newAdmin);
+    event GovernorTransferred(address oldGovernor, address newGovernor);
 
     /// @notice An error given unauthorized method calls
     error Unauthorized();
@@ -17,36 +17,36 @@ contract Configurator is ConfiguratorStorage {
     error InvalidAddress();
 
     /// @notice Initializes the storage for Configurator
-    function initialize(address _admin, address _factory, Configuration calldata _config) public {
+    function initialize(address _governor, address _factory, Configuration calldata _config) public {
         if (version != 0) revert AlreadyInitialized();
-        if (_admin == address(0)) revert InvalidAddress();
+        if (_governor == address(0)) revert InvalidAddress();
         if (_factory == address(0)) revert InvalidAddress();
 
-        admin = _admin;
+        governor = _governor;
         factory = _factory;
         configuratorParams = _config;
         version = 1;
     }
 
     /// @notice Sets the factory for Configurator
-    /// @dev only callable by admin
+    /// @dev only callable by governor
     function setFactory(address _factory) external {
-        if (msg.sender != admin) revert Unauthorized();
+        if (msg.sender != governor) revert Unauthorized();
         factory = _factory;
     }
 
     // XXX Define other setters for setting params
-    /// @dev only callable by admin
+    /// @dev only callable by governor
     function setGovernor(address _governor) external {
-        if (msg.sender != admin) revert Unauthorized();
+        if (msg.sender != governor) revert Unauthorized();
         configuratorParams.governor = _governor;
     }
 
     // XXX What about removing an asset?
     // XXX Should we check MAX_ASSETS here as well?
-    /// @dev only callable by admin
+    /// @dev only callable by governor
     function addAsset(AssetConfig calldata asset) external {
-        if (msg.sender != admin) revert Unauthorized();
+        if (msg.sender != governor) revert Unauthorized();
         configuratorParams.assetConfigs.push(asset);
     }
 
@@ -63,12 +63,12 @@ contract Configurator is ConfiguratorStorage {
         return newComet;
     }
 
-    /// @notice Transfers the admin rights to a new address
-    /// @dev only callable by admin
-    function transferAdmin(address newAdmin) external {
-        if (msg.sender != admin) revert Unauthorized();
-        address oldAdmin = admin;
-        admin = newAdmin;
-        emit AdminTransferred(oldAdmin, newAdmin);
+    /// @notice Transfers the governor rights to a new address
+    /// @dev only callable by governor
+    function transferGovernor(address newGovernor) external {
+        if (msg.sender != governor) revert Unauthorized();
+        address oldGovernor = governor;
+        governor = newGovernor;
+        emit GovernorTransferred(oldGovernor, newGovernor);
     }
 }

--- a/contracts/ConfiguratorStorage.sol
+++ b/contracts/ConfiguratorStorage.sol
@@ -20,8 +20,8 @@ contract ConfiguratorStorage is CometConfiguration {
     /// getters created for public variables.
     Configuration internal configuratorParams; // XXX can create a public getter for this
 
-    /// @notice The admin of the protocol
-    address public admin; 
+    /// @notice The governor of the protocol
+    address public governor;
 
     /// @notice Address for the Comet factory contract
     address public factory;

--- a/test/configurator-test.ts
+++ b/test/configurator-test.ts
@@ -51,7 +51,7 @@ describe('configurator', function () {
     await proxyAdmin.transferOwnership(timelock.address);
 
     const configuratorAsProxy = configurator.attach(configuratorProxy.address);
-    await configuratorAsProxy.transferAdmin(timelock.address); // set timelock as admin of Configurator
+    await configuratorAsProxy.transferGovernor(timelock.address); // set timelock as admin of Configurator
 
     expect((await configuratorAsProxy.getConfiguration()).governor).to.be.equal(governor.address);
 
@@ -60,7 +60,7 @@ describe('configurator', function () {
     let setGovernorCalldata = ethers.utils.defaultAbiCoder.encode(["address"], [alice.address]);
     let deployAndUpgradeToCalldata = ethers.utils.defaultAbiCoder.encode(["address", "address"], [configuratorProxy.address, cometProxy.address]);
     await timelock.execute([configuratorProxy.address, proxyAdmin.address], [0, 0], ["setGovernor(address)", "deployAndUpgradeTo(address,address)"], [setGovernorCalldata, deployAndUpgradeToCalldata]);
-    
+
     expect((await configuratorAsProxy.getConfiguration()).governor).to.be.equal(alice.address);
   });
 


### PR DESCRIPTION
Opening as a separate PR against `silver/duplicate-definition` since this feels like a potentially consequential change.

Part of the ABI de-duplication from #278 

Once scenarios are running again, I can confirm that this removes the `duplicate definition - admin` logs