### PR TITLE
[N-01] sanity test for accrueAccount

### DIFF
--- a/test/accrue-test.ts
+++ b/test/accrue-test.ts
@@ -233,3 +233,19 @@ describe('accrue', function () {
     await ethers.provider.send('hardhat_reset', []); // dont break downstream tests...
   });
 });
+
+describe('accrueAccount', function () {
+  it('has no effect when called on an address with no protocol activity', async () => {
+    const { comet, users: [unusedAccount] } = await makeProtocol();
+
+    const userBasic0 = await comet.userBasic(unusedAccount.address);
+    await comet.accrueAccount(unusedAccount.address);
+    const userBasic1 = await comet.userBasic(unusedAccount.address);
+
+    expect(userBasic0).to.deep.equal(userBasic1);
+    expect(userBasic1.principal).to.eq(0);
+    expect(userBasic1.baseTrackingIndex).to.eq(0);
+    expect(userBasic1.baseTrackingAccrued).to.eq(0);
+    expect(userBasic1.assetsIn).to.eq(0);
+  });
+});


### PR DESCRIPTION
Sanity test for confirming that there is no effect for calling `accrueAccount` on an address that has no activity.

Basically just confirming that all values are 0 to begin with and remain 0 after `accrueAccount(address)` is called.

Addresses #395 