### PR TITLE
remove hard-coded network argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "audit:liquidator": "vendoza contracts/liquidator/vendor/manifest.json",
     "audit:vendor": "vendoza contracts/vendor/manifest.json",
     "slither:fn-clashes": "slither-check-upgradeability contracts/Configurator.sol Configurator --proxy-filename contracts/ConfiguratorProxy.sol --proxy-name ConfiguratorProxy",
-    "liquidation-bot": "hardhat run scripts/liquidation_bot/index.ts --network mainnet"
+    "liquidation-bot": "hardhat run scripts/liquidation_bot/index.ts"
   },
   "keywords": [],
   "author": "Compound Finance",


### PR DESCRIPTION
The main Liquidation Bot command has mainnet hard-coded as an argument.

Removing so that users can run it against testnet (to get those sweet testnet profits).