### PR TITLE
zero fee for transfer when sourcing tokens

### DIFF
--- a/scenario/context/CometAsset.ts
+++ b/scenario/context/CometAsset.ts
@@ -1,4 +1,4 @@
-import { BigNumberish, Contract, Signer } from 'ethers';
+import { BigNumberish, Contract, Overrides, Signer } from 'ethers';
 import { ERC20 } from '../../build/types';
 import CometActor from './CometActor';
 import { AddressLike, resolveAddress } from './Address';
@@ -29,10 +29,10 @@ export default class CometAsset {
     return (await this.token.balanceOf(address)).toBigInt();
   }
 
-  async transfer(from: CometActor, amount: number | bigint, recipient: CometAsset | string) {
+  async transfer(from: CometActor, amount: number | bigint, recipient: CometAsset | string, overrides: Overrides = {}) {
     let recipientAddress = typeof(recipient) === 'string' ? recipient : recipient.address;
 
-    await wait(this.token.connect(from.signer).transfer(recipientAddress, amount));
+    await wait(this.token.connect(from.signer).transfer(recipientAddress, amount, overrides));
   }
 
   async approve(from: CometActor, spender: AddressLike, amount?: number | bigint) {

--- a/scenario/context/CometContext.ts
+++ b/scenario/context/CometContext.ts
@@ -169,7 +169,9 @@ export class CometContext {
       let actorBalance = await cometAsset.balanceOf(actor);
       if (actorBalance > amount) {
         this.debug(`Source Tokens: stealing from actor ${name}`);
-        await cometAsset.transfer(actor, amount, recipientAddress);
+        // make gas fee 0 so we can source from contract addresses as well as EOAs
+        await world.hre.network.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x0']);
+        await cometAsset.transfer(actor, amount, recipientAddress, {gasPrice: 0});
         return;
       }
     }


### PR DESCRIPTION
Scenarios are still broken, but will solve this issue:

```
Comet#withdraw reverts if borrow is less than minimum borrow [1 run]@kovan: Error InvalidInputError: sender doesn't have enough funds to send tx. The max upfront cost is: 57434000804076 and the sender's account only has: 0
```