### PR TITLE
Bandaid solution for withdraw reserves scenario

### DIFF
--- a/scenario/WithdrawReservesScenario.ts
+++ b/scenario/WithdrawReservesScenario.ts
@@ -2,25 +2,30 @@ import { scenario } from './context/CometContext';
 import { expect } from 'chai';
 import { utils } from 'ethers';
 
+// XXX we could use a Comet reserves constraint here
 scenario(
   'Comet#withdrawReserves > governor withdraw reserves',
   {
     tokenBalances: {
-      $comet: { $base: 100 },
+      betty: { $base: 100 },
     },
     upgrade: true,
   },
   async ({ comet, timelock, actors }, world, context) => {
-    const { albert } = actors;
+    const { albert, betty } = actors;
 
     const baseToken = context.getAssetByAddress(await comet.baseToken());
     const scale = (await comet.baseScale()).toBigInt();
 
-    expect(await baseToken.balanceOf(comet.address)).to.equal(100n * scale);
+    // Since we don't have a constraint to set Comet reserves, we'll be transferring 100 base tokens to Comet from an actor
+    // XXX however, this wouldn't work if reserves on testnet are negative
+    await betty.transferErc20(baseToken.address, comet.address, 100n * scale);
+    const cometBaseBalance = await baseToken.balanceOf(comet.address);
 
     expect(await comet.governor()).to.equal(timelock.address);
 
-    let withdrawReservesCalldata = utils.defaultAbiCoder.encode(["address", "uint256"], [albert.address, 10n * scale]);
+    const toWithdrawAmount = 10n * scale;
+    let withdrawReservesCalldata = utils.defaultAbiCoder.encode(["address", "uint256"], [albert.address, toWithdrawAmount]);
     const txn = await context.fastGovernanceExecute(
       [comet.address],
       [0],
@@ -28,8 +33,8 @@ scenario(
       [withdrawReservesCalldata]
     );
 
-    expect(await baseToken.balanceOf(comet.address)).to.equal(90n * scale);
-    expect(await baseToken.balanceOf(albert.address)).to.equal(10n * scale);
+    expect(await baseToken.balanceOf(comet.address)).to.equal(cometBaseBalance - toWithdrawAmount);
+    expect(await baseToken.balanceOf(albert.address)).to.equal(toWithdrawAmount);
 
     return txn; // return txn to measure gas
   }

--- a/scenario/context/CometActor.ts
+++ b/scenario/context/CometActor.ts
@@ -66,6 +66,11 @@ export default class CometActor {
     await tx.wait();
   }
 
+  async transferErc20(tokenAddress: string, dst: string, amount: bigint): Promise<ContractReceipt> {
+    let erc20 = ERC20__factory.connect(tokenAddress, this.signer);
+    return await (await erc20.transfer(dst, amount)).wait();
+  }
+
   async allow(manager: CometActor, isAllowed: boolean): Promise<ContractReceipt> {
     let comet = await this.context.getComet();
     return await (await comet.connect(this.signer).allow(manager.address, isAllowed)).wait();


### PR DESCRIPTION
Withdraw reserves scenarios are failing on Kovan because there are not enough reserves to withdraw. The longer-term fix is to implement a reserves constraint. This short-term fix transfers some base asset from an actor to Comet to create the reserves. However, this scenario may still fail if there are negative reserves on testnet.