### PR TITLE
Taming migration scripts

### DIFF
--- a/.github/workflows/deploy-market.yaml
+++ b/.github/workflows/deploy-market.yaml
@@ -1,0 +1,53 @@
+name: 'Deploy Market'
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        type: choice
+        description: Network
+        options:
+          - fuji
+          - kovan
+      simulate:
+        type: boolean
+        description: Simulate
+      eth_pk:
+        description: Ethereum Private Key
+jobs:
+  deploy_market:
+    name: Deploy Market
+    runs-on: ubuntu-latest
+    env:
+      ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_KEY }}
+      SNOWTRACE_KEY: ${{ secrets.SNOWTRACE_KEY }}
+      INFURA_KEY: ${{ secrets.INFURA_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install packages
+        run: yarn install --non-interactive --frozen-lockfile
+
+      - name: Compile
+        run: yarn hardhat compile
+
+      - name: Check types
+        run: yarn tsc
+
+      - name: Run Deploy
+        run: yarn hardhat deploy --network ${{ github.event.inputs.network }} ${{ fromJSON('["", "--simulate"]')[github.event.inputs.simulate == 'true'] }}
+        env:
+          ETH_PK: ${{ github.event.inputs.eth_pk }}
+          DEBUG: true
+
+      - name: Commit changes
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git add deployments/\*/roots.json
+          git commit -m "Modified deployment roots from GitHub Actions"
+          git push origin

--- a/.github/workflows/run-scenarios.yaml
+++ b/.github/workflows/run-scenarios.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v2
         with:

--- a/README.md
+++ b/README.md
@@ -187,9 +187,33 @@ Scenarios are high-level property and ad-hoc tests for the Comet protocol. To ru
 
 For more information, see [SCENARIO.md](./SCENARIO.md).
 
+### Migrations
+
+XXX explain/get to
+ deploying a new root contract?
+  deployments/${network}/${market}/deploy.ts
+   open PR, run `deploy` workflow through CI
+    will commit `deployments/` diffs to branch
+ otherwise
+  deployments/${network}/${market}/migrations/XXX.ts
+   open PR
+    if prepare step
+     run `prepare-migration` workflow through CI
+      XXX currently required to run to obtain artifact for enact
+    run `enact-migration` workflow through CI
+     wait for governance/execution
+      merge PR with completed change
+
+New deployment?
+ copy `deploy.ts` scripts from existing instance
+  ignore migrations
+   continue same as above
+
 ### Deploying to testnets
 
 #### Kovan
+
+XXX simplify to above
 
 1. run `1644388553_deploy_kovan` migration, `prepare` step
 2. update `deployments/kovan/roots.json` with the new roots from step 1

--- a/deployments/fuji/migrations/1653512197_seed_rewards_with_comp.ts
+++ b/deployments/fuji/migrations/1653512197_seed_rewards_with_comp.ts
@@ -6,10 +6,11 @@ import { migration } from '../../../plugins/deployment_manager/Migration';
 interface Vars { };
 
 // XXX COMP doesn't exist on Fuji (yet?). Modify this script with a different reward token.
-migration<Vars>('1653512197_seed_rewards_with_comp', {
+export default migration('1653512197_seed_rewards_with_comp', {
   prepare: async (deploymentManager: DeploymentManager) => {
     return {};
   },
+
   enact: async (deploymentManager: DeploymentManager, vars: Vars) => {
     /*
     XXX enable once COMP (or another reward token) is added for Fuji
@@ -72,8 +73,5 @@ migration<Vars>('1653512197_seed_rewards_with_comp', {
     // console.log("RewardConfig: ", await rewards.rewardConfig(comet.address));
 
     */
-  },
-  enacted: async (deploymentManager: DeploymentManager) => {
-    return false;
-  },
+  }
 });

--- a/deployments/kovan/migrations/1653512186_seed_rewards_with_comp.ts
+++ b/deployments/kovan/migrations/1653512186_seed_rewards_with_comp.ts
@@ -6,10 +6,11 @@ import { wait } from '../../../test/helpers';
 
 interface Vars { };
 
-migration<Vars>('1653512186_seed_rewards_with_comp', {
+export default migration('1653512186_seed_rewards_with_comp', {
   prepare: async (deploymentManager: DeploymentManager) => {
     return {};
   },
+
   enact: async (deploymentManager: DeploymentManager, vars: Vars) => {
     const { ethers } = deploymentManager.hre;
 
@@ -68,8 +69,5 @@ migration<Vars>('1653512186_seed_rewards_with_comp', {
     // debug("COMP balance of Timelock: ", await COMP.balanceOf(timelock.address));
     // debug("COMP balance of CometRewards: ", await COMP.balanceOf(rewards.address));
     // debug("RewardConfig: ", await rewards.rewardConfig(comet.address));
-  },
-  enacted: async (deploymentManager: DeploymentManager) => {
-    return false;
-  },
+  }
 });

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -31,7 +31,7 @@ const {
   ETHERSCAN_KEY,
   SNOWTRACE_KEY,
   INFURA_KEY,
-  MNEMONIC = '',
+  MNEMONIC = 'myth like bonus scare over problem client lizard pioneer submit female collect',
   REPORT_GAS = 'false',
 } = process.env;
 
@@ -84,11 +84,7 @@ function setupDefaultNetworkProviders(hardhatConfig: HardhatUserConfig) {
       url: netConfig.url || getDefaultProviderURL(netConfig.network),
       gas: netConfig.gas || 'auto',
       gasPrice: netConfig.gasPrice || 'auto',
-      accounts: ETH_PK
-        ? [ETH_PK]
-        : {
-          mnemonic: MNEMONIC,
-        },
+      accounts: ETH_PK ? [ETH_PK] : { mnemonic: MNEMONIC },
     };
   }
 }
@@ -127,9 +123,7 @@ const config: HardhatUserConfig = {
       gas: 12000000,
       gasPrice: 'auto',
       blockGasLimit: 12000000,
-      accounts: {
-        mnemonic: MNEMONIC || 'myth like bonus scare over problem client lizard pioneer submit female collect',
-      },
+      accounts: ETH_PK ? [{ privateKey: ETH_PK, balance: (10n ** 36n).toString() }] : { mnemonic: MNEMONIC },
       // this should be default commented out and only enabled during dev to allow partial testing
       // XXX comment out by default once we've made the full contract fit
       allowUnlimitedContractSize: true,

--- a/plugins/deployment_manager/MigrationTemplate.ts
+++ b/plugins/deployment_manager/MigrationTemplate.ts
@@ -11,16 +11,14 @@ import { migration } from '../../../plugins/deployment_manager/Migration';
 
 interface Vars {};
 
-migration<Vars>('${timestamp}_${name}', {
+export default migration('${timestamp}_${name}', {
   prepare: async (deploymentManager: DeploymentManager) => {
     return {};
   },
-  enact: async (deploymentManager: DeploymentManager, vars: Vars) => {
 
-  },
-  enacted: async (deploymentManager: DeploymentManager) => {
-    return false;
-  },
+  enact: async (deploymentManager: DeploymentManager, vars: Vars) => {
+    // No governance changes
+  }
 });\n`;
 }
 

--- a/plugins/deployment_manager/test/DeploymentManagerTest.ts
+++ b/plugins/deployment_manager/test/DeploymentManagerTest.ts
@@ -318,7 +318,6 @@ describe('DeploymentManager', () => {
         actions: {
           prepare: async () => null,
           enact: async () => { /* */ },
-          enacted: async () => false
         },
       };
 

--- a/plugins/deployment_manager/test/MigrationTemplateTest.ts
+++ b/plugins/deployment_manager/test/MigrationTemplateTest.ts
@@ -13,16 +13,14 @@ import { migration } from '../../../plugins/deployment_manager/Migration';
 
 interface Vars {};
 
-migration<Vars>('1_cool', {
+export default migration('1_cool', {
   prepare: async (deploymentManager: DeploymentManager) => {
     return {};
   },
-  enact: async (deploymentManager: DeploymentManager, vars: Vars) => {
 
-  },
-  enacted: async (deploymentManager: DeploymentManager) => {
-    return false;
-  },
+  enact: async (deploymentManager: DeploymentManager, vars: Vars) => {
+    // No governance changes
+  }
 });
 `;
 

--- a/plugins/deployment_manager/test/migration.ts
+++ b/plugins/deployment_manager/test/migration.ts
@@ -1,0 +1,10 @@
+import { migration } from '../Migration';
+
+export default migration('test migration', {
+  prepare: async (_deploymentManager) => {
+    return ['step 1'];
+  },
+  enact: async (_deploymentManager, _x) => {
+    // no-op...
+  }
+});

--- a/scenario/CometScenario.ts
+++ b/scenario/CometScenario.ts
@@ -1,7 +1,7 @@
 import { CometProperties, scenario } from './context/CometContext';
 import { expect } from 'chai';
 
-scenario('initializes governor correctly', { migrate: true }, async ({ comet, timelock, actors }, world) => {
+scenario('initializes governor correctly', {}, async ({ comet, timelock, actors }, world) => {
   // TODO: Make this more interesting.
   expect(await comet.governor()).to.equal(timelock.address);
 });

--- a/scenario/constraints/ProposalConstraint.ts
+++ b/scenario/constraints/ProposalConstraint.ts
@@ -1,0 +1,45 @@
+import { Constraint, Scenario, Solution, World } from '../../plugins/scenario';
+import { CometContext } from '../context/CometContext';
+import { Requirements } from './Requirements';
+
+function* subsets<T>(array: T[], offset = 0): Generator<T[]> {
+  while (offset < array.length) {
+    let first = array[offset++];
+    for (let subset of subsets(array, offset)) {
+      subset.push(first);
+      yield subset;
+    }
+  }
+  yield [];
+}
+
+function debug(...args: any[]) {
+  console.log(`[ProposalConstraint]`, ...args);
+}
+
+export class ProposalConstraint<T extends CometContext, R extends Requirements> implements Constraint<T, R> {
+  async solve(requirements: R, context: T, world: World) {
+    let solutions: Solution<T>[] = [];
+
+    // XXX pull all pending proposals for the associated gov (chain)
+    //  produce all the subsets and queue/execute each batch of them
+    //   to form each solution
+    let pendingProposals = [];
+
+    for (let proposalList of subsets(pendingProposals)) {
+      solutions.push(async function (context: T): Promise<T> {
+        // XXX queue/execute each proposal in the list
+        // XXX if gov chain is not local chain, simulate bridge
+        debug(`XXX...`);
+        return context;
+      });
+    }
+
+    return null; // XXX
+    return solutions;
+  }
+
+  async check(requirements: R, context: T, world: World) {
+    return; // XXX
+  }
+}

--- a/scenario/constraints/index.ts
+++ b/scenario/constraints/index.ts
@@ -5,3 +5,4 @@ export { ModernConstraint } from './ModernConstraint';
 export { UtilizationConstraint } from './UtilizationConstraint';
 export { CometBalanceConstraint } from './CometBalanceConstraint';
 export { MigrationConstraint } from './MigrationConstraint';
+export { ProposalConstraint } from './ProposalConstraint';

--- a/scenario/utils.ts
+++ b/scenario/utils.ts
@@ -1,4 +1,6 @@
 import { expect } from 'chai';
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
 import { BigNumber, BigNumberish, utils } from 'ethers';
 import { CometContext } from './context/CometContext';
 import CometAsset from './context/CometAsset';
@@ -269,4 +271,11 @@ function matchGroup(str, patterns): ComparativeAmount {
     if (match) return { val: match[1], op: ComparisonOp[k] };
   }
   throw new Error(`No match for ${str} in ${patterns}`);
+}
+
+export async function modifiedPaths(pattern: RegExp, against: string = 'origin/main'): Promise<string[]> {
+  const output = execSync(`git diff --numstat $(git merge-base ${against} HEAD)`);
+  const paths = output.toString().split('\n').map(l => l.split(/\s+/)[2]);
+  const modified = paths.filter(p => pattern.test(p) && existsSync(p));
+  return modified;
 }


### PR DESCRIPTION
We are working towards a simplified/standard workflow which we still need to document:

 1. Open a PR with a migration script
 2. Run 'prepare' workflow in GitHub CI
  - this should deploy any necessary contracts
  - changes to roots should auto-commit to the PR branch
  - maybe go post in the forum about it for review
 3. Run 'enact' workflow in GitHub CI or elsewhere
  - this should make any necessary gov proposals
 4. Once the proposal is accepted by gov, merge PR with new roots

NB: currently `roots.json` changes *can* happen in migrations. In the next iteration of this, we will have a separate workflow for the (single) 'deploy' script, which should be the only thing modifying roots. Changes which happen in migrations should be automatically spidered in when any related proposal passes. Otherwise, a new root should be added and it should be part of 'deploy'.