### PR TITLE
Properly catch scenario errors originating from applying solutions

### DIFF
--- a/plugins/scenario/Runner.ts
+++ b/plugins/scenario/Runner.ts
@@ -84,17 +84,17 @@ export class Runner<T, U, R> {
       // create a fresh copy of context that solutions can modify
       let ctx: T = await scenario.forker(context);
 
-      // apply each solution in the combo, then check they all still hold
-      for (const solution of combo) {
-        ctx = (await solution(ctx, world)) || ctx;
-      }
-
-      for (const constraint of constraints) {
-        await constraint.check(scenario.requirements, ctx, world);
-      }
-
-      // requirements met, run the property
       try {
+        // apply each solution in the combo, then check they all still hold
+        for (const solution of combo) {
+          ctx = (await solution(ctx, world)) || ctx;
+        }
+
+        for (const constraint of constraints) {
+          await constraint.check(scenario.requirements, ctx, world);
+        }
+
+        // requirements met, run the property
         let txnReceipt = await scenario.property(await scenario.transformer(ctx), world, ctx);
         if (txnReceipt) {
           cumulativeGas += txnReceipt.cumulativeGasUsed.toNumber();


### PR DESCRIPTION
Previously, any exception thrown in a solution or its checker will end the entire scenario runner. This change will allow the scenario runner to keep running so we get a summary of all the scenarios run even if there is an exception in a solution/checker.