### PR TITLE
Make contracts cached per network properly

### DIFF
--- a/.github/workflows/run-scenarios.yaml
+++ b/.github/workflows/run-scenarios.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            deployments/.contracts
+            deployments/*/.contracts
             deployments/**/aliases.json
             !deployments/hardhat
             !deployments/relations.ts

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ artifacts/
 build/
 cache/
 dist/
-deployments/.contracts
+deployments/*/.contracts
 deployments/*/*/verify
 deployments/*/*/aliases.json
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,7 +2,7 @@ artifacts
 build
 cache
 coverage
-deployments/.contracts
+deployments/*/.contracts
 deployments/*/*/*.json
 dist
 SPEC.md

--- a/plugins/deployment_manager/ContractMap.ts
+++ b/plugins/deployment_manager/ContractMap.ts
@@ -4,14 +4,14 @@ import { Address, Alias, BuildFile } from './Types';
 
 export type ContractMap = Map<Alias, Contract>;
 
-function getFileSpec(address: Address): FileSpec {
-  return { top: ['.contracts', address + '.json'] };
+function getFileSpec(network: string, address: Address): FileSpec {
+  return { top: [network, '.contracts', address + '.json'] };
 }
 
-export async function getBuildFile(cache: Cache, address: Address): Promise<BuildFile> {
-  return cache.readCache<BuildFile>(getFileSpec(address));
+export async function getBuildFile(cache: Cache, network: string, address: Address): Promise<BuildFile> {
+  return cache.readCache<BuildFile>(getFileSpec(network, address));
 }
 
-export async function storeBuildFile(cache: Cache, address: Address, buildFile: BuildFile) {
-  await cache.storeCache(getFileSpec(address), buildFile);
+export async function storeBuildFile(cache: Cache, network: string, address: Address, buildFile: BuildFile) {
+  await cache.storeCache(getFileSpec(network, address), buildFile);
 }

--- a/plugins/deployment_manager/Deploy.ts
+++ b/plugins/deployment_manager/Deploy.ts
@@ -4,11 +4,10 @@ import * as fs from 'fs/promises';
 import { Contract, Signer } from 'ethers';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 
-import { putAlias } from './Aliases';
 import { putVerifyArgs } from './VerifyArgs';
 import { Cache } from './Cache';
 import { storeBuildFile } from './ContractMap';
-import { Alias, BuildFile } from './Types';
+import { BuildFile } from './Types';
 import { debug, getPrimaryContract } from './Utils';
 import { VerifyArgs, verifyContract, VerificationStrategy } from './Verify';
 
@@ -18,12 +17,12 @@ export abstract class Deployer<Contract, DeployArgs extends Array<any>> {
 }
 
 export interface DeployOpts {
+  network: string; // the real name of the network we would actually or hypothetically deploy on
   overwrite?: boolean; // should we overwrite existing contract link
   connect?: Signer; // signer for the returned contract
   verificationStrategy?: VerificationStrategy; // strategy for verifying contracts on etherscan
   raiseOnVerificationFailure?: boolean; // if verification is considered critical
   cache?: Cache; // caches the build file, if included
-  alias?: Alias; // set an alias for the contract and store in cache
 }
 
 // Deploys a contract given a build file (e.g. something imported or spidered)
@@ -31,7 +30,7 @@ async function deployFromBuildFile<C extends Contract>(
   buildFile: BuildFile,
   deployArgs: any[],
   hre: HardhatRuntimeEnvironment,
-  deployOpts: DeployOpts = {}
+  deployOpts: DeployOpts
 ): Promise<C> {
   let [contractName, metadata] = getPrimaryContract(buildFile);
   const [ethersSigner] = await hre.ethers.getSigners();
@@ -46,11 +45,7 @@ async function deployFromBuildFile<C extends Contract>(
 
 async function maybeStoreCache(deployOpts: DeployOpts, contract: Contract, buildFile: BuildFile) {
   if (deployOpts.cache) {
-    await storeBuildFile(deployOpts.cache, contract.address, buildFile);
-
-    if (deployOpts.alias) {
-      await putAlias(deployOpts.cache, deployOpts.alias, contract.address);
-    }
+    await storeBuildFile(deployOpts.cache, deployOpts.network, contract.address, buildFile);
   }
 }
 
@@ -88,7 +83,7 @@ export async function deploy<
   contractFile: string,
   deployArgs: DeployArgs,
   hre: HardhatRuntimeEnvironment,
-  deployOpts: DeployOpts = {}
+  deployOpts: DeployOpts
 ): Promise<C> {
   let contractFileName = contractFile.split('/').reverse()[0];
   let contractName = contractFileName.replace('.sol', '');
@@ -139,7 +134,7 @@ export async function deployBuild<C extends Contract>(
   buildFile: BuildFile,
   deployArgs: any[],
   hre: HardhatRuntimeEnvironment,
-  deployOpts: DeployOpts = {}
+  deployOpts: DeployOpts
 ): Promise<C> {
   debug(`Deploying ${Object.keys(buildFile.contracts)} with args`, deployArgs);
 

--- a/plugins/deployment_manager/DeploymentManager.ts
+++ b/plugins/deployment_manager/DeploymentManager.ts
@@ -105,6 +105,7 @@ export class DeploymentManager {
 
   private async deployOpts(): Promise<DeployOpts> {
     return {
+      network: this.network,
       verificationStrategy: this.config.verificationStrategy,
       cache: this.cache,
       connect: await this.getSigner(),
@@ -144,7 +145,7 @@ export class DeploymentManager {
 
   /* Unconditionally casts a contract as the given artifact type, without caching */
   async cast<C extends Contract>(address: string, artifact: string): Promise<C> {
-    const buildFile = await readContract(this.cache, this.hre, artifact, address, true);
+    const buildFile = await readContract(this.cache, this.hre, artifact, this.network, address, true);
     return getEthersContract<C>(address, buildFile, this.hre);
   }
 
@@ -159,7 +160,6 @@ export class DeploymentManager {
   ): Promise<C> {
     const maybeExisting: C = await this.contract(alias);
     if (!maybeExisting || force) {
-      // NB: might use an override alias on deployOpts, but it doesn't invalidate cache...
       const buildFile = await this.import(address, fromNetwork);
       const contract: C = await this._deployBuild(buildFile, deployArgs, retries);
       await this.putAlias(alias, contract);
@@ -178,7 +178,6 @@ export class DeploymentManager {
   ): Promise<C> {
     const maybeExisting: C = await this.contract(alias);
     if (!maybeExisting || force) {
-      // NB: might use an override alias on deployOpts, but it doesn't invalidate cache...
       const contract: C = await this._deploy(contractFile, deployArgs, retries);
       await this.putAlias(alias, contract);
       return contract;

--- a/plugins/deployment_manager/Import.ts
+++ b/plugins/deployment_manager/Import.ts
@@ -19,7 +19,7 @@ export async function fetchAndCacheContract(
   force = false
 ): Promise<BuildFile> {
   const buildFile = await fetchContract(cache, network, address, importRetries, importRetryDelay, force);
-  await storeBuildFile(cache, address, buildFile);
+  await storeBuildFile(cache, network, address, buildFile);
   return buildFile;
 }
 
@@ -54,7 +54,7 @@ export async function fetchContract(
   importRetryDelay = DEFAULT_RETRY_DELAY,
   force = false
 ): Promise<BuildFile> {
-  const cachedBuildFile = !force && await getBuildFile(cache, address);
+  const cachedBuildFile = !force && await getBuildFile(cache, network, address);
   if (cachedBuildFile) {
     return cachedBuildFile;
   } else {
@@ -67,10 +67,11 @@ export async function readContract(
   cache: Cache,
   hre: HardhatRuntimeEnvironment,
   fullyQualifiedName: string,
+  network: string,
   address: Address,
   force = false
 ): Promise<BuildFile> {
-  const cachedBuildFile = !force && await getBuildFile(cache, address);
+  const cachedBuildFile = !force && await getBuildFile(cache, network, address);
   if (cachedBuildFile) {
     return cachedBuildFile;
   } else {

--- a/plugins/deployment_manager/Spider.ts
+++ b/plugins/deployment_manager/Spider.ts
@@ -71,8 +71,8 @@ async function isContract(hre: HRE, address: string) {
   return await hre.ethers.provider.getCode(address) !== '0x';
 }
 
-async function localBuild(cache: Cache, hre: HRE, artifact: string, address: Address): Promise<Build> {
-  const buildFile = await readContract(cache, hre, artifact, address, !cache);
+async function localBuild(cache: Cache, hre: HRE, artifact: string, network: string, address: Address): Promise<Build> {
+  const buildFile = await readContract(cache, hre, artifact, network, address, !cache);
   const contract = getEthersContract(address, buildFile, hre);
   return { buildFile, contract };
 }
@@ -177,7 +177,7 @@ async function crawl(
     // }
     if (aliasTemplateConfig.artifact) {
       //debug(`  ... has artifact specified (${aliasTemplateConfig.artifact})`);
-      const build = await localBuild(cache, hre, aliasTemplateConfig.artifact, address);
+      const build = await localBuild(cache, hre, aliasTemplateConfig.artifact, network, address);
       const alias = await readAlias(build.contract, aliasRender, context, path);
       return maybeProcess(alias, build, aliasTemplateConfig);
     } else {
@@ -196,7 +196,7 @@ async function crawl(
         //debug(`   ... has contract config (${build.buildFile.contract})`);
         if (contractConfig.artifact) {
           //debug(`    ... has artifact specified (${contractConfig.artifact})`);
-          const build_ = await localBuild(null, hre, contractConfig.artifact, address);
+          const build_ = await localBuild(null, hre, contractConfig.artifact, network, address);
           const alias = await readAlias(build_.contract, aliasRender, context, path);
           return maybeProcess(alias, build_, contractConfig);
         } else {

--- a/plugins/deployment_manager/test/ContractMapTest.ts
+++ b/plugins/deployment_manager/test/ContractMapTest.ts
@@ -12,18 +12,20 @@ describe('ContractMap', () => {
     it('gets what it stores', async () => {
       const cache = new Cache('test-network', 'test-deployment', false, tempDir());
       const address = '0x0000000000000000000000000000000000000000';
-      await storeBuildFile(cache, address, faucetTokenBuildFile);
-      const buildFile = await getBuildFile(cache, address);
+      await storeBuildFile(cache, 'test-network', address, faucetTokenBuildFile);
+      const buildFile = await getBuildFile(cache, 'test-network', address);
+      const noBuildFile = await getBuildFile(cache, 'no-test-network', address);
       expect(buildFile).to.eql(faucetTokenBuildFile);
+      expect(noBuildFile).to.eql(undefined);
     });
 
     it('stores deploys in the right place', async () => {
       const cache = new Cache('test-network', 'test-deployment', false, tempDir());
-      await deploy('test/FaucetToken.sol', tokenArgs, hre, { cache, alias: 'Toke' });
-      const contracts = cache.cache.get('.contracts');
-      const aliases = cache.cache.get('test-network').get('test-deployment').get('aliases.json');
-      const address = aliases.get('Toke');
-      expect(contracts.has(`${address.toLowerCase()}.json`)).to.eql(true);
+      await deploy('test/FaucetToken.sol', tokenArgs, hre, { cache, network: 'test-network' });
+      const contracts = cache.cache.get('test-network').get('.contracts');
+      const noContracts = cache.cache.get('no-test-network');
+      expect(contracts.size).to.eql(1);
+      expect(noContracts).to.eql(undefined);
     });
   });
 });

--- a/plugins/deployment_manager/test/DeployHelpers.ts
+++ b/plugins/deployment_manager/test/DeployHelpers.ts
@@ -1,5 +1,4 @@
 import hre from 'hardhat';
-import { FaucetToken, FaucetToken__factory } from '../../../build/types';
 import { BuildFile } from '../Types';
 import { deploy, deployBuild } from '../Deploy';
 export { deploy, deployBuild, hre };
@@ -25,9 +24,5 @@ export const faucetTokenBuildFile: BuildFile = {
 export const tokenArgs: [number, string, number, string] = [10000000, 'Test Token', 6, 'TEST'];
 
 export async function buildToken() {
-  return await deploy<FaucetToken, FaucetToken__factory, [number, string, number, string]>(
-    'test/FaucetToken.sol',
-    tokenArgs,
-    hre
-  );
+  return await deploy('test/FaucetToken.sol', tokenArgs, hre, { network: 'test-network' });
 }

--- a/plugins/deployment_manager/test/DeployTest.ts
+++ b/plugins/deployment_manager/test/DeployTest.ts
@@ -11,7 +11,7 @@ describe('Deploy', () => {
   });
 
   it('deployBuild', async () => {
-    let token = await deployBuild(faucetTokenBuildFile, tokenArgs, hre);
+    let token = await deployBuild(faucetTokenBuildFile, tokenArgs, hre, { network: 'test-network' });
     expect(await token.symbol()).to.equal('TEST');
   });
 });

--- a/plugins/deployment_manager/test/DeploymentManagerTest.ts
+++ b/plugins/deployment_manager/test/DeploymentManagerTest.ts
@@ -116,7 +116,7 @@ describe('DeploymentManager', () => {
         ['spot', '0x0000000000000000000000000000000000000000', []]
       );
       // Check that we've cached the build file
-      expect((await getBuildFile(deploymentManager.cache, spot.address)).contract).to.eql('Dog');
+      expect((await getBuildFile(deploymentManager.cache, 'test-network', spot.address)).contract).to.eql('Dog');
     });
   });
 

--- a/plugins/deployment_manager/test/ImportTest.ts
+++ b/plugins/deployment_manager/test/ImportTest.ts
@@ -77,7 +77,7 @@ describe('Import', () => {
 
   it('loads from cache', async () => {
     let cache = new Cache('test-network', 'test-deployment');
-    await storeBuildFile(cache, '0x0000000000000000000000000000000000000001', fiatTokenBuildFile);
+    await storeBuildFile(cache, 'avalanche', '0x0000000000000000000000000000000000000001', fiatTokenBuildFile);
     expect(
       await fetchContract(cache, 'avalanche', '0x0000000000000000000000000000000000000001', 0)
     ).to.equal(fiatTokenBuildFile);
@@ -94,7 +94,7 @@ describe('Import', () => {
         0
       )
     ).to.eql(fiatTokenBuildFile);
-    expect(await getBuildFile(cache, '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e')).to.eql(
+    expect(await getBuildFile(cache, 'avalanche', '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e')).to.eql(
       fiatTokenBuildFile
     );
   });

--- a/plugins/deployment_manager/test/SpiderTest.ts
+++ b/plugins/deployment_manager/test/SpiderTest.ts
@@ -32,14 +32,14 @@ async function setupContracts(
     'vendor/proxy/transparent/ProxyAdmin.sol',
     [],
     hre,
-    { cache }
+    { cache, network: 'test-network' }
   );
 
   let finnImpl: Dog = await deploy(
     'test/Dog.sol',
     ['finn:implementation', '0x0000000000000000000000000000000000000000', []],
     hre,
-    { cache }
+    { cache, network: 'test-network' }
   );
 
   let proxy: TransparentUpgradeableProxy = await deploy(
@@ -56,21 +56,21 @@ async function setupContracts(
       ).data,
     ],
     hre,
-    { cache }
+    { cache, network: 'test-network' }
   );
 
   let molly: Dog = await deploy(
     'test/Dog.sol',
     ['molly', proxy.address, []],
     hre,
-    { cache }
+    { cache, network: 'test-network' }
   );
 
   let spot: Dog = await deploy(
     'test/Dog.sol',
     ['spot', proxy.address, []],
     hre,
-    { cache }
+    { cache, network: 'test-network' }
   );
 
   let finn = finnImpl.attach(proxy.address);
@@ -118,7 +118,7 @@ describe('Spider', () => {
       },
     };
 
-    let { aliases, contracts } = await spider(cache, 'avalanche', hre, relationConfig, roots);
+    let { aliases, contracts } = await spider(cache, 'test-network', hre, relationConfig, roots);
 
     expect(objectFromMap(aliases)).to.eql({
       finn: finn.address,

--- a/plugins/deployment_manager/test/VerifyArgsTest.ts
+++ b/plugins/deployment_manager/test/VerifyArgsTest.ts
@@ -16,7 +16,7 @@ describe('VerifyArgs', () => {
       'test/Dog.sol',
       ['spot', '0x0000000000000000000000000000000000000001', []],
       hre,
-      { cache }
+      { cache, network: 'test-network' }
     );
     let verifyArgs1: VerifyArgs = { via: 'artifacts', address: '0x0000000000000000000000000000000000000000', constructorArguments: [] };
     let verifyArgs2: VerifyArgs = { via: 'buildfile', contract: testContract, buildFile: faucetTokenBuildFile, deployArgs: [] };

--- a/plugins/deployment_manager/test/VerifyTest.ts
+++ b/plugins/deployment_manager/test/VerifyTest.ts
@@ -70,7 +70,7 @@ describe('Verify', () => {
   describe('via buildfile', () => {
     it('verify from build file', async () => {
       mockVerifySuccess(hre);
-      let contract = await deployBuild(faucetTokenBuildFile, tokenArgs, hre);
+      let contract = await deployBuild(faucetTokenBuildFile, tokenArgs, hre, { network: 'test-network' });
       await verifyContract(
         { via: 'buildfile', contract, buildFile: faucetTokenBuildFile, deployArgs: tokenArgs },
         hre,

--- a/tasks/deployment_manager/task.ts
+++ b/tasks/deployment_manager/task.ts
@@ -72,16 +72,20 @@ task('deploy', 'Deploys market')
 
     const verify = noVerify ? false : !simulate;
     const desc = verify ? 'Verify' : 'Would verify';
-    await dm.verifyContracts(async (address, args) => {
-      // TODO: add comet impl verification (on deploy) and delete verify-comet script
-      if (args.via === 'buildfile') {
-        const { contract: _, ...rest } = args;
-        console.log(`[${tag}] ${desc} ${address}:`, rest);
-      } else {
-        console.log(`[${tag}] ${desc} ${address}:`, args);
-      }
-      return verify;
-    });
+    if (noVerify && simulate) {
+      // Don't even print if --no-verify is set with --simulate
+    } else {
+      await dm.verifyContracts(async (address, args) => {
+        // TODO: add comet impl verification (on deploy) and delete verify-comet script
+        if (args.via === 'buildfile') {
+          const { contract: _, ...rest } = args;
+          console.log(`[${tag}] ${desc} ${address}:`, rest);
+        } else {
+          console.log(`[${tag}] ${desc} ${address}:`, args);
+        }
+        return verify;
+      });
+    }
   });
 
 task('gen:migration', 'Generates a new migration')

--- a/tasks/spider/task.ts
+++ b/tasks/spider/task.ts
@@ -4,7 +4,7 @@ import { DeploymentManager } from '../../plugins/deployment_manager/DeploymentMa
 
 async function deleteSpiderArtifacts() {
   [
-    'rm -rf deployments/.contracts',
+    'rm -rf deployments/*/.contracts',
     'rm deployments/*/*/aliases.json',
   ].forEach(async (command) => {
     console.log(command);


### PR DESCRIPTION
I was wrong to think contract addresses are always a function of bytecode.
This adds caching per network the right way, being aware of the (true) network we are cloning from or deploying to.
This was a bit easier to add with proxies out of the way.