### PR TITLE
don't return stale migration loader (`Cannot find contract 'WBTC.e$'`)

### DIFF
--- a/plugins/deployment_manager/Migration.ts
+++ b/plugins/deployment_manager/Migration.ts
@@ -40,10 +40,6 @@ export class Loader<T> {
 export let loader: any;
 
 export function setupLoader<T>() {
-  if (loader) {
-    return loader;
-  }
-
   loader = new Loader<T>();
 }
 


### PR DESCRIPTION
I think I found the source of the intermittent scenario failure `Cannot find contract 'WBTC.e$'`.

Before the failure occurs, we log the following line:

```
[MigrationConstraint] Running scenario with migrations: ["1644388553_deploy_kovan","1644432723_deploy_fuji","1649108513_upgrade_timelock_and_set_up_governor","1649117302_upgrade_timelock_and_set_up_governor"]
```

That list includes Kovan and Fuji migrations; but with the way we construct the glob of migrations to run, we should only be loading `/deployments/kovan/migrations/**.ts` or `/deployments/fuji/migrations/**.ts`, not both:

```
// scenario/constraints/MigrationConstraint.ts:45
let migrationsGlob = path.join('deployments', context.deploymentManager.network(), 'migrations', '**.ts');
let migrations = Object.values(await loadMigrations(migrationsGlob));
```

But if you look at `loadMigrations`, we construct a `Loader` instance and store it in the `loader` variable. If `setupLoader` gets called a second time, we return the already constructed loader (that's my change; the original code threw an error if it was called twice).

I think this loader is stale when we run multiple bases; the loader gets loaded with the Kovan migrations and later has the Fuji migrations added to it. Then we attempt to run the scenario after applying both Kovan and Fuji migrations.

If we just return a fresh instance of `Loader` when we call `setupLoader`, we should avoid this issue.


