### PR TITLE
Support deploying specific contracts instead of all at once

### DIFF
--- a/deployments/fuji/migrations/1644432723_deploy_fuji.ts
+++ b/deployments/fuji/migrations/1644432723_deploy_fuji.ts
@@ -77,7 +77,7 @@ migration('1644432723_deploy_fuji', {
 
     let { cometProxy, configuratorProxy } = await deployNetworkComet(
       deploymentManager,
-      { deployCometProxy: true, deployConfiguratorProxy: true },
+      {},
       {},
       contracts
     );

--- a/deployments/fuji/migrations/1644432723_deploy_fuji.ts
+++ b/deployments/fuji/migrations/1644432723_deploy_fuji.ts
@@ -77,7 +77,7 @@ migration('1644432723_deploy_fuji', {
 
     let { cometProxy, configuratorProxy } = await deployNetworkComet(
       deploymentManager,
-      {},
+      { all: true },
       {},
       contracts
     );

--- a/deployments/kovan/migrations/1644388553_deploy_kovan.ts
+++ b/deployments/kovan/migrations/1644388553_deploy_kovan.ts
@@ -88,7 +88,7 @@ migration('1644388553_deploy_kovan', {
     );
 
     const blockNumber = await ethers.provider.getBlockNumber();
-    const blockTimestamp =  (await ethers.provider.getBlock(blockNumber)).timestamp;
+    const blockTimestamp = (await ethers.provider.getBlock(blockNumber)).timestamp;
 
     let uni = await deploymentManager.clone(
       cloneAddr.uni,
@@ -114,7 +114,7 @@ migration('1644388553_deploy_kovan', {
 
     let { cometProxy, configuratorProxy } = await deployNetworkComet(
       deploymentManager,
-      { deployCometProxy: true, deployConfiguratorProxy: true },
+      {},
       {},
       contracts
     );

--- a/deployments/kovan/migrations/1644388553_deploy_kovan.ts
+++ b/deployments/kovan/migrations/1644388553_deploy_kovan.ts
@@ -114,7 +114,7 @@ migration('1644388553_deploy_kovan', {
 
     let { cometProxy, configuratorProxy } = await deployNetworkComet(
       deploymentManager,
-      {},
+      { all: true },
       {},
       contracts
     );

--- a/scenario/constraints/ModernConstraint.ts
+++ b/scenario/constraints/ModernConstraint.ts
@@ -40,8 +40,7 @@ export class ModernConstraint<T extends CometContext, R extends Requirements> im
           const deploymentManager = ctx.deploymentManager;
           await deployComet(
             deploymentManager,
-            { deployCometProxy: true, deployConfiguratorProxy: true },
-            config.cometConfig
+            { configurationOverrides: config.cometConfig },
           );
           await deploymentManager.spider();
           ctx.actors = await getActors(ctx, world);

--- a/scenario/utils.ts
+++ b/scenario/utils.ts
@@ -111,9 +111,17 @@ export async function upgradeComet(world: World, context: CometContext, configOv
   let { comet: newComet } = await deployComet(
     context.deploymentManager,
     // Deploy a new configurator proxy to set the proper CometConfiguration storage values
-    { deployCometProxy: false, deployConfiguratorProxy: true },
-    cometConfig,
-    { adminSigner: context.actors['admin'].signer }
+    {
+      contractsToDeploy: {
+        configuratorProxy: true,
+        configurator: true,
+        comet: true,
+        cometExt: true,
+        cometFactory: true
+      },
+      configurationOverrides: cometConfig,
+      adminSigner: context.actors['admin'].signer
+    }
   );
   let initializer: string | undefined;
   if (!oldComet.totalsBasic || (await oldComet.totalsBasic()).lastAccrualTime === 0) {

--- a/src/deploy/Development.ts
+++ b/src/deploy/Development.ts
@@ -28,7 +28,7 @@ import {
 import { ConfigurationStruct } from '../../build/types/Comet';
 import { ExtConfigurationStruct } from '../../build/types/CometExt';
 export { Comet } from '../../build/types';
-import { DeployedContracts, DeployProxyOption, ProtocolConfiguration } from './index';
+import { DeployedContracts, ContractsToDeploy, ProtocolConfiguration } from './index';
 import { extractCalldata, fastGovernanceExecute } from '../utils';
 
 async function makeToken(
@@ -65,9 +65,15 @@ async function makePriceFeed(
 // TODO: Support configurable assets as well?
 export async function deployDevelopmentComet(
   deploymentManager: DeploymentManager,
-  deployProxy: DeployProxyOption = { deployCometProxy: true, deployConfiguratorProxy: true },
-  configurationOverrides: ProtocolConfiguration = {}
+  contractsToDeploy?: ContractsToDeploy,
+  configurationOverrides?: ProtocolConfiguration
 ): Promise<DeployedContracts> {
+  if (contractsToDeploy == null) {
+    contractsToDeploy = { all: true };
+  }
+  if (configurationOverrides == null) {
+    configurationOverrides = {};
+  }
   const [admin, pauseGuardianSigner] = await deploymentManager.getSigners();
 
   let dai = await makeToken(deploymentManager, 1000000, 'DAI', 18, 'DAI');
@@ -98,18 +104,43 @@ export async function deployDevelopmentComet(
     supplyCap: (500000e10).toString(),
   };
 
-  let governorSimple = await deploymentManager.deploy<GovernorSimple, GovernorSimple__factory, []>(
-    'test/GovernorSimple.sol',
-    []
-  );
+  let governorSimple, timelock, proxyAdmin, cometExt, cometProxy, configuratorProxy, comet, configurator, cometFactory;
 
-  let timelock = await deploymentManager.deploy<SimpleTimelock, SimpleTimelock__factory, [string]>(
-    'test/SimpleTimelock.sol',
-    [governorSimple.address]
-  );
+  /* === Deploy Contracts === */
 
-  // Initialize the storage of GovernorSimple
-  await governorSimple.initialize(timelock.address, [admin.address]);
+  if (contractsToDeploy.all || contractsToDeploy.governor) {
+    governorSimple = await deploymentManager.deploy<GovernorSimple, GovernorSimple__factory, []>(
+      'test/GovernorSimple.sol',
+      []
+    );
+  } else {
+    governorSimple = await deploymentManager.contract('governor') as GovernorSimple;
+  }
+
+  if (contractsToDeploy.all || contractsToDeploy.timelock) {
+    timelock = await deploymentManager.deploy<SimpleTimelock, SimpleTimelock__factory, [string]>(
+      'test/SimpleTimelock.sol',
+      [governorSimple.address]
+    );
+  } else {
+    timelock = await deploymentManager.contract('timelock') as SimpleTimelock;
+  }
+
+  if (contractsToDeploy.all || contractsToDeploy.governor) {
+    // Initialize the storage of GovernorSimple
+    await governorSimple.initialize(timelock.address, [admin.address]);
+  }
+
+  if (contractsToDeploy.all || contractsToDeploy.cometProxyAdmin) {
+    let proxyAdminArgs: [] = [];
+    proxyAdmin = await deploymentManager.deploy<CometProxyAdmin, CometProxyAdmin__factory, []>(
+      'CometProxyAdmin.sol',
+      proxyAdminArgs
+    );
+    await proxyAdmin.transferOwnership(timelock.address);
+  } else {
+    proxyAdmin = await deploymentManager.contract('cometAdmin') as ProxyAdmin;
+  }
 
   const {
     symbol,
@@ -160,13 +191,17 @@ export async function deployDevelopmentComet(
     ...configurationOverrides,
   };
 
-  const extConfiguration = {
-    symbol32: deploymentManager.hre.ethers.utils.formatBytes32String(symbol),
-  };
-  const cometExt = await deploymentManager.deploy<CometExt, CometExt__factory, [ExtConfigurationStruct]>(
-    'CometExt.sol',
-    [extConfiguration]
-  );
+  if (contractsToDeploy.all || contractsToDeploy.cometExt) {
+    const extConfiguration = {
+      symbol32: deploymentManager.hre.ethers.utils.formatBytes32String(symbol),
+    };
+    cometExt = await deploymentManager.deploy<CometExt, CometExt__factory, [ExtConfigurationStruct]>(
+      'CometExt.sol',
+      [extConfiguration]
+    );
+  } else {
+    cometExt = await deploymentManager.contract('comet:implementation:implementation') as CometExt;
+  }
 
   const configuration = {
     governor,
@@ -191,47 +226,38 @@ export async function deployDevelopmentComet(
     targetReserves,
     assetConfigs,
   };
-  const comet = await deploymentManager.deploy<Comet, Comet__factory, [ConfigurationStruct]>(
-    'Comet.sol',
-    [configuration]
-  );
 
-  const cometFactory = await deploymentManager.deploy<CometFactory, CometFactory__factory, []>(
-    'CometFactory.sol',
-    []
-  );
+  if (contractsToDeploy.all || contractsToDeploy.comet) {
+    comet = await deploymentManager.deploy<Comet, Comet__factory, [ConfigurationStruct]>(
+      'Comet.sol',
+      [configuration]
+    );
+  } else {
+    comet = await deploymentManager.contract('comet:implementation') as CometInterface;
+  }
 
-  const configurator = await deploymentManager.deploy<Configurator, Configurator__factory, []>(
-    'Configurator.sol',
-    []
-  );
+  if (contractsToDeploy.all || contractsToDeploy.cometFactory) {
+    cometFactory = await deploymentManager.deploy<CometFactory, CometFactory__factory, []>(
+      'CometFactory.sol',
+      []
+    );
+  } else {
+    // XXX need to handle the fact that there can be multiple Comet factories
+  }
+
+  if (contractsToDeploy.all || contractsToDeploy.configurator) {
+    configurator = await deploymentManager.deploy<Configurator, Configurator__factory, []>(
+      'Configurator.sol',
+      []
+    );
+  } else {
+    configurator = await deploymentManager.contract('configurator:implementation') as Configurator;
+  }
 
   /* === Proxies === */
 
   let updatedRoots = await deploymentManager.getRoots();
-  let cometProxy = null;
-  let configuratorProxy = null;
-  let proxyAdmin = null;
-
-  // If we are deploying new proxies for both Comet and Configurator, we will also deploy a new ProxyAdmin
-  // because this is most likely going to be a completely fresh deployment.
-  // Note: If this assumption is incorrect, we should probably add a third option in `DeployProxyOption` to
-  //       specify if a new CometProxyAdmin should be deployed.
-  if (deployProxy.deployCometProxy && deployProxy.deployConfiguratorProxy) {
-    let proxyAdminArgs: [] = [];
-    proxyAdmin = await deploymentManager.deploy<CometProxyAdmin, CometProxyAdmin__factory, []>(
-      'CometProxyAdmin.sol',
-      proxyAdminArgs
-    );
-    await proxyAdmin.transferOwnership(timelock.address);
-  } else {
-    // We don't want to be using a new ProxyAdmin/Timelock/Governor if we are not deploying both proxies
-    proxyAdmin = await deploymentManager.contract('cometAdmin') as ProxyAdmin;
-    timelock = await deploymentManager.contract('timelock') as SimpleTimelock;
-    governorSimple = await deploymentManager.contract('governor') as GovernorSimple;
-  }
-
-  if (deployProxy.deployCometProxy) {
+  if (contractsToDeploy.all || contractsToDeploy.cometProxy) {
     // Comet proxy
     cometProxy = await deploymentManager.deploy<
       TransparentUpgradeableProxy,
@@ -250,7 +276,7 @@ export async function deployDevelopmentComet(
     cometProxy = await deploymentManager.contract('comet') as CometInterface;
   }
 
-  if (deployProxy.deployConfiguratorProxy) {
+  if (contractsToDeploy.all || contractsToDeploy.configuratorProxy) {
     // Configuration proxy
     configuratorProxy = await deploymentManager.deploy<
       ConfiguratorProxy,
@@ -265,6 +291,11 @@ export async function deployDevelopmentComet(
     // Set the initial factory and configuration for Comet in Configurator
     const setFactoryCalldata = extractCalldata((await configurator.populateTransaction.setFactory(cometProxy.address, cometFactory.address)).data);
     const setConfigurationCalldata = extractCalldata((await configurator.populateTransaction.setConfiguration(cometProxy.address, configuration)).data);
+    // XXX THIS WOULDN'T WORK ON MAINNET WITH NO GOVERNORSIMPLE!!!
+    // think about how this should be adapted for mainnet. would probably be through an actual proposal...
+    // Configurator deployed first.
+    // Comet Proxy is deployed with no implementation?... so that configurator can deploy the impl?
+    // or Comet Proxy deployed with implementation
     await fastGovernanceExecute(
       governorSimple.connect(admin),
       [configuratorProxy.address, configuratorProxy.address],
@@ -277,6 +308,8 @@ export async function deployDevelopmentComet(
     );
 
     updatedRoots.set('configurator', configuratorProxy.address);
+  } else {
+    configuratorProxy = await deploymentManager.contract('configurator') as Configurator;
   }
 
   await deploymentManager.putRoots(updatedRoots);

--- a/src/deploy/Development.ts
+++ b/src/deploy/Development.ts
@@ -131,17 +131,6 @@ export async function deployDevelopmentComet(
     await governorSimple.initialize(timelock.address, [admin.address]);
   }
 
-  if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.cometProxyAdmin)) {
-    let proxyAdminArgs: [] = [];
-    proxyAdmin = await deploymentManager.deploy<CometProxyAdmin, CometProxyAdmin__factory, []>(
-      'CometProxyAdmin.sol',
-      proxyAdminArgs
-    );
-    await proxyAdmin.transferOwnership(timelock.address);
-  } else {
-    proxyAdmin = await deploymentManager.contract('cometAdmin') as ProxyAdmin;
-  }
-
   const {
     symbol,
     governor,
@@ -256,6 +245,17 @@ export async function deployDevelopmentComet(
 
   /* === Proxies === */
 
+  if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.cometProxyAdmin)) {
+    let proxyAdminArgs: [] = [];
+    proxyAdmin = await deploymentManager.deploy<CometProxyAdmin, CometProxyAdmin__factory, []>(
+      'CometProxyAdmin.sol',
+      proxyAdminArgs
+    );
+    await proxyAdmin.transferOwnership(governor);
+  } else {
+    proxyAdmin = await deploymentManager.contract('cometAdmin') as ProxyAdmin;
+  }
+
   let updatedRoots = await deploymentManager.getRoots();
   if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.cometProxy)) {
     // Comet proxy
@@ -285,7 +285,7 @@ export async function deployDevelopmentComet(
     >('ConfiguratorProxy.sol', [
       configurator.address,
       proxyAdmin.address,
-      (await configurator.populateTransaction.initialize(timelock.address)).data,
+      (await configurator.populateTransaction.initialize(governor)).data,
     ]);
 
     // Set the initial factory and configuration for Comet in Configurator

--- a/src/deploy/Development.ts
+++ b/src/deploy/Development.ts
@@ -65,15 +65,9 @@ async function makePriceFeed(
 // TODO: Support configurable assets as well?
 export async function deployDevelopmentComet(
   deploymentManager: DeploymentManager,
-  contractsToDeploy?: ContractsToDeploy,
-  configurationOverrides?: ProtocolConfiguration
+  contractsToDeploy: ContractsToDeploy = { all: true },
+  configurationOverrides: ProtocolConfiguration = {},
 ): Promise<DeployedContracts> {
-  if (contractsToDeploy == null) {
-    contractsToDeploy = { all: true };
-  }
-  if (configurationOverrides == null) {
-    configurationOverrides = {};
-  }
   const [admin, pauseGuardianSigner] = await deploymentManager.getSigners();
 
   let dai = await makeToken(deploymentManager, 1000000, 'DAI', 18, 'DAI');

--- a/src/deploy/Network.ts
+++ b/src/deploy/Network.ts
@@ -25,34 +25,65 @@ import {
 import { ConfigurationStruct } from '../../build/types/Comet';
 import { ExtConfigurationStruct } from '../../build/types/CometExt';
 
-import { DeployedContracts, DeployProxyOption, ProtocolConfiguration } from './index';
+import { ContractsToDeploy, DeployedContracts, ProtocolConfiguration } from './index';
 import { getConfiguration } from './NetworkConfiguration';
 import { extractCalldata, fastGovernanceExecute } from '../utils';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 export async function deployNetworkComet(
   deploymentManager: DeploymentManager,
-  deployProxy: DeployProxyOption = { deployCometProxy: true, deployConfiguratorProxy: true },
-  configurationOverrides: ProtocolConfiguration = {},
+  contractsToDeploy?: ContractsToDeploy,
+  configurationOverrides?: ProtocolConfiguration,
   contractMapOverride?: ContractMap,
   adminSigner?: SignerWithAddress,
 ): Promise<DeployedContracts> {
+  if (contractsToDeploy == null) {
+    contractsToDeploy = { all: true };
+  }
+  if (configurationOverrides == null) {
+    configurationOverrides = {};
+  }
   if (adminSigner == null) {
     adminSigner = await deploymentManager.getSigner();
   }
 
-  let governorSimple = await deploymentManager.deploy<GovernorSimple, GovernorSimple__factory, []>(
-    'test/GovernorSimple.sol',
-    []
-  );
+  let governorSimple, timelock, proxyAdmin, cometExt, cometProxy, configuratorProxy, comet, configurator, cometFactory;
 
-  let timelock = await deploymentManager.deploy<SimpleTimelock, SimpleTimelock__factory, [string]>(
-    'test/SimpleTimelock.sol',
-    [governorSimple.address]
-  );
+  /* === Deploy Contracts === */
 
-  // Initialize the storage of GovernorSimple
-  await governorSimple.initialize(timelock.address, [adminSigner.address]);
+  if (contractsToDeploy.all || contractsToDeploy.governor) {
+    governorSimple = await deploymentManager.deploy<GovernorSimple, GovernorSimple__factory, []>(
+      'test/GovernorSimple.sol',
+      []
+    );
+  } else {
+    governorSimple = await deploymentManager.contract('governor') as GovernorSimple;
+  }
+
+  if (contractsToDeploy.all || contractsToDeploy.timelock) {
+    timelock = await deploymentManager.deploy<SimpleTimelock, SimpleTimelock__factory, [string]>(
+      'test/SimpleTimelock.sol',
+      [governorSimple.address]
+    );
+  } else {
+    timelock = await deploymentManager.contract('timelock') as SimpleTimelock;
+  }
+
+  if (contractsToDeploy.all || contractsToDeploy.governor) {
+    // Initialize the storage of GovernorSimple
+    await governorSimple.initialize(timelock.address, [adminSigner.address]);
+  }
+
+  if (contractsToDeploy.all || contractsToDeploy.cometProxyAdmin) {
+    let proxyAdminArgs: [] = [];
+    proxyAdmin = await deploymentManager.deploy<CometProxyAdmin, CometProxyAdmin__factory, []>(
+      'CometProxyAdmin.sol',
+      proxyAdminArgs
+    );
+    await proxyAdmin.transferOwnership(timelock.address);
+  } else {
+    proxyAdmin = await deploymentManager.contract('cometAdmin') as ProxyAdmin;
+  }
 
   const {
     symbol,
@@ -83,13 +114,17 @@ export async function deployNetworkComet(
     ...configurationOverrides
   };
 
-  const extConfiguration = {
-    symbol32: deploymentManager.hre.ethers.utils.formatBytes32String(symbol),
-  };
-  const cometExt = await deploymentManager.deploy<CometExt, CometExt__factory, [ExtConfigurationStruct]>(
-    'CometExt.sol',
-    [extConfiguration]
-  );
+  if (contractsToDeploy.all || contractsToDeploy.cometExt) {
+    const extConfiguration = {
+      symbol32: deploymentManager.hre.ethers.utils.formatBytes32String(symbol),
+    };
+    cometExt = await deploymentManager.deploy<CometExt, CometExt__factory, [ExtConfigurationStruct]>(
+      'CometExt.sol',
+      [extConfiguration]
+    );
+  } else {
+    cometExt = await deploymentManager.contract('comet:implementation:implementation') as CometExt;
+  }
 
   const configuration = {
     governor,
@@ -114,47 +149,38 @@ export async function deployNetworkComet(
     targetReserves,
     assetConfigs,
   };
-  const comet = await deploymentManager.deploy<Comet, Comet__factory, [ConfigurationStruct]>(
-    'Comet.sol',
-    [configuration]
-  );
 
-  const cometFactory = await deploymentManager.deploy<CometFactory, CometFactory__factory, []>(
-    'CometFactory.sol',
-    []
-  );
+  if (contractsToDeploy.all || contractsToDeploy.comet) {
+    comet = await deploymentManager.deploy<Comet, Comet__factory, [ConfigurationStruct]>(
+      'Comet.sol',
+      [configuration]
+    );
+  } else {
+    comet = await deploymentManager.contract('comet:implementation') as CometInterface;
+  }
 
-  const configurator = await deploymentManager.deploy<Configurator, Configurator__factory, []>(
-    'Configurator.sol',
-    []
-  );
+  if (contractsToDeploy.all || contractsToDeploy.cometFactory) {
+    cometFactory = await deploymentManager.deploy<CometFactory, CometFactory__factory, []>(
+      'CometFactory.sol',
+      []
+    );
+  } else {
+    // XXX need to handle the fact that there can be multiple Comet factories
+  }
+
+  if (contractsToDeploy.all || contractsToDeploy.configurator) {
+    configurator = await deploymentManager.deploy<Configurator, Configurator__factory, []>(
+      'Configurator.sol',
+      []
+    );
+  } else {
+    configurator = await deploymentManager.contract('configurator:implementation') as Configurator;
+  }
 
   /* === Proxies === */
 
   let updatedRoots = await deploymentManager.getRoots();
-  let cometProxy = null;
-  let configuratorProxy = null;
-  let proxyAdmin = null;
-
-  // If we are deploying new proxies for both Comet and Configurator, we will also deploy a new ProxyAdmin
-  // because this is most likely going to be a completely fresh deployment.
-  // Note: If this assumption is incorrect, we should probably add a third option in `DeployProxyOption` to
-  //       specify if a new CometProxyAdmin should be deployed.
-  if (deployProxy.deployCometProxy && deployProxy.deployConfiguratorProxy) {
-    let proxyAdminArgs: [] = [];
-    proxyAdmin = await deploymentManager.deploy<CometProxyAdmin, CometProxyAdmin__factory, []>(
-      'CometProxyAdmin.sol',
-      proxyAdminArgs
-    );
-    await proxyAdmin.transferOwnership(timelock.address);
-  } else {
-    // We don't want to be using a new ProxyAdmin/Timelock/Governor if we are not deploying both proxies
-    proxyAdmin = await deploymentManager.contract('cometAdmin') as ProxyAdmin;
-    timelock = await deploymentManager.contract('timelock') as SimpleTimelock;
-    governorSimple = await deploymentManager.contract('governor') as GovernorSimple;
-  }
-
-  if (deployProxy.deployCometProxy) {
+  if (contractsToDeploy.all || contractsToDeploy.cometProxy) {
     // Comet proxy
     cometProxy = await deploymentManager.deploy<
       TransparentUpgradeableProxy,
@@ -173,7 +199,7 @@ export async function deployNetworkComet(
     cometProxy = await deploymentManager.contract('comet') as CometInterface;
   }
 
-  if (deployProxy.deployConfiguratorProxy) {
+  if (contractsToDeploy.all || contractsToDeploy.configuratorProxy) {
     // Configuration proxy
     configuratorProxy = await deploymentManager.deploy<
       ConfiguratorProxy,
@@ -200,6 +226,8 @@ export async function deployNetworkComet(
     );
 
     updatedRoots.set('configurator', configuratorProxy.address);
+  } else {
+    configuratorProxy = await deploymentManager.contract('configurator') as Configurator;
   }
 
   await deploymentManager.putRoots(updatedRoots);

--- a/src/deploy/Network.ts
+++ b/src/deploy/Network.ts
@@ -74,17 +74,6 @@ export async function deployNetworkComet(
     await governorSimple.initialize(timelock.address, [adminSigner.address]);
   }
 
-  if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.cometProxyAdmin)) {
-    let proxyAdminArgs: [] = [];
-    proxyAdmin = await deploymentManager.deploy<CometProxyAdmin, CometProxyAdmin__factory, []>(
-      'CometProxyAdmin.sol',
-      proxyAdminArgs
-    );
-    await proxyAdmin.transferOwnership(timelock.address);
-  } else {
-    proxyAdmin = await deploymentManager.contract('cometAdmin') as ProxyAdmin;
-  }
-
   const {
     symbol,
     governor,
@@ -179,6 +168,17 @@ export async function deployNetworkComet(
 
   /* === Proxies === */
 
+  if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.cometProxyAdmin)) {
+    let proxyAdminArgs: [] = [];
+    proxyAdmin = await deploymentManager.deploy<CometProxyAdmin, CometProxyAdmin__factory, []>(
+      'CometProxyAdmin.sol',
+      proxyAdminArgs
+    );
+    await proxyAdmin.transferOwnership(governor);
+  } else {
+    proxyAdmin = await deploymentManager.contract('cometAdmin') as ProxyAdmin;
+  }
+
   let updatedRoots = await deploymentManager.getRoots();
   if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.cometProxy)) {
     // Comet proxy
@@ -208,7 +208,7 @@ export async function deployNetworkComet(
     >('ConfiguratorProxy.sol', [
       configurator.address,
       proxyAdmin.address,
-      (await configurator.populateTransaction.initialize(timelock.address)).data,
+      (await configurator.populateTransaction.initialize(governor)).data,
     ]);
 
     // Set the initial factory and configuration for Comet in Configurator

--- a/src/deploy/Network.ts
+++ b/src/deploy/Network.ts
@@ -32,17 +32,11 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 export async function deployNetworkComet(
   deploymentManager: DeploymentManager,
-  contractsToDeploy?: ContractsToDeploy,
-  configurationOverrides?: ProtocolConfiguration,
+  contractsToDeploy: ContractsToDeploy = { all: true },
+  configurationOverrides: ProtocolConfiguration = {},
   contractMapOverride?: ContractMap,
   adminSigner?: SignerWithAddress,
 ): Promise<DeployedContracts> {
-  if (contractsToDeploy == null) {
-    contractsToDeploy = { all: true };
-  }
-  if (configurationOverrides == null) {
-    configurationOverrides = {};
-  }
   if (adminSigner == null) {
     adminSigner = await deploymentManager.getSigner();
   }

--- a/src/deploy/Network.ts
+++ b/src/deploy/Network.ts
@@ -52,27 +52,21 @@ export async function deployNetworkComet(
   /* === Deploy Contracts === */
 
   if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.governor)) {
-    console.log('deploying governor')
     governorSimple = await deploymentManager.deploy<GovernorSimple, GovernorSimple__factory, []>(
       'test/GovernorSimple.sol',
       []
     );
   } else {
     governorSimple = await deploymentManager.contract('governor') as GovernorSimple;
-    console.log('NOT deploying governor')
   }
 
   if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.timelock)) {
-    console.log('deploying timelock')
-
     timelock = await deploymentManager.deploy<SimpleTimelock, SimpleTimelock__factory, [string]>(
       'test/SimpleTimelock.sol',
       [governorSimple.address]
     );
   } else {
     timelock = await deploymentManager.contract('timelock') as SimpleTimelock;
-    console.log('NOT deploying timelock')
-
   }
 
   if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.governor)) {
@@ -81,8 +75,6 @@ export async function deployNetworkComet(
   }
 
   if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.cometProxyAdmin)) {
-    console.log('deploying proxy admin')
-
     let proxyAdminArgs: [] = [];
     proxyAdmin = await deploymentManager.deploy<CometProxyAdmin, CometProxyAdmin__factory, []>(
       'CometProxyAdmin.sol',
@@ -123,8 +115,6 @@ export async function deployNetworkComet(
   };
 
   if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.cometExt)) {
-    console.log('deploying ext')
-
     const extConfiguration = {
       symbol32: deploymentManager.hre.ethers.utils.formatBytes32String(symbol),
     };
@@ -161,8 +151,6 @@ export async function deployNetworkComet(
   };
 
   if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.comet)) {
-    console.log('deploying comet')
-
     comet = await deploymentManager.deploy<Comet, Comet__factory, [ConfigurationStruct]>(
       'Comet.sol',
       [configuration]
@@ -181,8 +169,6 @@ export async function deployNetworkComet(
   }
 
   if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.configurator)) {
-    console.log('deploying configurator')
-
     configurator = await deploymentManager.deploy<Configurator, Configurator__factory, []>(
       'Configurator.sol',
       []
@@ -214,8 +200,6 @@ export async function deployNetworkComet(
   }
 
   if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.configuratorProxy)) {
-    console.log('deploying configurator proxy')
-
     // Configuration proxy
     configuratorProxy = await deploymentManager.deploy<
       ConfiguratorProxy,

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -38,12 +38,22 @@ export interface ProtocolConfiguration {
   assetConfigs?: AssetConfigStruct[];
 }
 
-export interface DeployProxyOption {
-  deployCometProxy?: boolean;
-  deployConfiguratorProxy?: boolean;
+export interface ContractsToDeploy {
+  all?: boolean;
+  cometProxy?: boolean;
+  configuratorProxy?: boolean;
+  cometProxyAdmin?: boolean;
+  timelock?: boolean;
+  governor?: boolean;
+  cometExt?: boolean;
+  comet?: boolean;
+  configurator?: boolean;
+  cometFactory?: boolean;
 }
 
 interface DeployCometOptionalParams {
+  contractsToDeploy?: ContractsToDeploy;
+  configurationOverrides?: ProtocolConfiguration;
   contractMapOverride?: ContractMap;
   adminSigner?: SignerWithAddress;
 }
@@ -59,16 +69,14 @@ export interface DeployedContracts {
 
 export async function deployComet(
   deploymentManager: DeploymentManager,
-  deployProxy: DeployProxyOption = { deployCometProxy: true, deployConfiguratorProxy: true },
-  configurationOverrides: ProtocolConfiguration = {},
   optionalParams: DeployCometOptionalParams = {},
 ): Promise<DeployedContracts> {
   // If we have a `configuration.json` for the network, use it.
   // Otherwise, we do a "development"-style deploy, which deploys fake tokens, etc, and generally
   // provides less value than a full-fledged test-net or mainnet fork.
   if (await hasNetworkConfiguration(deploymentManager.deployment)) {
-    return await deployNetworkComet(deploymentManager, deployProxy, configurationOverrides, optionalParams.contractMapOverride, optionalParams.adminSigner);
+    return await deployNetworkComet(deploymentManager, optionalParams.contractsToDeploy, optionalParams.configurationOverrides, optionalParams.contractMapOverride, optionalParams.adminSigner);
   } else {
-    return await deployDevelopmentComet(deploymentManager, deployProxy, configurationOverrides);
+    return await deployDevelopmentComet(deploymentManager, optionalParams.contractsToDeploy, optionalParams.configurationOverrides);
   }
 }

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -38,6 +38,10 @@ export interface ProtocolConfiguration {
   assetConfigs?: AssetConfigStruct[];
 }
 
+// Specific contracts take precedence over `all`, which allows for expressions
+// such as:
+// { all: true, timelock: false }
+// which will deploy all contracts other than Timelock
 export interface ContractsToDeploy {
   all?: boolean;
   cometProxy?: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,3 +16,10 @@ export function extractCalldata(txnData: string): string {
   // Remove the first 4 bytes (function selector) of the transaction data
   return '0x' + txnData.slice(10);
 }
+
+export function shouldDeploy(deployAll: boolean, deployContract: boolean): boolean {
+  if (deployContract !== undefined) {
+    return deployContract;
+  }
+  return deployAll;
+}


### PR DESCRIPTION
This PR improves our deployment scripts in a few ways:

- Consolidate all deployment options into `DeployCometOptionalParams` so only a single object for optional params needs to be passed into `deployComet`
- Introduce a new `ContractsToDeploy` optional param that allows for more specificity in which contracts to deploy. This should put us in the right direction for mainnet and L2 migrations that don't need certain contracts (e.g. `SimpleTimelock` and `GovernorSimple`)

`ContractsToDeploy` usage:
If `ContractsToDeploy` is not provided as an optional param, all contracts will be deployed. The interface also has an `all` property that explicitly states to deploy all contracts. The `all` property can be combined with other properties to deploy "all but some" contracts. e.g.

```
{ all: true, timelock: false }
```

will deploy all contracts except for the `Timelock`.