### PR TITLE
Set RewardConfig during initial deployment

### DIFF
--- a/deployments/fuji/usdc/configuration.json
+++ b/deployments/fuji/usdc/configuration.json
@@ -21,6 +21,7 @@
     "baseBorrowSpeed": "0.0011458333333333333e15",
     "baseMinForRewards": "1000000e6"
   },
+  "rewardToken": "WAVAX",
   "assets": {
     "WBTC.e": {
       "priceFeed": "0x31CF013A08c6Ac228C94551d535d5BAfE19c602a",

--- a/deployments/hardhat/dai/configuration.json
+++ b/deployments/hardhat/dai/configuration.json
@@ -20,5 +20,6 @@
     "baseBorrowSpeed": "0.0011458333333333333e15",
     "baseMinForRewards": "1000000e6"
   },
+  "rewardToken": "GOLD",
   "assets": {}
 }

--- a/deployments/kovan/usdc/configuration.json
+++ b/deployments/kovan/usdc/configuration.json
@@ -21,6 +21,7 @@
     "baseBorrowSpeed": "0.0011458333333333333e15",
     "baseMinForRewards": "1000000e6"
   },
+  "rewardToken": "COMP",
   "assets": {
     "COMP": {
       "priceFeed": "0xECF93D14d25E02bA2C13698eeDca9aA98348EFb6",

--- a/deployments/mainnet/usdc/configuration.json
+++ b/deployments/mainnet/usdc/configuration.json
@@ -24,6 +24,7 @@
     "baseBorrowSpeed": "0e15",
     "baseMinForRewards": "1000000e6"
   },
+  "rewardTokenAddress": "0xc00e94cb662c3520282e6f5717214004a7f26888",
   "assets": {
     "COMP": {
       "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",

--- a/src/deploy/Network.ts
+++ b/src/deploy/Network.ts
@@ -282,7 +282,7 @@ export async function deployNetworkComet(
 function validateConfiguration(contractsToDeploy: ContractsToDeploy, config: ProtocolConfiguration) {
   if (shouldDeploy(contractsToDeploy.all, contractsToDeploy.rewards)) {
     if (config.rewardTokenAddress == null) {
-      throw Error('RewardToken or RewardTokenAddress must be defined in configuration.json if CometRewards is being deployed.')
+      throw Error('RewardToken or RewardTokenAddress must be defined in configuration.json if CometRewards is being deployed.');
     }
   }
 }

--- a/src/deploy/NetworkConfiguration.ts
+++ b/src/deploy/NetworkConfiguration.ts
@@ -70,6 +70,8 @@ interface NetworkConfiguration {
   rates: NetworkRateConfiguration;
   tracking: NetworkTrackingConfiguration;
   assets: { [name: string]: NetworkAssetConfiguration };
+  rewardToken?: string;
+  rewardTokenAddress?: string;
 }
 
 function getContractAddress(contractName: string, contracts: ContractMap, fallbackAddress?: string): string {
@@ -132,7 +134,8 @@ function getOverridesOrConfig(
     targetReserves: _ => number(config.targetReserves),
     ...interestRateInfoMapping(config.rates),
     ...trackingInfoMapping(config.tracking),
-    assetConfigs: _ => getAssetConfigs(config.assets, contracts)
+    assetConfigs: _ => getAssetConfigs(config.assets, contracts),
+    rewardTokenAddress: _ => getContractAddress(config.rewardToken, contracts, config.rewardTokenAddress)
   });
   return Object.entries(mapping()).reduce((acc, [k, f]) => {
     return { [k]: overrides[k] ?? f(config), ...acc };

--- a/src/deploy/NetworkConfiguration.ts
+++ b/src/deploy/NetworkConfiguration.ts
@@ -135,7 +135,9 @@ function getOverridesOrConfig(
     ...interestRateInfoMapping(config.rates),
     ...trackingInfoMapping(config.tracking),
     assetConfigs: _ => getAssetConfigs(config.assets, contracts),
-    rewardTokenAddress: _ => getContractAddress(config.rewardToken, contracts, config.rewardTokenAddress)
+    rewardTokenAddress: _ => (config.rewardToken || config.rewardTokenAddress) ?
+      getContractAddress(config.rewardToken, contracts, config.rewardTokenAddress) :
+      undefined
   });
   return Object.entries(mapping()).reduce((acc, [k, f]) => {
     return { [k]: overrides[k] ?? f(config), ...acc };

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -32,6 +32,7 @@ export interface ProtocolConfiguration {
   baseBorrowMin?: BigNumberish;
   targetReserves?: BigNumberish;
   assetConfigs?: AssetConfigStruct[];
+  rewardTokenAddress?: string;
 }
 
 // Specific contracts take precedence over `all`, which allows for expressions


### PR DESCRIPTION
This PR updates the deploy function to set the `RewardConfig` in the `CometRewards` contract as part of the deployment process. 

Two optional fields have been added to `configuration.json` to specify the reward token for a certain deployment: `rewardToken` (token symbol) and `rewardTokenAddress`. If the rewards contract is to be deployed, then one of these two fields must be specified in the deployment's `configuration.json`.