### PR TITLE
Modify the LICENSE parameters

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,10 +13,10 @@ Licensed Work:        Compound III
                       The Licensed Work is (c) 2022 Compound Labs
 
 Additional Use Grant: Any uses listed and defined at
-                      c3-license-grants.compound.finance
+                      v3-additional-grants.compound-community-licenses.eth
 
-Change Date:          The earlier of 2025-05-04 or a date specified at
-                      c3-license-date.compound.finance
+Change Date:          The earlier of 2025-12-31 or a date specified at
+                      v3-change-date.compound-community-licenses.eth
 
 Change License:       GNU General Public License v2.0 or later
 


### PR DESCRIPTION
The intention is to use an ENS domain controlled by the DAO. The Compound community should be able to deploy the code as it sees fit, and manage any additional use grants. The default license change date should be at least 3 years from the original publication of the code.