### PR TITLE
Configurator check for baseToken instead of governor

### DIFF
--- a/contracts/Configurator.sol
+++ b/contracts/Configurator.sol
@@ -83,7 +83,7 @@ contract Configurator is ConfiguratorStorage {
     function setConfiguration(address cometProxy, Configuration calldata newConfiguration) external {
         if (msg.sender != governor) revert Unauthorized();
         Configuration memory oldConfiguration = configuratorParams[cometProxy];
-        if (oldConfiguration.governor != address(0)) revert ConfigurationAlreadyExists();
+        if (oldConfiguration.baseToken != address(0)) revert ConfigurationAlreadyExists();
 
         configuratorParams[cometProxy] = newConfiguration;
         emit SetConfiguration(cometProxy, oldConfiguration, newConfiguration);


### PR DESCRIPTION
As proposed by OpenZeppelin, since `governor` is mutable in configuration. For correctness, we should either do this or update docs that `baseToken` and `trackingIndexScale` are technically mutable. If we check for `governor`, then governance could reset `governor` to `address(0)` and then overwrite the entire config, which would include `baseToken` and `trackingIndexScale`.