### PR TITLE
[ChainSecurity 5.15] Gas optimization to sometimes avoid base price checks

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -508,13 +508,13 @@ contract Comet is CometCore {
      * @return Whether the account is minimally collateralized enough to borrow
      */
     function isBorrowCollateralized(address account) public view returns (bool) {
-        uint16 assetsIn = userBasic[account].assetsIn;
         int104 principal = userBasic[account].principal;
 
         if (principal >= 0) {
             return true;
         }
 
+        uint16 assetsIn = userBasic[account].assetsIn;
         int liquidity = signedMulPrice(
             presentValue(principal),
             getPrice(baseTokenPriceFeed),
@@ -581,13 +581,13 @@ contract Comet is CometCore {
      * @return Whether the account is minimally collateralized enough to not be liquidated
      */
     function isLiquidatable(address account) public view returns (bool) {
-        uint16 assetsIn = userBasic[account].assetsIn;
         int104 principal = userBasic[account].principal;
 
         if (principal >= 0) {
             return false;
         }
 
+        uint16 assetsIn = userBasic[account].assetsIn;
         int liquidity = signedMulPrice(
             presentValue(principal),
             getPrice(baseTokenPriceFeed),


### PR DESCRIPTION
Have not benchmarked gas impact yet, adds ~100 bytes to contract size.

EDIT: Gas benchmarking results are commented below.

tldr: Saves a large amount of gas (~25k) whenever liquidity checks can be skipped. Otherwise, the extra `if` statement adds a tiny bit of gas (~50) to most other calls.