### PR TITLE
add recipient to Liquidator.sol

### DIFF
--- a/test/liquidation/liquidation-bot-test.ts
+++ b/test/liquidation/liquidation-bot-test.ts
@@ -15,7 +15,7 @@ describe('Liquidator', function () {
   });
 
   it('Should execute DAI flash swap with profit', async () => {
-    const { comet, liquidator, users: [owner, underwater], assets: { dai, usdc } } = await makeLiquidatableProtocol();
+    const { comet, liquidator, users: [owner, underwater, recipient], assets: { dai, usdc } } = await makeLiquidatableProtocol();
     // underwater user approves Comet
     await dai.connect(underwater).approve(comet.address, exp(120, 18));
     // underwater user supplies DAI to Comet
@@ -23,7 +23,7 @@ describe('Liquidator', function () {
     // artificially put in an underwater borrow position
     await comet.setBasePrincipal(underwater.address, -(exp(200, 6)));
 
-    const beforeUSDCBalance = await usdc.balanceOf(owner.address);
+    const beforeUSDCBalance = await usdc.balanceOf(recipient.address);
     const tx = await wait(liquidator.connect(owner).initFlash({
       accounts: [underwater.address],
       pairToken: ethers.utils.getAddress(dai.address),
@@ -32,7 +32,7 @@ describe('Liquidator', function () {
 
 
     expect(tx.hash).to.be.not.null;
-    const afterUSDCBalance = await usdc.balanceOf(owner.address);
+    const afterUSDCBalance = await usdc.balanceOf(recipient.address);
     const profit = afterUSDCBalance - beforeUSDCBalance;
     expect(tx.hash).to.be.not.null;
     expect(profit).to.be.greaterThan(0);
@@ -45,19 +45,19 @@ describe('Liquidator', function () {
   });
 
   it('Should execute WETH flash swap with profit', async () => {
-    const { comet, liquidator, users: [owner, underwater], assets: { usdc, weth } } = await makeLiquidatableProtocol();
+    const { comet, liquidator, users: [owner, underwater, recipient], assets: { usdc, weth } } = await makeLiquidatableProtocol();
     await weth.connect(underwater).approve(comet.address, exp(120, 18));
     await comet.connect(underwater).supply(weth.address, exp(120, 18));
     await comet.setBasePrincipal(underwater.address, -(exp(4000, 6)));
 
-    const beforeUSDCBalance = await usdc.balanceOf(owner.address);
+    const beforeUSDCBalance = await usdc.balanceOf(recipient.address);
     const tx = await wait(liquidator.connect(owner).initFlash({
       accounts: [underwater.address],
       pairToken: ethers.utils.getAddress(DAI),
       poolFee: 100
     }));
 
-    const afterUSDCBalance = await usdc.balanceOf(owner.address);
+    const afterUSDCBalance = await usdc.balanceOf(recipient.address);
     const profit = afterUSDCBalance - beforeUSDCBalance;
     expect(tx.hash).to.be.not.null;
     expect(profit).to.be.greaterThan(0);
@@ -70,19 +70,19 @@ describe('Liquidator', function () {
   });
 
   it('Should execute WBTC flash swap with profit', async () => {
-    const { comet, liquidator, users: [owner, underwater], assets: { usdc, wbtc } } = await makeLiquidatableProtocol();
+    const { comet, liquidator, users: [owner, underwater, recipient], assets: { usdc, wbtc } } = await makeLiquidatableProtocol();
     await wbtc.connect(underwater).approve(comet.address, exp(2, 8));
     await comet.connect(underwater).supply(wbtc.address, exp(2, 8));
     await comet.setBasePrincipal(underwater.address, -(exp(40000, 6)));
 
-    const beforeUSDCBalance = await usdc.balanceOf(owner.address);
+    const beforeUSDCBalance = await usdc.balanceOf(recipient.address);
     const tx = await wait(liquidator.connect(owner).initFlash({
       accounts: [underwater.address],
       pairToken: ethers.utils.getAddress(DAI),
       poolFee: 100
     }));
 
-    const afterUSDCBalance = await usdc.balanceOf(owner.address);
+    const afterUSDCBalance = await usdc.balanceOf(recipient.address);
     const profit = afterUSDCBalance - beforeUSDCBalance;
     expect(tx.hash).to.be.not.null;
     expect(profit).to.be.greaterThan(0);
@@ -95,19 +95,19 @@ describe('Liquidator', function () {
   });
 
   it('Should execute UNI flash swap with profit', async () => {
-    const { comet, liquidator, users: [owner, underwater], assets: { usdc, uni } } = await makeLiquidatableProtocol();
+    const { comet, liquidator, users: [owner, underwater, recipient], assets: { usdc, uni } } = await makeLiquidatableProtocol();
     await uni.connect(underwater).approve(comet.address, exp(120, 18));
     await comet.connect(underwater).supply(uni.address, exp(120, 18));
     await comet.setBasePrincipal(underwater.address, -(exp(40000, 6)));
 
-    const beforeUSDCBalance = await usdc.balanceOf(owner.address);
+    const beforeUSDCBalance = await usdc.balanceOf(recipient.address);
     const tx = await wait(liquidator.connect(owner).initFlash({
       accounts: [underwater.address],
       pairToken: ethers.utils.getAddress(DAI),
       poolFee: 100,
     }));
 
-    const afterUSDCBalance = await usdc.balanceOf(owner.address);
+    const afterUSDCBalance = await usdc.balanceOf(recipient.address);
     const profit = afterUSDCBalance - beforeUSDCBalance;
     expect(tx.hash).to.be.not.null;
     expect(profit).to.be.greaterThan(0);
@@ -120,19 +120,19 @@ describe('Liquidator', function () {
   });
 
   it('Should execute COMP flash swap with profit', async () => {
-    const { comet, liquidator, users: [owner, underwater], assets: { usdc, comp } } = await makeLiquidatableProtocol();
+    const { comet, liquidator, users: [owner, underwater, recipient], assets: { usdc, comp } } = await makeLiquidatableProtocol();
     await comp.connect(underwater).approve(comet.address, exp(12, 18));
     await comet.connect(underwater).supply(comp.address, exp(12, 18));
     await comet.setBasePrincipal(underwater.address, -(exp(40000, 6)));
 
-    const beforeUSDCBalance = await usdc.balanceOf(owner.address);
+    const beforeUSDCBalance = await usdc.balanceOf(recipient.address);
     const tx = await wait(liquidator.connect(owner).initFlash({
       accounts: [underwater.address],
       pairToken: ethers.utils.getAddress(DAI),
       poolFee: 100,
     }));
 
-    const afterUSDCBalance = await usdc.balanceOf(owner.address);
+    const afterUSDCBalance = await usdc.balanceOf(recipient.address);
     const profit = afterUSDCBalance - beforeUSDCBalance;
     expect(tx.hash).to.be.not.null;
     expect(profit).to.be.greaterThan(0);
@@ -145,19 +145,19 @@ describe('Liquidator', function () {
   });
 
   it('Should execute LINK flash swap with profit', async () => {
-    const { comet, liquidator, users: [owner, underwater], assets: { usdc, link } } = await makeLiquidatableProtocol();
+    const { comet, liquidator, users: [owner, underwater, recipient], assets: { usdc, link } } = await makeLiquidatableProtocol();
     await link.connect(underwater).approve(comet.address, exp(12, 18));
     await comet.connect(underwater).supply(link.address, exp(12, 18));
     await comet.setBasePrincipal(underwater.address, -(exp(4000, 6)));
 
-    const beforeUSDCBalance = await usdc.balanceOf(owner.address);
+    const beforeUSDCBalance = await usdc.balanceOf(recipient.address);
     const tx = await wait(liquidator.connect(owner).initFlash({
       accounts: [underwater.address],
       pairToken: ethers.utils.getAddress(DAI),
       poolFee: 100
     }));
 
-    const afterUSDCBalance = await usdc.balanceOf(owner.address);
+    const afterUSDCBalance = await usdc.balanceOf(recipient.address);
     const profit = afterUSDCBalance - beforeUSDCBalance;
     expect(tx.hash).to.be.not.null;
     expect(profit).to.be.greaterThan(0);

--- a/test/liquidation/makeLiquidatableProtocol.ts
+++ b/test/liquidation/makeLiquidatableProtocol.ts
@@ -139,9 +139,14 @@ export default async function makeLiquidatableProtocol() {
     totalBorrowBase: 2e13
   });
 
+
+  // create underwater user
+  const [signer, underwaterUser, recipient] = await ethers.getSigners();
+
   // build Liquidator
   const Liquidator = await ethers.getContractFactory('Liquidator') as Liquidator__factory;
   const liquidator = await Liquidator.deploy(
+    recipient.address,
     ethers.utils.getAddress(SWAP_ROUTER),
     ethers.utils.getAddress(comet.address),
     ethers.utils.getAddress(UNISWAP_V3_FACTORY),
@@ -159,9 +164,6 @@ export default async function makeLiquidatableProtocol() {
     [500, 500, 3000, 3000, 3000, 3000]
   );
   await liquidator.deployed();
-
-  // create underwater user
-  const [signer, underwaterUser] = await ethers.getSigners();
 
   const mockDai = new ethers.Contract(DAI, daiAbi, signer);
   const mockUSDC = new ethers.Contract(USDC, usdcAbi, signer);
@@ -230,7 +232,7 @@ export default async function makeLiquidatableProtocol() {
   return {
     comet: cometHarnessInterface,
     liquidator,
-    users: [signer, underwaterUser],
+    users: [signer, underwaterUser, recipient],
     assets: {
       dai: mockDai,
       usdc: mockUSDC,

--- a/test/liquidation/makeLiquidatableProtocol.ts
+++ b/test/liquidation/makeLiquidatableProtocol.ts
@@ -139,7 +139,6 @@ export default async function makeLiquidatableProtocol() {
     totalBorrowBase: 2e13
   });
 
-
   // create underwater user
   const [signer, underwaterUser, recipient] = await ethers.getSigners();
 


### PR DESCRIPTION
adding an immutable recipient address to the Liquidator contract. when you deploy, you specify the address that should receive the profits of any liquidations.

this should prevent generalized front-runners from taking profitable transactions from the caller of the Liquidator contract, since a front-runner that mimicked the arguments would only end up sending profits to the specified address.

it has the added benefit of allowing us to initiate transactions from a hot wallet but automatically transfer liquidated funds to a cold wallet.

cc: @ajb413 