### PR TITLE
Delete --quiet flag

### DIFF
--- a/tasks/scenario/task.ts
+++ b/tasks/scenario/task.ts
@@ -27,15 +27,10 @@ task('scenario', 'Runs scenario tests')
   .addOptionalParam('bases', 'Bases to run on [defaults to all]')
   .addFlag('noSpider', 'skip spider')
   .addFlag('sync', 'run synchronously')
-  .addFlag('quiet', 'set Ethers log level to OFF')
   .addOptionalParam('stall', 'milliseconds to wait until we fail for stalling', 120000, types.int)
   .addOptionalParam('workers', 'count of workers', 6, types.int)
   .setAction(async (taskArgs, env: HardhatRuntimeEnvironment) => {
     let bases: ForkSpec[] = getBasesFromTaskArgs(taskArgs.bases, env);
-
-    if (taskArgs.quiet) {
-      env.ethers.utils.Logger.setLogLevel(env.ethers.utils.Logger.levels.OFF);
-    }
 
     if (!taskArgs.noSpider) {
       await env.run('scenario:spider', taskArgs);


### PR DESCRIPTION
Now that #278 is merged, we shouldn't need the `--quiet` flag any longer.

It was more of a band-aid than an actual fix, and only worked in combination with the `--sync` flag. Probably not worth keeping around.

This reverts commit 7b4bd0b13b068b054de9af39413109899348bed1.