### PR TITLE
[N08] Disallow reconfiguring a Comet rewards token

### DIFF
--- a/contracts/CometRewards.sol
+++ b/contracts/CometRewards.sol
@@ -37,6 +37,7 @@ contract CometRewards {
 
     /** Custom errors **/
 
+    error AlreadyConfigured(address);
     error InvalidUInt64(uint);
     error NotPermitted(address);
     error NotSupported(address);
@@ -57,6 +58,7 @@ contract CometRewards {
      */
     function _setRewardConfig(address comet, address token) external {
         if (msg.sender != governor) revert NotPermitted(msg.sender);
+        if (rewardConfig[comet].token != address(0)) revert AlreadyConfigured(comet);
 
         uint64 accrualScale = CometInterface(comet).baseAccrualScale();
         uint8 tokenDecimals = ERC20(token).decimals();

--- a/test/rewards-test.ts
+++ b/test/rewards-test.ts
@@ -139,6 +139,20 @@ describe('CometRewards', () => {
       expect(await COMP.balanceOf(alice.address)).to.be.equal(exp(86400, 18));
     });
 
+    it('fails if comet instance is already configured', async () => {
+      const {
+        comet,
+        governor,
+        tokens: { COMP },
+      } = await makeProtocol({
+        baseMinForRewards: 10e6,
+      });
+      const { rewards } = await makeRewards({ governor, configs: [[comet, COMP]] });
+      await expect(
+        rewards._setRewardConfig(comet.address, COMP.address)
+      ).to.be.revertedWith(`custom error 'AlreadyConfigured("${comet.address}")`);
+    });
+
     it('fails if comet instance is not configured', async () => {
       const {
         comet,


### PR DESCRIPTION
This prevents governance from making an unlikely mistake (#402).