### PR TITLE
Add back signer reset

### DIFF
--- a/plugins/deployment_manager/DeploymentManager.ts
+++ b/plugins/deployment_manager/DeploymentManager.ts
@@ -320,6 +320,8 @@ export class DeploymentManager {
       debug(`Retrying with retries left: ${retries}, wait: ${wait}`);
       debug('Error is: ', e);
       if (retries === 0) throw e;
+      // XXX to be extra safe, we can also get the signer transaction count and figure out the next nonce
+      this._signers = [];
       await new Promise(ok => setTimeout(ok, wait));
       return await this.asyncCallWithRetry(fn, retries, timeLimit, wait * 2);
     }

--- a/plugins/deployment_manager/DeploymentManager.ts
+++ b/plugins/deployment_manager/DeploymentManager.ts
@@ -321,6 +321,8 @@ export class DeploymentManager {
       debug('Error is: ', e);
       if (retries === 0) throw e;
       // XXX to be extra safe, we can also get the signer transaction count and figure out the next nonce
+      // We reset signers here to force a new signer to be instantiated using a new provider. This helps
+      // when retrying hanging txns.
       this._signers = [];
       await new Promise(ok => setTimeout(ok, wait));
       return await this.asyncCallWithRetry(fn, retries, timeLimit, wait * 2);


### PR DESCRIPTION
Adding this back since it is needed for retrying hanging txns and was removed previously when we mistakenly thought it contributed to the nonce re-use issues in scenarios.