### PR TITLE
restore mnemonic

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -123,7 +123,7 @@ const config: HardhatUserConfig = {
       gas: 12000000,
       gasPrice: 'auto',
       blockGasLimit: 12000000,
-      accounts: ETH_PK ? [{ privateKey: ETH_PK, balance: (10n ** 36n).toString() }] : { mnemonic: MNEMONIC },
+      accounts: { mnemonic: MNEMONIC },
       // this should be default commented out and only enabled during dev to allow partial testing
       // XXX comment out by default once we've made the full contract fit
       allowUnlimitedContractSize: true,


### PR DESCRIPTION
If you run unit tests or scenarios on `main` with a value set for the environment variable `ETH_PK`, then nearly all tests will fail:

<img width="614" alt="image" src="https://user-images.githubusercontent.com/2570291/182264221-7a3b9ca9-0e18-4721-8e92-2b3eca406ad8.png">

The address that can't be found is the one for the `pauseGuardian`, which is equal to `signers[1]`.

The reason this can't be found is because in the Hardhat config, if you have `ETH_PK` set, then we only generate a single signer. So the signer array only has one member, and `signers[1]` is undefined.

We can fix this by restoring the signer generation to use `MNEMONIC`. If we really need to set the balance for the generated signers, we can use the `accountsBalance` field: https://hardhat.org/hardhat-network/docs/reference#accounts