### PR TITLE
Fault tolerant deploys

### DIFF
--- a/plugins/deployment_manager/Deploy.ts
+++ b/plugins/deployment_manager/Deploy.ts
@@ -37,6 +37,7 @@ async function deployFromBuildFile(
   const [ethersSigner] = await hre.ethers.getSigners();
   const signer = deployOpts.connect ?? ethersSigner;
   const contractFactory = new hre.ethers.ContractFactory(metadata.abi, metadata.bin, signer);
+  debug(`Deploying ${Object.keys(buildFile.contracts)} with args`, deployArgs);
   const contract = await contractFactory.deploy(...deployArgs);
   const deployed = await contract.deployed();
   debug(`Deployed ${contractName}`);
@@ -101,6 +102,8 @@ export async function deploy<
   let contract = await factory.deploy(...deployArgs);
   await contract.deployed();
 
+  debug(`Deployed ${contractName} via tx ${contract.deployTransaction?.hash}`);
+
   let buildFile = await getBuildFileFromArtifacts(contractFile, contractFileName);
 
   if (!buildFile.contract) {
@@ -117,8 +120,6 @@ export async function deploy<
   }
 
   await maybeStoreCache(deployOpts, contract, buildFile);
-
-  debug(`Deployed ${contractName} via tx ${contract.deployTransaction?.hash}`);
 
   return contract;
 }

--- a/plugins/deployment_manager/DeploymentManager.ts
+++ b/plugins/deployment_manager/DeploymentManager.ts
@@ -265,7 +265,7 @@ export class DeploymentManager {
       if (retries === 0) throw e;
       // XXX to be extra safe, we can also get the signer transaction count and figure out the next nonce
       this._signers = [];
-      return await this.asyncCallWithRetry(fn, retries);
+      return await this.asyncCallWithRetry(fn, retries, timeLimit);
     }
   }
 

--- a/plugins/deployment_manager/DeploymentManager.ts
+++ b/plugins/deployment_manager/DeploymentManager.ts
@@ -14,6 +14,7 @@ import { Migration, getArtifactSpec } from './Migration';
 import { generateMigration } from './MigrationTemplate';
 import { ExtendedNonceManager } from './NonceManager';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { asyncCallWithTimeout, debug } from './Utils';
 
 interface DeploymentManagerConfig {
   baseDir?: string;
@@ -116,13 +117,19 @@ export class DeploymentManager {
     C extends Contract,
     Factory extends Deployer<C, DeployArgs>,
     DeployArgs extends Array<any>
-  >(contractFile: string, deployArgs: DeployArgs): Promise<C> {
-    return deploy<C, Factory, DeployArgs>(contractFile, deployArgs, this.hre, await this.deployOpts());
+  >(contractFile: string, deployArgs: DeployArgs, retries?: number): Promise<C> {
+    return await this.asyncCallWithRetry(
+      async () => deploy<C, Factory, DeployArgs>(contractFile, deployArgs, this.hre, await this.deployOpts()),
+      retries
+    );
   }
 
   /* Deploys a contract from a build file, e.g. an one imported contract */
-  async deployBuild(buildFile: BuildFile, deployArgs: any[]): Promise<Contract> {
-    return await deployBuild(buildFile, deployArgs, this.hre, await this.deployOpts());
+  async deployBuild(buildFile: BuildFile, deployArgs: any[], retries?: number): Promise<Contract> {
+    return await this.asyncCallWithRetry(
+      async () => deployBuild(buildFile, deployArgs, this.hre, await this.deployOpts()),
+      retries
+    );
   }
 
   /* Stores a new alias, which can then be referenced via `deploymentManager.contract()` */
@@ -240,9 +247,31 @@ export class DeploymentManager {
     return await this.cache.readCache(getArtifactSpec(migration));
   }
 
-  async clone<C extends Contract>(address: string, args: any[], network?: string): Promise<C> {
+  /**
+   * Call an async function with a given amount of retries
+   * @param fn an async function that takes a signer as an argument. The function takes a signer
+   * because a new instance of a signer needs to be used on each retry
+   * @param retries the number of times to retry the function. Default is 5 retries
+   * @param timeLimit time limit before timeout in milliseconds
+   */
+  async asyncCallWithRetry(fn: (signer: SignerWithAddress) => Promise<any>, retries: number = 5, timeLimit?: number) {
+    const signer = await this.getSigner();
+    try {
+      return await asyncCallWithTimeout(fn(signer), timeLimit);
+    } catch (e) {
+      retries -= 1;
+      debug(`Retrying with retries left: ${retries}`);
+      debug(`Error is ${e}`);
+      if (retries === 0) throw e;
+      // XXX to be extra safe, we can also get the signer transaction count and figure out the next nonce
+      this._signers = [];
+      return await this.asyncCallWithRetry(fn, retries);
+    }
+  }
+
+  async clone<C extends Contract>(address: string, args: any[], network?: string, retries?: number): Promise<C> {
     let buildFile = await this.import(address, network);
-    return await this.deployBuild(buildFile, args) as C;
+    return await this.deployBuild(buildFile, args, retries) as C;
   }
 
   network(): string {

--- a/plugins/deployment_manager/Utils.ts
+++ b/plugins/deployment_manager/Utils.ts
@@ -121,3 +121,24 @@ export function asArray<A>(v: A | A[]): A[] {
     }
   }
 }
+
+/**
+ * Call an async function with a maximum time limit (in milliseconds) for the timeout
+ * @param asyncPromise an async promise to resolve
+ * @param timeLimit time limit before timeout in milliseconds. Default is 2 min
+ */
+export async function asyncCallWithTimeout(asyncPromise: Promise<any>, timeLimit: number = 120_000) {
+  let timeoutHandle;
+
+  const timeoutPromise = new Promise((_resolve, reject) => {
+    timeoutHandle = setTimeout(
+      () => reject(new Error('Async call timeout limit reached')),
+      timeLimit
+    );
+  });
+
+  return Promise.race([asyncPromise, timeoutPromise]).then(result => {
+    clearTimeout(timeoutHandle);
+    return result;
+  })
+}

--- a/plugins/deployment_manager/Utils.ts
+++ b/plugins/deployment_manager/Utils.ts
@@ -140,5 +140,5 @@ export async function asyncCallWithTimeout(asyncPromise: Promise<any>, timeLimit
   return Promise.race([asyncPromise, timeoutPromise]).then(result => {
     clearTimeout(timeoutHandle);
     return result;
-  })
+  });
 }


### PR DESCRIPTION
This PR makes our deploys more consistent by handling network failures using retries and timeouts (to handle hanging txns). A new function `asyncCallWithRetry` is added to the `DeploymentManager` for this purpose.

I opted to implement the retry/timeout logic at the function level. The other approach would be to wrap an entire deployment script around one retry/timeout handler, but this requires us to cache which txns were already executed, which is difficult to generically do. The trade-off with my approach is that we have to explicitly wrap ad hoc (non-deploy) txns such as `usdc.initialize()` with an `asyncCallWithRetry` function in the deployment script.


