### PR TITLE
Fix overflow bug that occasionally occurs when supplying 0 base

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -591,7 +591,7 @@ contract Comet is CometMainInterface {
      * @dev The change in principal broken into repay and supply amounts
      */
     function repayAndSupplyAmount(int104 oldPrincipal, int104 newPrincipal) internal pure returns (uint104, uint104) {
-        // If the new principal is less than the old principal, then no amount has been repaid or supplied.
+        // If the new principal is less than the old principal, then no amount has been repaid or supplied
         if (newPrincipal < oldPrincipal) return (0, 0);
 
         if (newPrincipal <= 0) {
@@ -607,7 +607,7 @@ contract Comet is CometMainInterface {
      * @dev The change in principal broken into withdraw and borrow amounts
      */
     function withdrawAndBorrowAmount(int104 oldPrincipal, int104 newPrincipal) internal pure returns (uint104, uint104) {
-        // If the new principal is greater than the old principal, then no amount has been withdrawn or borrowed.
+        // If the new principal is greater than the old principal, then no amount has been withdrawn or borrowed
         if (newPrincipal > oldPrincipal) return (0, 0);
 
         if (newPrincipal >= 0) {

--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -592,6 +592,9 @@ contract Comet is CometMainInterface {
      * @dev Note: The assumption `newPrincipal >= oldPrincipal` MUST be true
      */
     function repayAndSupplyAmount(int104 oldPrincipal, int104 newPrincipal) internal pure returns (uint104, uint104) {
+        // If the new principal is less than the old principal, then no amount has been repaid or supplied.
+        if (newPrincipal < oldPrincipal) return (0, 0);
+
         if (newPrincipal <= 0) {
             return (uint104(newPrincipal - oldPrincipal), 0);
         } else if (oldPrincipal >= 0) {
@@ -606,6 +609,9 @@ contract Comet is CometMainInterface {
      * @dev Note: The assumption `oldPrincipal >= newPrincipal` MUST be true
      */
     function withdrawAndBorrowAmount(int104 oldPrincipal, int104 newPrincipal) internal pure returns (uint104, uint104) {
+        // If the new principal is greater than the old principal, then no amount has been withdrawn or borrowed.
+        if (newPrincipal > oldPrincipal) return (0, 0);
+
         if (newPrincipal >= 0) {
             return (uint104(oldPrincipal - newPrincipal), 0);
         } else if (oldPrincipal <= 0) {

--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -589,7 +589,6 @@ contract Comet is CometMainInterface {
 
     /**
      * @dev The change in principal broken into repay and supply amounts
-     * @dev Note: The assumption `newPrincipal >= oldPrincipal` MUST be true
      */
     function repayAndSupplyAmount(int104 oldPrincipal, int104 newPrincipal) internal pure returns (uint104, uint104) {
         // If the new principal is less than the old principal, then no amount has been repaid or supplied.
@@ -606,7 +605,6 @@ contract Comet is CometMainInterface {
 
     /**
      * @dev The change in principal broken into withdraw and borrow amounts
-     * @dev Note: The assumption `oldPrincipal >= newPrincipal` MUST be true
      */
     function withdrawAndBorrowAmount(int104 oldPrincipal, int104 newPrincipal) internal pure returns (uint104, uint104) {
         // If the new principal is greater than the old principal, then no amount has been withdrawn or borrowed.


### PR DESCRIPTION
This PR fixes a math overflow bug that occasionally occurs when supplying 0 base. I also added a unit test to verify the fix, as well as another unit test to show a weird quirk that can occur when withdrawing 0 base. 

**Bug details:**
In `supplyBase`, we calculate `dstPrincipalNew` using `dstPrincipal` (old principal value before amount is supplied). The formula is:

`int104 dstPrincipalNew = principalValue(presentValue(dstPrincipal) + signed104(amount))`

When `amount=0`, the formula condenses to:

`dstPrincipalNew = principalValue(presentValue(dstPrincipal))`

Due to the fact that both `principalValue` and `presentValue` round down in favor of the protocol, we can actually end up with a value of `dstPrincipalNew < dstPrincipal`. 

This breaks our assumption in `repayAndSupplyAmount` that `newPrincipal >= oldPrincipal` MUST be true. In the old code, this would cause `supplyAmount` returned from `repayAndSupplyAmount` to be an extremely large number (`uint104(-1)` to be precise), which would later cause an overflow during an addition operation. The new code now explicitly checks this assumption and sets both `repayAmount` and `supplyAmount` to 0 if the assumption is violated. We apply a similar check in `withdrawAndBorrowAmount` as well.