### PR TITLE
Add cached/cloned to DeploymentManager for idempotency in migrations

### DIFF
--- a/plugins/deployment_manager/ContractMap.ts
+++ b/plugins/deployment_manager/ContractMap.ts
@@ -1,7 +1,7 @@
 import { Contract, Signer } from 'ethers';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 
-import { Cache, FileSpec } from './Cache';
+import { Cache, FileSpec, FindSpec } from './Cache';
 import { ABI, Address, Alias, BuildFile } from './Types';
 import { Aliases, getAliases } from './Aliases';
 import { Proxies, getProxies } from './Proxies';
@@ -92,12 +92,21 @@ function getFileSpec(address: Address): FileSpec {
   return { rel: ['contracts', address + '.json'] };
 }
 
+function getFindSpec(): FindSpec {
+  return { rel: ['contracts'], key: p => p.match(/(0x[a-f0-9]{40}).json/)[1] };
+}
+
 export async function getBuildFile(cache: Cache, address: Address): Promise<BuildFile> {
   return await cache.readCache<BuildFile>(getFileSpec(address));
 }
 
 export async function storeBuildFile(cache: Cache, address: Address, buildFile: BuildFile) {
   await cache.storeCache(getFileSpec(address), buildFile);
+}
+
+export async function getAddressForContract(cache: Cache, contract: string) {
+  // XXX searching just by name is error-prone, but this is mainly a debugging tool
+  return cache.findCacheKey(getFindSpec(), v => v.contract === contract);
 }
 
 async function getRequiredBuildFile(

--- a/plugins/deployment_manager/Utils.ts
+++ b/plugins/deployment_manager/Utils.ts
@@ -33,6 +33,10 @@ export async function fileExists(path: string): Promise<boolean> {
   }
 }
 
+export async function ls(path: string): Promise<string[]> {
+  return fs.readdir(path);
+}
+
 export function getPrimaryContract(buildFile: BuildFile): [string, ContractMetadata] {
   let targetContract = buildFile.contract;
   if (!targetContract) {


### PR DESCRIPTION
This adds a few fns to DeploymentManager that can be used in migration scripts instead of `deploy` (`cached`) and `clone` (`cloned`). Using these, one can transform a valid migration script into a (partially) idempotent version which can reuse existing deployments at will. This is primarily useful for debugging, and should not be used in migration scripts run in production, since searching artifacts by contract name is not a reliable process.