### PR TITLE
Accrue inside getReserves and add totalBorrow()

### DIFF
--- a/contracts/CometMainInterface.sol
+++ b/contracts/CometMainInterface.sol
@@ -58,6 +58,7 @@ abstract contract CometMainInterface is CometCore {
     function getLiquidationMargin(address account) virtual external view returns (int);
 
     function totalSupply() virtual external view returns (uint256);
+    function totalBorrow() virtual external view returns (uint256);
     function balanceOf(address owner) virtual external view returns (uint256);
     function borrowBalanceOf(address account) virtual external view returns (uint256);
 

--- a/test/balance-test.ts
+++ b/test/balance-test.ts
@@ -1,0 +1,38 @@
+import { expect, makeProtocol, setTotalsBasic } from './helpers';
+
+describe('totalBorrow', function () {
+  it('has correct totalBorrow', async () => {
+    const { comet } = await makeProtocol();
+    await setTotalsBasic(comet, {
+      baseBorrowIndex: 2e15,
+      totalBorrowBase: 50e6,
+    });
+    expect(await comet.totalBorrow()).to.eq(100e6);
+  });
+});
+
+describe('borrowBalanceOf', function () {
+  it('returns borrow amount (when principal amount is negative)', async () => {
+    const { comet, users: [user] } = await makeProtocol();
+    await setTotalsBasic(comet, {
+      baseSupplyIndex: 2e15,
+      baseBorrowIndex: 3e15,
+    });
+    await comet.setBasePrincipal(user.address, -100e6); // borrow of $100 USDC
+    const borrowBalanceOf = await comet.borrowBalanceOf(user.address);
+    expect(borrowBalanceOf).to.eq(300e6) // baseSupplyIndex = 3e15
+  });
+
+  it('returns 0 when principal amount is positive', async () => {
+    const { comet, users: [user] } = await makeProtocol();
+    await setTotalsBasic(comet, {
+      baseSupplyIndex: 2e15,
+      baseBorrowIndex: 3e15,
+    });
+    await comet.setBasePrincipal(user.address, 100e6);
+    const borrowBalanceOf = await comet.borrowBalanceOf(user.address);
+    expect(borrowBalanceOf).to.eq(0);
+  });
+});
+
+// XXX test implicit interest accrual explicitly

--- a/test/comet-ext-test.ts
+++ b/test/comet-ext-test.ts
@@ -31,22 +31,6 @@ describe('CometExt', function () {
     expect(priceScale).to.eq(exp(1, 8));
   });
 
-  describe('borrowBalanceOf', function () {
-    it('returns borrow amount (when principal amount is negative)', async () => {
-      await comet.setBasePrincipal(user.address, -100e6); // borrow of $100 USDC
-
-      const borrowBalanceOf = await comet.borrowBalanceOf(user.address);
-      expect(borrowBalanceOf).to.eq(300e6) // baseSupplyIndex = 3e15
-    });
-
-    it('returns 0 when principal amount is positive', async () => {
-      await comet.setBasePrincipal(user.address, 100e6);
-
-      const borrowBalanceOf = await comet.borrowBalanceOf(user.address);
-      expect(borrowBalanceOf).to.eq(0);
-    });
-  });
-
   it('returns collateralBalance (in units of the collateral asset)', async () => {
     const { WETH } = tokens;
 


### PR DESCRIPTION
Based on feedback from integrating UI, also added notes to rate model fns which explicitly do *not* accrue.

Not sure whether it's better to drop the `accrueInternal` on `withdrawReserves` and `buyCollateral`. If we do, it only saves 16 bytes contract size and a little gas, and probably the most audit-worthy change.

We also need a test for the new `totalBorrow` fn.