### PR TITLE
Make getAssetInfoByAddress public and update visibility of functions in CometInterface

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -553,7 +553,7 @@ contract Comet is CometMainInterface {
      * @param account The address to check liquidity for
      * @return The common price quantity of borrow liquidity
      */
-    function getBorrowLiquidity(address account) override public view returns (int) {
+    function getBorrowLiquidity(address account) override external view returns (int) {
         uint16 assetsIn = userBasic[account].assetsIn;
 
         int liquidity = signedMulPrice(
@@ -626,7 +626,7 @@ contract Comet is CometMainInterface {
      * @param account The address to check margin for
      * @return The common price quantity of liquidation margin
      */
-    function getLiquidationMargin(address account) override public view returns (int) {
+    function getLiquidationMargin(address account) override external view returns (int) {
         uint16 assetsIn = userBasic[account].assetsIn;
 
         int liquidity = signedMulPrice(

--- a/contracts/CometMainInterface.sol
+++ b/contracts/CometMainInterface.sol
@@ -54,8 +54,8 @@ abstract contract CometMainInterface is CometCore {
 
     function isBorrowCollateralized(address account) virtual public view returns (bool);
     function isLiquidatable(address account) virtual public view returns (bool);
-    function getBorrowLiquidity(address account) virtual public view returns (int);
-    function getLiquidationMargin(address account) virtual public view returns (int);
+    function getBorrowLiquidity(address account) virtual external view returns (int);
+    function getLiquidationMargin(address account) virtual external view returns (int);
 
     function totalSupply() virtual external view returns (uint256);
     function balanceOf(address owner) virtual external view returns (uint256);

--- a/docs/README.md
+++ b/docs/README.md
@@ -228,7 +228,7 @@ This function returns the amount of base asset in USD that is presently borrowab
 #### Comet
 
 ```solidity
-function getBorrowLiquidity(address account) public view returns (int)
+function getBorrowLiquidity(address account) external view returns (int)
 ```
 
 * `account`: The account to examine borrow liquidity.
@@ -308,7 +308,7 @@ This function returns the USD value of liquidity available before the specified 
 #### Comet
 
 ```solidity
-function getLiquidationMargin(address account) public view returns (int)
+function getLiquidationMargin(address account) external view returns (int)
 ```
 
 * `account`: The account to examine liquidity available.
@@ -1105,7 +1105,7 @@ struct AssetInfo {
     uint128 supplyCap;
 }
 
-function getAssetInfo(uint8 i) returns (AssetInfo memory)
+function getAssetInfo(uint8 i) public view returns (AssetInfo memory)
 ```
 
 * `i`: The index of the asset based on the order it was added to the protocol. The index begins at `0`.
@@ -1138,6 +1138,59 @@ const infoObject = await comet.methods.getAssetInfo(0).call();
 ```js
 const comet = new ethers.Contract(contractAddress, abiJson, provider);
 const infoObject = await comet.callStatic.getAssetInfo(0);
+```
+
+### Get Asset Info By Address
+
+This method returns asset information of a specific asset.
+
+#### Comet
+
+```solidity
+struct AssetInfo {
+    uint8 offset;
+    address asset;
+    address priceFeed;
+    uint64 scale;
+    uint64 borrowCollateralFactor;
+    uint64 liquidateCollateralFactor;
+    uint64 liquidationFactor;
+    uint128 supplyCap;
+}
+
+function getAssetInfoByAddress(address asset) public view returns (AssetInfo memory)
+```
+
+* `address`: The address of the asset.
+* `RETURNS`: The asset information as a struct called `AssetInfo`.
+* `offset`: The index of the asset based on the order it was added to the protocol.
+* `asset`: The address of the asset's smart contract.
+* `priceFeed`: The address of the price feed contract for this asset.
+* `scale`: An integer that equals `10 ^ x` where `x` is the amount of decimal places in the asset's smart contract.
+* `borrowCollateralFactor`: The collateral factor as an integer that represents the decimal value scaled up by `10 ^ 18`.
+* `liquidateCollateralFactor`: The liquidate collateral factor as an integer that represents the decimal value scaled up by `10 ^ 18`.
+* `liquidationFactor`: The liquidation factor as an integer that represents the decimal value scaled up by `10 ^ 18`.
+* `supplyCap`: The supply cap of the asset as an integer scaled up by `10 ^ x` where `x` is the amount of decimal places in the asset's smart contract.
+
+#### Solidity
+
+```solidity
+Comet comet = Comet(0xCometAddress);
+AssetInfo info = comet.getAssetInfoByAddress(0xAsset);
+```
+
+#### Web3.js v1.5.x
+
+```js
+const comet = new web3.eth.Contract(abiJson, contractAddress);
+const infoObject = await comet.methods.getAssetInfoByAddress('0xAsset').call();
+```
+
+#### Ethers.js v5.x
+
+```js
+const comet = new ethers.Contract(contractAddress, abiJson, provider);
+const infoObject = await comet.callStatic.getAssetInfoByAddress('0xAsset');
 ```
 
 ### Get Price


### PR DESCRIPTION
Other than `getAssetInfoByAddress` which changed from `internal` to `public`, all the other changes are changing between `public` and `external`.