### PR TITLE
disable Fuji seed_rewards_with_comp migration

### DIFF
--- a/deployments/fuji/migrations/1653512197_seed_rewards_with_comp.ts
+++ b/deployments/fuji/migrations/1653512197_seed_rewards_with_comp.ts
@@ -11,6 +11,9 @@ migration<Vars>('1653512197_seed_rewards_with_comp', {
     return {};
   },
   enact: async (deploymentManager: DeploymentManager, vars: Vars) => {
+    /*
+    XXX enable once COMP (or another reward token) is added for Fuji
+
     let [signer] = await deploymentManager.hre.ethers.getSigners();
 
     const timelock = await deploymentManager.contract('timelock') as SimpleTimelock;
@@ -67,6 +70,8 @@ migration<Vars>('1653512197_seed_rewards_with_comp', {
     // console.log("COMP balance of Timelock: ", await COMP.balanceOf(timelock.address));
     // console.log("COMP balance of CometRewards: ", await COMP.balanceOf(rewards.address));
     // console.log("RewardConfig: ", await rewards.rewardConfig(comet.address));
+
+    */
   },
   enacted: async (deploymentManager: DeploymentManager) => {
     return false;


### PR DESCRIPTION
COMP doesn't exist on Fuji yet, so the `seed_rewards_with_comp` migration fails when run by the `MigrationConstraint`:

<img width="971" alt="image" src="https://user-images.githubusercontent.com/2570291/171452560-602ac9c3-a756-4ce6-b9c7-b238dd0a4dd4.png">

In #358 , Kevin mentioned that we're not running this migration yet on Fuji.

Commenting out the body of it so scenarios pass until we enable add a reward token on Fuji.