### PR TITLE
Add indexed keyword to `GovernorTransferred` event in rewards contract

### DIFF
--- a/contracts/CometRewards.sol
+++ b/contracts/CometRewards.sol
@@ -32,7 +32,7 @@ contract CometRewards {
 
     /** Custom events **/
 
-    event GovernorTransferred(address oldGovernor, address newGovernor);
+    event GovernorTransferred(address indexed oldGovernor, address indexed newGovernor);
     event RewardClaimed(address indexed recipient, address indexed token, uint256 amount);
 
     /** Custom errors **/


### PR DESCRIPTION
Based on OZ's latest response to our audit response to #389.