### PR TITLE
Fix empty solutions being returned by proposal constraint

### DIFF
--- a/scenario/constraints/ProposalConstraint.ts
+++ b/scenario/constraints/ProposalConstraint.ts
@@ -87,7 +87,7 @@ export class ProposalConstraint<T extends CometContext, R extends Requirements> 
       });
     }
 
-    return solutions;
+    return solutions.length > 0 ? solutions : null;
   }
 
   async check(requirements: R, context: T, world: World) {


### PR DESCRIPTION
This bug is causing all our mainnet scenarios to run with 0 solutions (basically mainnet scenarios are skipped).