### PR TITLE
Add tracer to DeploymentManager to capture spend and improve logging

### DIFF
--- a/deployments/hardhat/dai/deploy.ts
+++ b/deployments/hardhat/dai/deploy.ts
@@ -1,6 +1,6 @@
 import { Deployed, DeploymentManager } from '../../../plugins/deployment_manager';
 import { FaucetToken, SimplePriceFeed } from '../../../build/types';
-import { DeploySpec, cloneGov, debug, deployComet, exp, sameAddress, wait } from '../../../src/deploy';
+import { DeploySpec, cloneGov, deployComet, exp, sameAddress, wait } from '../../../src/deploy';
 
 async function makeToken(
   deploymentManager: DeploymentManager,
@@ -24,6 +24,7 @@ async function makePriceFeed(
 
 // TODO: Support configurable assets as well?
 export default async function deploy(deploymentManager: DeploymentManager, deploySpec: DeploySpec): Promise<Deployed> {
+  const trace = deploymentManager.tracer();
   const ethers = deploymentManager.hre.ethers;
   const signer = await deploymentManager.getSigner();
 
@@ -68,10 +69,10 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
   await deploymentManager.idempotent(
     async () => (await GOLD.balanceOf(rewards.address)).eq(0),
     async () => {
-      debug(`Sending some GOLD to CometRewards`);
+      trace(`Sending some GOLD to CometRewards`);
       const amount = exp(2_000_000, 8);
-      await wait(GOLD.connect(signer).transfer(rewards.address, amount));
-      debug(`GOLD.balanceOf(${rewards.address}): ${await GOLD.balanceOf(rewards.address)}`);
+      trace(await wait(GOLD.connect(signer).transfer(rewards.address, amount)));
+      trace(`GOLD.balanceOf(${rewards.address}): ${await GOLD.balanceOf(rewards.address)}`);
     }
   );
 

--- a/plugins/deployment_manager/Types.ts
+++ b/plugins/deployment_manager/Types.ts
@@ -1,3 +1,5 @@
+import { TransactionResponse } from '@ethersproject/abstract-provider';
+
 export type ABI = string | any[];
 export type Address = string;
 export type Alias = string;
@@ -19,3 +21,6 @@ export interface ContractMetadata {
   source?: string;
   constructorArgs: string;
 }
+
+export type TraceArg = string | TransactionResponse;
+export type TraceFn = (TraceArg, ...any) => void;

--- a/plugins/deployment_manager/Utils.ts
+++ b/plugins/deployment_manager/Utils.ts
@@ -115,6 +115,10 @@ export function asArray<A>(v: A | A[]): A[] {
   }
 }
 
+export function txCost({ cumulativeGasUsed, effectiveGasPrice }): bigint {
+  return cumulativeGasUsed.mul(effectiveGasPrice).toBigInt();
+}
+
 /**
  * Call an async function with a maximum time limit (in milliseconds) for the timeout
  * @param asyncPromise an async promise to resolve

--- a/plugins/deployment_manager/test/VerifyArgsTest.ts
+++ b/plugins/deployment_manager/test/VerifyArgsTest.ts
@@ -6,20 +6,19 @@ import * as os from 'os';
 import { deleteVerifyArgs, getVerifyArgs, putVerifyArgs } from '../VerifyArgs';
 import { VerifyArgs } from '../Verify';
 import { deploy, faucetTokenBuildFile } from './DeployHelpers';
-import { Dog__factory, Dog } from '../../../build/types';
 
 describe('VerifyArgs', () => {
   it('gets, sets, and deletes verify args', async () => {
-    let cache = new Cache('test-network', 'test-deployment', false, os.tmpdir());
+    const cache = new Cache('test-network', 'test-deployment', false, os.tmpdir());
 
-    let testContract = await deploy<Dog, Dog__factory, [string, string, string[]]>(
+    const testContract = await deploy(
       'test/Dog.sol',
       ['spot', '0x0000000000000000000000000000000000000001', []],
       hre,
       { cache, network: 'test-network' }
     );
-    let verifyArgs1: VerifyArgs = { via: 'artifacts', address: '0x0000000000000000000000000000000000000000', constructorArguments: [] };
-    let verifyArgs2: VerifyArgs = { via: 'buildfile', contract: testContract, buildFile: faucetTokenBuildFile, deployArgs: [] };
+    const verifyArgs1: VerifyArgs = { via: 'artifacts', address: '0x0000000000000000000000000000000000000000', constructorArguments: [] };
+    const verifyArgs2: VerifyArgs = { via: 'buildfile', contract: testContract, buildFile: faucetTokenBuildFile, deployArgs: [] };
 
     expect(objectFromMap(await getVerifyArgs(cache))).to.eql({});
     await putVerifyArgs(cache, '0x0000000000000000000000000000000000000000', verifyArgs1);

--- a/plugins/scenario/worker/Worker.ts
+++ b/plugins/scenario/worker/Worker.ts
@@ -60,10 +60,10 @@ export async function run<T, U, R>({ bases, config, worker }: WorkerData) {
   }
 
   for (const base of bases) {
-    const world = new World(hreForBase(base), base);
-    const delta = await world.deploymentManager.runDeployScript({ allMissing: true });
-    console.log(`[${base.name}] Deployed ${world.deploymentManager.counter} contracts to initialize world 🗺`);
-    console.log(`[${base.name}]\n${world.deploymentManager.diffDelta(delta)}`);
+    const world = new World(hreForBase(base), base), dm = world.deploymentManager;
+    const delta = await dm.runDeployScript({ allMissing: true });
+    console.log(`[${base.name}] Deployed ${dm.counter} contracts, spent ${dm.spent} to initialize world 🗺`);
+    console.log(`[${base.name}]\n${dm.diffDelta(delta)}`);
     runners[base.name] = new Runner({ base, world });
   }
 

--- a/tasks/deployment_manager/task.ts
+++ b/tasks/deployment_manager/task.ts
@@ -67,7 +67,7 @@ task('deploy', 'Deploys market')
 
     const overrides = undefined; // TODO: pass through cli args
     const delta = await dm.runDeployScript(overrides ?? { allMissing: true });
-    console.log(`[${tag}] Deployed ${dm.counter} contracts`);
+    console.log(`[${tag}] Deployed ${dm.counter} contracts, spent ${dm.spent} Ξ`);
     console.log(`[${tag}]\n${dm.diffDelta(delta)}`);
 
     const verify = noVerify ? false : !simulate;


### PR DESCRIPTION
This replaces debug calls with calls to a tracer from the DeploymentManager.
The trace function makes logging more consistent with network names and transaction response support, which allows us to capture a detailed spend history and report it on the cli.