### PR TITLE
Update verification script and create a new script for upgrading Comet on testnets

### DIFF
--- a/scripts/upgrade-comet.ts
+++ b/scripts/upgrade-comet.ts
@@ -12,8 +12,6 @@ import {
 import { utils } from 'ethers';
 import { CometInterface, GovernorSimple } from '../build/types';
 
-const delay = ms => new Promise(res => setTimeout(res, ms));
-
 /**
  * Creates and queues a proposal that updates some `Comet` configuration and then deploys
  * a new version and upgrades to it.
@@ -38,8 +36,8 @@ async function main() {
   const configurator = await dm.contract('configurator') as Configurator;
   const governorAsAdmin = governor.connect(admin);
 
-  const setPauseGuardianCalldata = ethers.utils.defaultAbiCoder.encode(["address"], [signers[1].address]);
-  const deployAndUpgradeToCalldata = utils.defaultAbiCoder.encode(["address", "address"], [configurator.address, comet.address]);
+  const setPauseGuardianCalldata = ethers.utils.defaultAbiCoder.encode(['address'], [signers[1].address]);
+  const deployAndUpgradeToCalldata = utils.defaultAbiCoder.encode(['address', 'address'], [configurator.address, comet.address]);
   let tx = await (await governorAsAdmin.propose(
     [
       configurator.address,
@@ -50,8 +48,8 @@ async function main() {
       0,
     ],
     [
-      "setPauseGuardian(address)",
-      "deployAndUpgradeTo(address,address)",
+      'setPauseGuardian(address)',
+      'deployAndUpgradeTo(address,address)',
     ],
     [
       setPauseGuardianCalldata,

--- a/scripts/verify-comet.ts
+++ b/scripts/verify-comet.ts
@@ -8,8 +8,6 @@ import { DeploymentManager } from '../plugins/deployment_manager/DeploymentManag
 import { Configurator } from '../build/types';
 import { ConfigurationStruct } from '../build/types/CometFactory';
 
-const delay = ms => new Promise(res => setTimeout(res, ms));
-
 async function verifyContract(address: string, constructorArguments) {
   try {
     return await hre.run('verify:verify', {
@@ -43,8 +41,6 @@ async function main() {
     verifyContracts: !isDevelopment,
     debug: true,
   });
-
-  let signers = await dm.hre.ethers.getSigners();
 
   const configurator = await dm.contract('configurator') as Configurator;
   let config: ConfigurationStruct = await configurator.getConfiguration();


### PR DESCRIPTION
Looks like we no longer need the "hack" solution for verifying a factory-deployed version of Comet 🎉🎉🎉

Steps I took to test that verification now works:
1. Run deployment migration script on Kovan to create a new batch of contracts.
2. Update `roots.json` and then run Spider.
3. Run the `upgrade-comet.ts` script to create + queue a new proposal to upgrade Comet.
4. Execute the proposal manually on Etherscan.
5. Find the new factory-created Comet contract from executing the proposal.
6. Check that it is unverified on Etherscan.
7. Run the `verify-comet.ts` script.
8. Check that it is now verified on Etherscan.