### PR TITLE
[N-09] Naming issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Third-party contracts (e.g. OZ proxies) live under `contracts/vendor`.
 
 There are currently two Comet-related contracts that extend directly from the vendor contracts. The contracts are:
 
-1. **TransparentUpgradeableConfiguratorProxy**: This contract extends OZ's `TransparentUpgradeableProxy`. We override the `_beforeFallback` function so that the proxy's admin can directly call the implementation. We only need this feature for the Configurator's proxy.
+1. **ConfiguratorProxy**: This contract extends OZ's `TransparentUpgradeableProxy`. We override the `_beforeFallback` function so that the proxy's admin can directly call the implementation. We only need this feature for the Configurator's proxy.
 2. **CometProxyAdmin**: This contract extends OZ's `ProxyAdmin`. We created a new function called `deployAndUpgradeTo`, which calls `Configurator.deploy()` and upgrades Comet proxy's implementation to this newly deployed Comet contract. This function is needed so we can pass the address of the new Comet to the `Proxy.upgrade()` call in one transaction.
 
 ## Usage

--- a/contracts/ConfiguratorProxy.sol
+++ b/contracts/ConfiguratorProxy.sol
@@ -6,7 +6,7 @@ import "./vendor/proxy/transparent/TransparentUpgradeableProxy.sol";
 /**
  * @dev A TransparentUpgradeableProxy that allows its admin to call its implementation.
  */
-contract TransparentUpgradeableConfiguratorProxy is TransparentUpgradeableProxy {
+contract ConfiguratorProxy is TransparentUpgradeableProxy {
     /**
      * @dev Initializes an upgradeable proxy managed by `_admin`, backed by the implementation at `_logic`, and
      * optionally initialized with `_data` as explained in {UpgradeableProxy-constructor}.

--- a/src/deploy/Development.ts
+++ b/src/deploy/Development.ts
@@ -20,8 +20,8 @@ import {
   Configurator__factory,
   CometProxyAdmin,
   CometProxyAdmin__factory,
-  TransparentUpgradeableConfiguratorProxy,
-  TransparentUpgradeableConfiguratorProxy__factory,
+  ConfiguratorProxy,
+  ConfiguratorProxy__factory,
   ProxyAdmin,
 } from '../../build/types';
 import { ConfigurationStruct } from '../../build/types/Comet';
@@ -222,10 +222,10 @@ export async function deployDevelopmentComet(
   if (deployProxy.deployConfiguratorProxy) {
     // Configuration proxy
     configuratorProxy = await deploymentManager.deploy<
-      TransparentUpgradeableConfiguratorProxy,
-      TransparentUpgradeableConfiguratorProxy__factory,
+      ConfiguratorProxy,
+      ConfiguratorProxy__factory,
       [string, string, string]
-    >('TransparentUpgradeableConfiguratorProxy.sol', [
+    >('ConfiguratorProxy.sol', [
       configurator.address,
       proxyAdmin.address,
       (await configurator.populateTransaction.initialize(timelock.address, cometFactory.address, configuration)).data, // new time lock is set, which we don't want

--- a/src/deploy/Network.ts
+++ b/src/deploy/Network.ts
@@ -13,8 +13,8 @@ import {
   CometProxyAdmin__factory,
   TransparentUpgradeableProxy,
   TransparentUpgradeableProxy__factory,
-  TransparentUpgradeableConfiguratorProxy,
-  TransparentUpgradeableConfiguratorProxy__factory,
+  ConfiguratorProxy,
+  ConfiguratorProxy__factory,
   Configurator,
   Configurator__factory,
   SimpleTimelock,
@@ -144,10 +144,10 @@ export async function deployNetworkComet(
   if (deployProxy.deployConfiguratorProxy) {
     // Configuration proxy
     configuratorProxy = await deploymentManager.deploy<
-      TransparentUpgradeableConfiguratorProxy,
-      TransparentUpgradeableConfiguratorProxy__factory,
+      ConfiguratorProxy,
+      ConfiguratorProxy__factory,
       [string, string, string]
-    >('TransparentUpgradeableConfiguratorProxy.sol', [
+    >('ConfiguratorProxy.sol', [
       configurator.address,
       proxyAdmin.address,
       (await configurator.populateTransaction.initialize(timelock.address, cometFactory.address, configuration)).data, // new time lock is set, which we don't want

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -20,8 +20,8 @@ import {
   SimplePriceFeed__factory,
   TransparentUpgradeableProxy,
   TransparentUpgradeableProxy__factory,
-  TransparentUpgradeableConfiguratorProxy,
-  TransparentUpgradeableConfiguratorProxy__factory,
+  ConfiguratorProxy,
+  ConfiguratorProxy__factory,
   CometProxyAdmin,
   CometProxyAdmin__factory,
   CometFactory,
@@ -102,7 +102,7 @@ export type Protocol = {
 
 export type ConfiguratorAndProtocol = {
   configurator: Configurator;
-  configuratorProxy: TransparentUpgradeableConfiguratorProxy;
+  configuratorProxy: ConfiguratorProxy;
   proxyAdmin: CometProxyAdmin;
   cometFactory: CometFactory;
   cometProxy: TransparentUpgradeableProxy;
@@ -408,7 +408,7 @@ export async function makeConfigurator(opts: ProtocolOpts = {}): Promise<Configu
 
   // Deploy Configurator proxy
   const initializeCalldata = (await configurator.populateTransaction.initialize(governor.address, cometFactory.address, configuration)).data;
-  const ConfiguratorProxy = (await ethers.getContractFactory('TransparentUpgradeableConfiguratorProxy')) as TransparentUpgradeableConfiguratorProxy__factory;
+  const ConfiguratorProxy = (await ethers.getContractFactory('ConfiguratorProxy')) as ConfiguratorProxy__factory;
   const configuratorProxy = await ConfiguratorProxy.deploy(
     configurator.address,
     proxyAdmin.address,


### PR DESCRIPTION
Some naming suggestions from OZ, if we choose to accept them

- replaced all `UInt`s with `Uint`
- renamed `TransparentUpgradeableConfiguratorProxy` to `ConfiguratorProxy`
- replaced `rescale` and `descale` variables with a shared `DESCALE` constant

I did not take their suggestion re: CometProxyAdmin. Personally, I disagree with their reasoning. To me, the name `CometProxyAdmin` means that it is Comet's ProxyAdmin, not that it is solely the Admin of the CometProxy.