### PR TITLE
Add Seacrest Support

### DIFF
--- a/.github/workflows/deploy-market.yaml
+++ b/.github/workflows/deploy-market.yaml
@@ -15,7 +15,7 @@ on:
         type: boolean
         description: Simulate
       eth_pk:
-        description: Ethereum Private Key
+        description: Ignore if you plan to use WalletConnect, otherwise, you can paste in a Ethereum private key
 jobs:
   deploy_market:
     name: Deploy Market
@@ -25,6 +25,13 @@ jobs:
       SNOWTRACE_KEY: ${{ secrets.SNOWTRACE_KEY }}
       INFURA_KEY: ${{ secrets.INFURA_KEY }}
     steps:
+      - name: Seacrest
+        uses: hayesgm/seacrest@v1
+        with:
+          ethereum_url: "${{ fromJSON('{\"fuji\": \"https://api.avax-test.network/ext/bc/C/rpc\", \"kovan\": \"https://kovan-eth.compound.finance\"}')[inputs.network] }}"
+          port: 8585
+        if: github.event.inputs.eth_pk == ''
+
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -42,9 +49,16 @@ jobs:
         run: yarn tsc
 
       - name: Run Deploy
-        run: yarn hardhat deploy --network ${{ github.event.inputs.network }} --deployment ${{ github.event.inputs.deployment }} ${{ fromJSON('["", "--simulate"]')[github.event.inputs.simulate == 'true'] }}
+        run: |
+          if [ -n "${{ inputs.eth_pk }}" ]; then
+            export ETH_PK="${{ inputs.eth_pk }}"
+          else
+            export NETWORK_PROVIDER="http://localhost:8585"
+            export REMOTE_ACCOUNTS="true"
+          fi
+
+          yarn hardhat deploy --network ${{ github.event.inputs.network }} --deployment ${{ github.event.inputs.deployment }} ${{ fromJSON('["", "--simulate"]')[github.event.inputs.simulate == 'true'] }}
         env:
-          ETH_PK: ${{ github.event.inputs.eth_pk }}
           DEBUG: true
 
       - name: Commit changes

--- a/.github/workflows/enact-migration.yaml
+++ b/.github/workflows/enact-migration.yaml
@@ -21,7 +21,7 @@ on:
         description: Run ID for Artifact
         required: true
       eth_pk:
-        description: Ethereum Private Key
+        description: Ignore if you plan to use WalletConnect, otherwise, you can paste in a Ethereum private key
 jobs:
   enact_migration:
     name: Enact Migration
@@ -31,6 +31,13 @@ jobs:
       SNOWTRACE_KEY: ${{ secrets.SNOWTRACE_KEY }}
       INFURA_KEY: ${{ secrets.INFURA_KEY }}
     steps:
+      - name: Seacrest
+        uses: hayesgm/seacrest@v1
+        with:
+          ethereum_url: "${{ fromJSON('{\"fuji\": \"https://api.avax-test.network/ext/bc/C/rpc\", \"kovan\": \"https://kovan-eth.compound.finance\"}')[inputs.network] }}"
+          port: 8585
+        if: github.event.inputs.eth_pk == ''
+
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -55,6 +62,12 @@ jobs:
           path: deployments/${{ github.event.inputs.network }}/${{ github.event.inputs.deployment }}/artifacts/
 
       - name: Run Enact Migration
-        run: yarn hardhat migrate --network ${{ github.event.inputs.network }} --deployment ${{ github.event.inputs.deployment }} --enact --overwrite ${{ fromJSON('["", "--simulate"]')[github.event.inputs.simulate == 'true'] }} ${{ github.event.inputs.migration }}
-        env:
-          ETH_PK: ${{ github.event.inputs.eth_pk }}
+        run: |
+          if [ -n "${{ inputs.eth_pk }}" ]; then
+            export ETH_PK="${{ inputs.eth_pk }}"
+          else
+            export NETWORK_PROVIDER="http://localhost:8585"
+            export REMOTE_ACCOUNTS="true"
+          fi
+
+          yarn hardhat migrate --network ${{ github.event.inputs.network }} --deployment ${{ github.event.inputs.deployment }} --enact --overwrite ${{ fromJSON('["", "--simulate"]')[github.event.inputs.simulate == 'true'] }} ${{ github.event.inputs.migration }}

--- a/.github/workflows/prepare-migration.yaml
+++ b/.github/workflows/prepare-migration.yaml
@@ -18,7 +18,7 @@ on:
         type: boolean
         description: Simulate
       eth_pk:
-        description: Ethereum Private Key
+        description: Ignore if you plan to use WalletConnect, otherwise, you can paste in a Ethereum private key
 jobs:
   prepare_migration:
     name: Prepare Migration
@@ -28,6 +28,13 @@ jobs:
       SNOWTRACE_KEY: ${{ secrets.SNOWTRACE_KEY }}
       INFURA_KEY: ${{ secrets.INFURA_KEY }}
     steps:
+      - name: Seacrest
+        uses: hayesgm/seacrest@v1
+        with:
+          ethereum_url: "${{ fromJSON('{\"fuji\": \"https://api.avax-test.network/ext/bc/C/rpc\", \"kovan\": \"https://kovan-eth.compound.finance\"}')[inputs.network] }}"
+          port: 8585
+        if: github.event.inputs.eth_pk == ''
+
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -45,9 +52,16 @@ jobs:
         run: yarn tsc
 
       - name: Run Prepare Migration
-        run: yarn hardhat migrate --network ${{ github.event.inputs.network }} --deployment ${{ github.event.inputs.deployment }} --prepare --overwrite ${{ fromJSON('["", "--simulate"]')[github.event.inputs.simulate == 'true'] }} ${{ github.event.inputs.migration }}
+        run: |
+          if [ -n "${{ inputs.eth_pk }}" ]; then
+            export ETH_PK="${{ inputs.eth_pk }}"
+          else
+            export NETWORK_PROVIDER="http://localhost:8585"
+            export REMOTE_ACCOUNTS="true"
+          fi
+
+          yarn hardhat migrate --network ${{ github.event.inputs.network }} --deployment ${{ github.event.inputs.deployment }} --prepare --overwrite ${{ fromJSON('["", "--simulate"]')[github.event.inputs.simulate == 'true'] }} ${{ github.event.inputs.migration }}
         env:
-          ETH_PK: ${{ github.event.inputs.eth_pk }}
           DEBUG: true
 
       - uses: actions/upload-artifact@v2 # upload test results


### PR DESCRIPTION
This patch adds Seacrest to our GitHub Actions for Deploy, Prepare and Enact. As per [Seacrest](https://github.com/hayesgm/seacrest), when you run these actions, you will be prompted with a QR Code to connect WalletConnect. Once you scan that QR code (with, e.g. MetaMask Mobile), the rest of the code will depend on that account for any transactions (e.g. deploying a contract). You will individually sign off on any requests during the progression of the action without any risk of key exfiltration.
    
Note: this patch removes `eth_pk` as an option, but technically we could have this as an either/or. I just tend to think it's superior enough that we should supplant the old flow.