### PR TITLE
Remove all unnecessary usages of `upgrade: true` in scenarios

### DIFF
--- a/scenario/AllowBySigScenario.ts
+++ b/scenario/AllowBySigScenario.ts
@@ -35,9 +35,14 @@ scenario(
   }
 );
 
+// XXX These revert scenarios need to set `upgrade: true` because Hardhat fails to
+// recognize custom errors received in fallback functions that originate from external
+// artifacts. For example, CometExt is an external artifact here unless we redeploy it
+// using the ModernConstraint.
+// Related: https://github.com/NomicFoundation/hardhat/issues/1875
 scenario(
   'Comet#allowBySig > fails if owner argument is altered',
-  {},
+  { upgrade: true },
   async ({ comet, actors }, world) => {
     const { albert, betty, charles } = actors;
 
@@ -69,7 +74,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig > fails if manager argument is altered',
-  {},
+  { upgrade: true },
   async ({ comet, actors }, world) => {
     const { albert, betty, charles } = actors;
 
@@ -101,7 +106,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig > fails if isAllowed argument is altered',
-  {},
+  { upgrade: true },
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -133,7 +138,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig > fails if nonce argument is altered',
-  {},
+  { upgrade: true },
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -165,7 +170,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig > fails if expiry argument is altered',
-  {},
+  { upgrade: true },
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -197,7 +202,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig fails if signature contains invalid nonce',
-  {},
+  { upgrade: true },
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -230,7 +235,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig rejects a repeated message',
-  {},
+  { upgrade: true },
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -273,7 +278,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig fails for invalid expiry',
-  {},
+  { upgrade: true },
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -305,7 +310,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig fails if v not in {27,28}',
-  {},
+  { upgrade: true },
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -339,7 +344,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig fails if s is too high',
-  {},
+  { upgrade: true },
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 

--- a/scenario/AllowBySigScenario.ts
+++ b/scenario/AllowBySigScenario.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 
 scenario(
   'Comet#allowBySig > allows a user to authorize a manager by signature',
-  { upgrade: true },
+  {},
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -37,7 +37,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig > fails if owner argument is altered',
-  { upgrade: true },
+  {},
   async ({ comet, actors }, world) => {
     const { albert, betty, charles } = actors;
 
@@ -69,7 +69,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig > fails if manager argument is altered',
-  { upgrade: true },
+  {},
   async ({ comet, actors }, world) => {
     const { albert, betty, charles } = actors;
 
@@ -101,7 +101,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig > fails if isAllowed argument is altered',
-  { upgrade: true },
+  {},
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -133,7 +133,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig > fails if nonce argument is altered',
-  { upgrade: true },
+  {},
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -165,7 +165,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig > fails if expiry argument is altered',
-  { upgrade: true },
+  {},
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -197,7 +197,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig fails if signature contains invalid nonce',
-  { upgrade: true },
+  {},
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -230,7 +230,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig rejects a repeated message',
-  { upgrade: true },
+  {},
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -273,7 +273,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig fails for invalid expiry',
-  { upgrade: true },
+  {},
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -305,7 +305,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig fails if v not in {27,28}',
-  { upgrade: true },
+  {},
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 
@@ -339,7 +339,7 @@ scenario(
 
 scenario(
   'Comet#allowBySig fails if s is too high',
-  { upgrade: true },
+  {},
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
 

--- a/scenario/AllowScenario.ts
+++ b/scenario/AllowScenario.ts
@@ -2,7 +2,7 @@ import { scenario } from './context/CometContext';
 import { expect } from 'chai';
 import { utils } from 'ethers';
 
-scenario('Comet#allow > allows a user to authorize a manager', { upgrade: true }, async ({ comet, actors }) => {
+scenario('Comet#allow > allows a user to authorize a manager', {}, async ({ comet, actors }) => {
   const { albert, betty } = actors;
 
   const txn = await albert.allow(betty, true);

--- a/scenario/ApproveThisScenario.ts
+++ b/scenario/ApproveThisScenario.ts
@@ -2,7 +2,7 @@ import { scenario } from './context/CometContext';
 import { expect } from 'chai';
 import { constants, utils } from 'ethers';
 
-scenario('Comet#approveThis > allows governor to authorize and rescind authorization for Comet ERC20', { upgrade: true }, async ({ comet, timelock, actors }, world, context) => {
+scenario('Comet#approveThis > allows governor to authorize and rescind authorization for Comet ERC20', {}, async ({ comet, timelock, actors }, world, context) => {
   let approveThisCalldata = utils.defaultAbiCoder.encode(["address", "address", "uint256"], [timelock.address, comet.address, constants.MaxUint256]);
   await context.fastGovernanceExecute(
     [comet.address],
@@ -24,7 +24,7 @@ scenario('Comet#approveThis > allows governor to authorize and rescind authoriza
   expect(await comet.isAllowed(comet.address, timelock.address)).to.be.false;
 });
 
-scenario('Comet#approveThis > allows governor to authorize and rescind authorization for non-Comet ERC20', { upgrade: true }, async ({ comet, timelock, actors }, world, context) => {
+scenario('Comet#approveThis > allows governor to authorize and rescind authorization for non-Comet ERC20', {}, async ({ comet, timelock, actors }, world, context) => {
   const baseTokenAddress = await comet.baseToken();
   const baseToken = context.getAssetByAddress(baseTokenAddress);
 
@@ -50,7 +50,7 @@ scenario('Comet#approveThis > allows governor to authorize and rescind authoriza
   expect(await baseToken.allowance(comet.address, timelock.address)).to.be.equal(0n);
 });
 
-scenario('Comet#approveThis > reverts if not called by governor', { upgrade: true }, async ({ comet, timelock, actors }) => {
+scenario('Comet#approveThis > reverts if not called by governor', {}, async ({ comet, timelock, actors }) => {
   await expect(comet.approveThis(timelock.address, comet.address, constants.MaxUint256))
     .to.be.revertedWith("custom error 'Unauthorized()'");
 });

--- a/scenario/CometScenario.ts
+++ b/scenario/CometScenario.ts
@@ -17,6 +17,6 @@ scenario('has assets', {}, async ({ comet, actors, assets }: CometProperties, wo
   expect(collateralAssets.map(a => a.asset)).to.have.members(contextAssets);
 });
 
-scenario('requires upgrade', { upgrade: true }, async ({ comet }, world) => {
+scenario('requires upgrade', {}, async ({ comet }, world) => {
   // Nothing currently here
 });

--- a/scenario/ConfiguratorScenario.ts
+++ b/scenario/ConfiguratorScenario.ts
@@ -4,7 +4,7 @@ import { utils } from 'ethers';
 import { scaleToDecimals } from './utils';
 
 scenario('upgrade governor', { upgradeAll: true }, async ({ comet, configurator, proxyAdmin, timelock, actors }, world, context) => {
-  const { admin, albert } = actors;
+  const { albert } = actors;
 
   expect(await comet.governor()).to.equal(timelock.address);
   expect((await configurator.getConfiguration(comet.address)).governor).to.equal(timelock.address);

--- a/scenario/ConstraintScenario.ts
+++ b/scenario/ConstraintScenario.ts
@@ -5,7 +5,6 @@ import { defactor, expect } from '../test/helpers';
 scenario(
   'Comet#constraint > collateral CometBalanceConstraint + BalanceConstraint both satisfied',
   {
-    upgrade: true,
     tokenBalances: {
       albert: { $asset0: 100 }, // in units of asset, not wei
     },
@@ -26,7 +25,6 @@ scenario(
 scenario(
   'Comet#constraint > base CometBalanceConstraint + BalanceConstraint both satisfied',
   {
-    upgrade: true,
     tokenBalances: {
       albert: { $base: 100 }, // in units of asset, not wei
     },
@@ -52,7 +50,6 @@ scenario(
 scenario(
   'Comet#constraint > negative comet base balance (borrow position)',
   {
-    upgrade: true,
     tokenBalances: {
       albert: { $base: 1000 }, // in units of asset, not wei
     },
@@ -80,7 +77,6 @@ scenario(
 scenario(
   'UtilizationConstraint > sets utilization to 25%',
   {
-    upgrade: true,
     utilization: 0.25,
   },
   async ({ comet }) => {
@@ -91,7 +87,6 @@ scenario(
 scenario(
   'UtilizationConstraint > sets utilization to 50%',
   {
-    upgrade: true,
     utilization: 0.50,
   },
   async ({ comet }) => {
@@ -102,7 +97,6 @@ scenario(
 scenario(
   'UtilizationConstraint > sets utilization to 75%',
   {
-    upgrade: true,
     utilization: 0.75,
   },
   async ({ comet }) => {
@@ -115,7 +109,6 @@ scenario(
 scenario.skip(
   'UtilizationConstraint > sets utilization to 100%',
   {
-    upgrade: true,
     utilization: 1,
   },
   async ({ comet }) => {

--- a/scenario/InterestRateScenario.ts
+++ b/scenario/InterestRateScenario.ts
@@ -80,6 +80,7 @@ scenario(
 scenario(
   'Comet#interestRate > below kink rates using hypothetical configuration constants',
   {
+    upgrade: true,
     cometConfig: {
       supplyKink: exp(0.8, 18),
       supplyPerYearInterestRateBase: exp(0, 18),
@@ -103,6 +104,7 @@ scenario(
 scenario(
   'Comet#interestRate > above kink rates using hypothetical configuration constants',
   {
+    upgrade: true,
     cometConfig: {
       supplyKink: exp(0.8, 18),
       supplyPerYearInterestRateBase: exp(0, 18),
@@ -126,6 +128,7 @@ scenario(
 scenario(
   'Comet#interestRate > rates using fuzzed configuration constants',
   {
+    upgrade: true,
     cometConfig: {
       // TODO: Read types directly from Solidity?
       supplyPerYearInterestRateBase: { type: FuzzType.UINT64 },

--- a/scenario/InterestRateScenario.ts
+++ b/scenario/InterestRateScenario.ts
@@ -40,7 +40,7 @@ function calculateUtilization(
 
 scenario(
   'Comet#interestRate > rates using on-chain configuration constants',
-  { upgrade: true },
+  {},
   async ({ comet, actors }) => {
     let { totalSupplyBase, totalBorrowBase, baseSupplyIndex, baseBorrowIndex } = await comet.totalsBasic();
     const supplyKink = await comet.supplyKink();
@@ -80,7 +80,6 @@ scenario(
 scenario(
   'Comet#interestRate > below kink rates using hypothetical configuration constants',
   {
-    upgrade: true,
     cometConfig: {
       supplyKink: exp(0.8, 18),
       supplyPerYearInterestRateBase: exp(0, 18),
@@ -104,7 +103,6 @@ scenario(
 scenario(
   'Comet#interestRate > above kink rates using hypothetical configuration constants',
   {
-    upgrade: true,
     cometConfig: {
       supplyKink: exp(0.8, 18),
       supplyPerYearInterestRateBase: exp(0, 18),
@@ -128,7 +126,6 @@ scenario(
 scenario(
   'Comet#interestRate > rates using fuzzed configuration constants',
   {
-    upgrade: true,
     cometConfig: {
       // TODO: Read types directly from Solidity?
       supplyPerYearInterestRateBase: { type: FuzzType.UINT64 },
@@ -176,7 +173,7 @@ scenario(
 // XXX this test seems too fickle
 scenario.skip(
   'Comet#interestRate > when utilization is 50%',
-  { utilization: 0.5, upgrade: true },
+  { utilization: 0.5 },
   async ({ comet, actors }, world) => {
     const utilization = await comet.getUtilization();
     expect(defactor(utilization)).to.be.approximately(0.5, 0.00001);

--- a/scenario/LiquidationScenario.ts
+++ b/scenario/LiquidationScenario.ts
@@ -3,7 +3,7 @@ import { CometInterface } from '../build/types';
 import CometActor from './context/CometActor';
 import { event, expect } from '../test/helpers';
 
-async function getLiquidationMargin({comet, actor, baseLiquidity, factorScale}): Promise<bigint> {
+async function getLiquidationMargin({ comet, actor, baseLiquidity, factorScale }): Promise<bigint> {
   const numAssets = await comet.numAssets();
   let liquidity = baseLiquidity;
   for (let i = 0; i < numAssets; i++) {
@@ -24,7 +24,7 @@ invariant:
 isolating for timeElapsed:
 timeElapsed = -liquidationMargin / (baseBalanceOf * price / baseScale) / (borrowRate / factorScale);
 */
-async function timeUntilUnderwater({comet, actor, fudgeFactor = 0n}: {comet: CometInterface, actor: CometActor, fudgeFactor?: bigint}): Promise<number> {
+async function timeUntilUnderwater({ comet, actor, fudgeFactor = 0n }: { comet: CometInterface, actor: CometActor, fudgeFactor?: bigint }): Promise<number> {
   const baseBalance = await actor.getCometBaseBalance();
   const baseScale = (await comet.baseScale()).toBigInt();
   const basePrice = (await comet.getPrice(await comet.baseTokenPriceFeed())).toBigInt();
@@ -32,7 +32,7 @@ async function timeUntilUnderwater({comet, actor, fudgeFactor = 0n}: {comet: Com
   const utilization = await comet.getUtilization();
   const borrowRate = (await comet.getBorrowRate(utilization)).toBigInt();
   const factorScale = (await comet.factorScale()).toBigInt();
-  const liquidationMargin = await getLiquidationMargin({comet, actor, baseLiquidity, factorScale});
+  const liquidationMargin = await getLiquidationMargin({ comet, actor, baseLiquidity, factorScale });
 
   if (liquidationMargin < 0) {
     return 0; // already underwater
@@ -52,7 +52,6 @@ scenario(
       albert: { $base: -1000 },
       betty: { $base: 1000 },
     },
-    upgrade: true
   },
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
@@ -67,7 +66,7 @@ scenario(
       })
     );
 
-    await betty.withdrawAsset({asset: baseToken, amount: baseBorrowMin}); // force accrue
+    await betty.withdrawAsset({ asset: baseToken, amount: baseBorrowMin }); // force accrue
 
     expect(await comet.isLiquidatable(albert.address)).to.be.true;
   }
@@ -86,7 +85,6 @@ scenario(
     pause: {
       absorbPaused: true,
     },
-    upgrade: true
   },
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
@@ -101,10 +99,10 @@ scenario(
       })
     );
 
-    await betty.withdrawAsset({asset: baseToken, amount: baseBorrowMin}); // force accrue
+    await betty.withdrawAsset({ asset: baseToken, amount: baseBorrowMin }); // force accrue
 
     await expect(
-      betty.absorb({absorber: betty.address, accounts: [albert.address]})
+      betty.absorb({ absorber: betty.address, accounts: [albert.address] })
     ).to.be.revertedWith("custom error 'Paused()'");
   }
 );
@@ -122,7 +120,6 @@ scenario(
       },
       betty: { $base: 10 }
     },
-    upgrade: true
   },
   async ({ comet, actors }, world) => {
     const { albert, betty } = actors;
@@ -137,7 +134,7 @@ scenario(
 
     const lp0 = await comet.liquidatorPoints(betty.address);
 
-    await betty.absorb({absorber: betty.address, accounts: [albert.address]});
+    await betty.absorb({ absorber: betty.address, accounts: [albert.address] });
 
     const lp1 = await comet.liquidatorPoints(betty.address);
 
@@ -176,10 +173,9 @@ scenario.skip(
         $asset0: .001
       },
     },
-    upgrade: true
   },
   async ({ comet, actors }, world) => {
-    const { albert, betty, admin } = actors;
+    const { albert, betty, charles } = actors;
     const { asset: asset0Address, scale } = await comet.getAssetInfo(0);
 
     const collateralBalance = scale.toBigInt() / 1000n; // .001
@@ -192,27 +188,27 @@ scenario.skip(
       })
     );
 
-    await betty.absorb({absorber: betty.address, accounts: [albert.address]});
+    await betty.absorb({ absorber: betty.address, accounts: [albert.address] });
 
-    const txReceipt = await admin.withdrawAssetFrom({
+    const txReceipt = await charles.withdrawAssetFrom({
       src: comet.address,
-      dst: admin.address,
+      dst: charles.address,
       asset: asset0Address,
       amount: collateralBalance
     });
 
-    expect(event({receipt: txReceipt}, 0)).to.deep.equal({
+    expect(event({ receipt: txReceipt }, 0)).to.deep.equal({
       Transfer: {
         from: comet.address,
-        to: admin.address,
+        to: charles.address,
         amount: collateralBalance
       }
     });
 
-    expect(event({receipt: txReceipt}, 1)).to.deep.equal({
+    expect(event({ receipt: txReceipt }, 1)).to.deep.equal({
       WithdrawCollateral: {
         src: comet.address,
-        to: admin.address,
+        to: charles.address,
         asset: asset0Address,
         amount: collateralBalance
       }

--- a/scenario/PauseGuardianScenario.ts
+++ b/scenario/PauseGuardianScenario.ts
@@ -76,7 +76,6 @@ scenario(
     pause: {
       all: false,
     },
-    upgrade: true
   },
   async ({ comet, actors }) => {
     const { albert } = actors;

--- a/scenario/SupplyScenario.ts
+++ b/scenario/SupplyScenario.ts
@@ -6,7 +6,6 @@ import { expectApproximately, getExpectedBaseBalance, getInterest } from './util
 scenario(
   'Comet#supply > base asset',
   {
-    upgrade: true,
     tokenBalances: {
       albert: { $base: 100 }, // in units of asset, not wei
     },
@@ -38,7 +37,6 @@ scenario(
 scenario(
   'Comet#supply > collateral asset',
   {
-    upgrade: true,
     tokenBalances: {
       albert: { $asset0: 100 }, // in units of asset, not wei
     },
@@ -76,7 +74,6 @@ scenario(
 scenario(
   'Comet#supply > repay borrow',
   {
-    upgrade: true,
     tokenBalances: {
       albert: { $base: 1000 }
     },
@@ -108,7 +105,6 @@ scenario(
 scenario(
   'Comet#supplyFrom > base asset',
   {
-    upgrade: true,
     tokenBalances: {
       albert: { $base: 100 }, // in units of asset, not wei
     },
@@ -144,7 +140,6 @@ scenario(
 scenario(
   'Comet#supplyFrom > collateral asset',
   {
-    upgrade: true,
     tokenBalances: {
       albert: { $asset0: 100 }, // in units of asset, not wei
     },
@@ -187,7 +182,6 @@ scenario(
 scenario(
   'Comet#supplyFrom > repay borrow',
   {
-    upgrade: true,
     tokenBalances: {
       albert: { $base: 1000 }
     },
@@ -223,7 +217,6 @@ scenario(
 scenario(
   'Comet#supply reverts if not enough ERC20 approval',
   {
-    upgrade: true,
     tokenBalances: {
       albert: { $base: 100 }, // in units of asset, not wei
     },
@@ -246,7 +239,6 @@ scenario(
 scenario(
   'Comet#supplyFrom reverts if not enough ERC20 approval',
   {
-    upgrade: true,
     tokenBalances: {
       albert: { $base: 100 }, // in units of asset, not wei
     },
@@ -274,7 +266,6 @@ scenario(
 scenario(
   'Comet#supply reverts if not enough ERC20 balance',
   {
-    upgrade: true,
     tokenBalances: {
       albert: { $base: 10 }, // in units of asset, not wei
     },
@@ -298,7 +289,6 @@ scenario(
 scenario(
   'Comet#supplyFrom reverts if not enough ERC20 balance',
   {
-    upgrade: true,
     tokenBalances: {
       albert: { $base: 10 }, // in units of asset, not wei
     },
@@ -325,7 +315,6 @@ scenario(
 scenario(
   'Comet#supplyFrom reverts if operator not given permission',
   {
-    upgrade: true,
     tokenBalances: {
       albert: { $asset0: 100 }, // in units of asset, not wei
     },
@@ -351,7 +340,6 @@ scenario(
 scenario(
   'Comet#supply reverts when supply is paused',
   {
-    upgrade: true,
     pause: {
       supplyPaused: true,
     },
@@ -375,7 +363,6 @@ scenario(
 scenario(
   'Comet#supplyFrom reverts when supply is paused',
   {
-    upgrade: true,
     pause: {
       supplyPaused: true,
     },
@@ -400,9 +387,7 @@ scenario(
 
 scenario(
   'Comet#supply reverts if asset is not supported',
-  {
-    upgrade: true,
-  },
+  {},
   async ({ comet, actors }, world, context) => {
     // XXX requires deploying an unsupported asset (maybe via remote token constraint)
   }

--- a/scenario/TransferScenario.ts
+++ b/scenario/TransferScenario.ts
@@ -6,7 +6,6 @@ import { expectApproximately, getExpectedBaseBalance, getInterest } from './util
 scenario(
   'Comet#transfer > collateral asset, enough balance',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $asset0: 100 }, // in units of asset, not wei
     },
@@ -30,7 +29,6 @@ scenario(
 scenario(
   'Comet#transfer > base asset, enough balance',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $base: 100 }, // in units of asset, not wei
     },
@@ -61,7 +59,6 @@ scenario(
 scenario(
   'Comet#transfer > base asset, total and user balances are summed up properly',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $base: 100 }, // in units of asset, not wei
     },
@@ -99,7 +96,6 @@ scenario(
 scenario(
   'Comet#transfer > partial withdraw / borrow base to partial repay / supply',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $base: 1000, $asset0: 5000 }, // in units of asset, not wei
       betty: { $base: -1000 },
@@ -133,7 +129,6 @@ scenario(
 scenario(
   'Comet#transferFrom > withdraw to repay',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $base: 1000, $asset0: 50 }, // in units of asset, not wei
       betty: { $base: -1000 },
@@ -168,7 +163,6 @@ scenario(
 scenario(
   'Comet#transfer base reverts if undercollateralized',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $base: 1000, $asset0: 0.000001 }, // in units of asset, not wei
       betty: { $base: -1000 },
@@ -202,7 +196,6 @@ scenario(
 scenario(
   'Comet#transferFrom base reverts if undercollateralized',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $base: 1000, $asset0: 0.000001 }, // in units of asset, not wei
       betty: { $base: -1000 },
@@ -239,7 +232,6 @@ scenario(
 scenario(
   'Comet#transfer collateral reverts if undercollateralized',
   {
-    upgrade: true,
     // XXX we should probably have a price constraint?
     cometBalances: {
       albert: { $base: -1000, $asset0: '== 3000' }, // in units of asset, not wei
@@ -265,7 +257,6 @@ scenario(
 scenario(
   'Comet#transferFrom collateral reverts if undercollateralized',
   {
-    upgrade: true,
     // XXX we should probably have a price constraint?
     cometBalances: {
       albert: { $base: -1000, $asset0: '== 3000' }, // in units of asset, not wei
@@ -294,9 +285,7 @@ scenario(
 
 scenario(
   'Comet#transfer disallows self-transfer of base',
-  {
-    upgrade: true,
-  },
+  {},
   async ({ comet, actors }) => {
     const { albert } = actors;
 
@@ -314,9 +303,7 @@ scenario(
 
 scenario(
   'Comet#transfer disallows self-transfer of collateral',
-  {
-    upgrade: true,
-  },
+  {},
   async ({ comet, actors }) => {
     const { albert } = actors;
 
@@ -334,9 +321,7 @@ scenario(
 
 scenario(
   'Comet#transferFrom disallows self-transfer of base',
-  {
-    upgrade: true,
-  },
+  {},
   async ({ comet, actors }) => {
     const { albert, betty } = actors;
 
@@ -357,9 +342,7 @@ scenario(
 
 scenario(
   'Comet#transferFrom disallows self-transfer of collateral',
-  {
-    upgrade: true,
-  },
+  {},
   async ({ comet, actors }) => {
     const { albert, betty } = actors;
 
@@ -380,9 +363,7 @@ scenario(
 
 scenario(
   'Comet#transferFrom reverts if operator not given permission',
-  {
-    upgrade: true,
-  },
+  {},
   async ({ comet, actors }, world, context) => {
     const { albert, betty } = actors;
     const baseAssetAddress = await comet.baseToken();
@@ -403,7 +384,6 @@ scenario(
 scenario(
   'Comet#transfer reverts when transfer is paused',
   {
-    upgrade: true,
     pause: {
       transferPaused: true,
     },
@@ -428,7 +408,6 @@ scenario(
 scenario(
   'Comet#transferFrom reverts when transfer is paused',
   {
-    upgrade: true,
     pause: {
       transferPaused: true,
     },
@@ -454,7 +433,6 @@ scenario(
 scenario(
   'Comet#transfer reverts if borrow is less than minimum borrow',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $base: 0, $asset0: 100 }
     }

--- a/scenario/WithdrawReservesScenario.ts
+++ b/scenario/WithdrawReservesScenario.ts
@@ -9,7 +9,6 @@ scenario(
     tokenBalances: {
       betty: { $base: 100000 },
     },
-    upgrade: true,
   },
   async ({ comet, timelock, actors }, world, context) => {
     const { albert, betty } = actors;
@@ -46,7 +45,6 @@ scenario(
     tokenBalances: {
       $comet: { $base: 100 },
     },
-    upgrade: true,
   },
   async ({ actors }) => {
     const { albert } = actors;
@@ -62,10 +60,9 @@ scenario(
     tokenBalances: {
       $comet: { $base: 100 },
     },
-    upgrade: true,
   },
   async ({ comet, actors }, world, context) => {
-    const { admin, albert } = actors;
+    const { albert } = actors;
 
     const scale = (await comet.baseScale()).toBigInt();
 

--- a/scenario/WithdrawScenario.ts
+++ b/scenario/WithdrawScenario.ts
@@ -6,7 +6,6 @@ import { expectApproximately, getExpectedBaseBalance } from './utils';
 scenario(
   'Comet#withdraw > base asset',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $base: 100 }, // in units of asset, not wei
     },
@@ -37,7 +36,6 @@ scenario(
 scenario(
   'Comet#withdraw > collateral asset',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $asset0: 100 }, // in units of asset, not wei
     },
@@ -64,7 +62,6 @@ scenario(
 scenario(
   'Comet#withdraw > borrow base',
   {
-    upgrade: true,
     tokenBalances: {
       $comet: { $base: 1000 }, // in units of asset, not wei
     },
@@ -95,7 +92,6 @@ scenario(
 scenario(
   'Comet#withdrawFrom > base asset',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $base: 100 }, // in units of asset, not wei
     },
@@ -128,7 +124,6 @@ scenario(
 scenario(
   'Comet#withdrawFrom > collateral asset',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $asset0: 1000 }, // in units of asset, not wei
     },
@@ -157,7 +152,6 @@ scenario(
 scenario(
   'Comet#withdrawFrom > borrow base',
   {
-    upgrade: true,
     tokenBalances: {
       $comet: { $base: 1000 }, // in units of asset, not wei
     },
@@ -190,7 +184,6 @@ scenario(
 scenario(
   'Comet#withdrawFrom reverts if operator not given permission',
   {
-    upgrade: true,
     tokenBalances: {
       $comet: { $base: 100 }, // in units of asset, not wei
     },
@@ -219,7 +212,6 @@ scenario(
 scenario(
   'Comet#withdraw reverts when withdraw is paused',
   {
-    upgrade: true,
     pause: {
       withdrawPaused: true,
     },
@@ -243,9 +235,8 @@ scenario(
 scenario(
   'Comet#withdrawFrom reverts when withdraw is paused',
   {
-    upgrade: true,
     pause: {
-        withdrawPaused: true,
+      withdrawPaused: true,
     },
   },
   async ({ comet, actors }) => {
@@ -269,7 +260,6 @@ scenario(
 scenario(
   'Comet#withdraw base reverts if position is undercollateralized',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $base: 0 }, // in units of asset, not wei
       charles: { $base: 1000 }, // to give the protocol enough base for others to borrow from
@@ -293,7 +283,6 @@ scenario(
 scenario(
   'Comet#withdraw collateral reverts if position is undercollateralized',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $base: -1000, $asset0: 1000 }, // in units of asset, not wei
     },
@@ -316,7 +305,6 @@ scenario(
 scenario(
   'Comet#withdraw reverts if borrow is less than minimum borrow',
   {
-    upgrade: true,
     cometBalances: {
       albert: { $base: 0, $asset0: 100 }
     }
@@ -338,9 +326,7 @@ scenario(
 
 scenario.skip(
   'Comet#withdraw reverts if asset is not supported',
-  {
-    upgrade: true,
-  },
+  {},
   async ({ comet, actors }, world, context) => {
     // XXX requires deploying an unsupported asset (maybe via remote token constraint)
   }
@@ -348,9 +334,7 @@ scenario.skip(
 
 scenario.skip(
   'Comet#withdraw reverts if not enough asset in protocol',
-  {
-    upgrade: true,
-  },
+  {},
   async ({ comet, actors }, world, context) => {
     // XXX fix for development base, where Faucet token doesn't give the same revert message
   }


### PR DESCRIPTION
This PR removes unnecessary usages of `upgrade: true` from our scenarios. Some scenarios still have valid reasons for using it (e.g. interest rate scenarios that use it to upgrade the interest rate params), so these are not fully removed from all scenarios.