### PR TITLE
Allow SimpleTimelock to receive ether

### DIFF
--- a/contracts/test/SimpleTimelock.sol
+++ b/contracts/test/SimpleTimelock.sol
@@ -19,6 +19,8 @@ contract SimpleTimelock {
         admin = admin_;
     }
 
+    receive() external payable {}
+
     function setAdmin(address newAdmin) public {
         if (msg.sender != address(this)) revert Unauthorized(); // call must come from Timelock itself
         admin = newAdmin;


### PR DESCRIPTION
To match the functionality of [Timelock](https://github.com/compound-finance/compound-protocol/blob/b9b14038612d846b83f8a009a82c38974ff2dcfe/contracts/Timelock.sol#L34) on mainnet.

This will allow us to seed the SimpleTimelock with some ether so we can impersonate it to source tokens from it.