### PR TITLE
Expect SupplyCapExceeded error in supply collateral scenario if supply cap will be exceeded

### DIFF
--- a/scenario/SupplyScenario.ts
+++ b/scenario/SupplyScenario.ts
@@ -33,6 +33,8 @@ scenario(
   }
 );
 
+// XXX introduce a SupplyCapConstraint to separately test the happy path and revert path instead
+// of testing them conditionally
 scenario(
   'Comet#supply > collateral asset',
   {
@@ -135,6 +137,8 @@ scenario(
   }
 );
 
+// XXX introduce a SupplyCapConstraint to separately test the happy path and revert path instead
+// of testing them conditionally
 scenario(
   'Comet#supplyFrom > collateral asset',
   {


### PR DESCRIPTION
The happy path for supply collateral scenarios are failing due to `SupplyCapExceeded()` errors on  Kovan because there is already a good amount supplied there. This fix applies a conditional check to the scenario such that it will expect a revert if the amount supplied will exceed the supply cap.