### PR TITLE
Add a workflow to run spider and upload artifacts

### DIFF
--- a/.github/workflows/run-spider.yaml
+++ b/.github/workflows/run-spider.yaml
@@ -1,0 +1,33 @@
+name: 'Run Spider'
+on:
+  workflow_dispatch:
+  pull_request:
+jobs:
+  run_spider:
+    name: Run Spider
+    runs-on: ubuntu-latest
+    env:
+      ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_KEY }}
+      SNOWTRACE_KEY: ${{ secrets.SNOWTRACE_KEY }}
+      INFURA_KEY: ${{ secrets.INFURA_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install packages
+        run: yarn install --non-interactive --frozen-lockfile
+
+      - name: Run Spider
+        run: |
+          for k in `ls deployments | grep -v .ts`; do yarn hardhat spider --network $k; done
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: deployments
+          path: deployments/
+          retention-days: 365 # TODO: should we have another flow to copy to permanent release?
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -4832,7 +4832,7 @@ hardhat-contract-sizer@^2.4.0:
 
 hardhat-cover@compound-finance/hardhat-cover:
   version "1.0.0"
-  resolved "https://codeload.github.com/compound-finance/hardhat-cover/tar.gz/b8d86dc7f259e033c598b377874ac7f23c628837"
+  resolved "https://codeload.github.com/compound-finance/hardhat-cover/tar.gz/4e312abb3552723e7ca17daef6e10a38d20f10be"
 
 hardhat-gas-reporter@^1.0.7:
   version "1.0.7"


### PR DESCRIPTION
This adds a workflow which runs spider and uploads the artifacts to GitHub. We'll probably want to store these permanently under a release at some point, but we could decouple that question and merge this so that future PRs with different `roots.json` can be used to wire up a version of the interface.