### PR TITLE
Make getAssetIndex public, fix bumpSupplyCaps

### DIFF
--- a/contracts/Configurator.sol
+++ b/contracts/Configurator.sol
@@ -307,7 +307,7 @@ contract Configurator is ConfiguratorStorage {
     /**
      * @dev Determine index of asset that matches given address
      */
-    function getAssetIndex(address cometProxy, address asset) internal view returns (uint) {
+    function getAssetIndex(address cometProxy, address asset) public view returns (uint) {
         AssetConfig[] memory assetConfigs = configuratorParams[cometProxy].assetConfigs;
         uint numAssets = assetConfigs.length;
         for (uint i = 0; i < numAssets; ) {

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -69,9 +69,6 @@ export const COMP_WHALES = [
   '0x61258f12c459984f32b83c86a6cc10aa339396de',
   '0x9aa835bc7b8ce13b9b0c9764a52fbf71ac62ccf1',
   '0x683a4f9915d6216f73d6df50151725036bd26c02',
-  '0xa1b61405791170833070c0ea61ed28728a840241',
-  '0x88fb3d509fc49b515bfeb04e23f53ba339563981',
-  '0x8169522c2c57883e8ef80c498aab7820da539806'
 ];
 
 export async function calldata(req: Promise<PopulatedTransaction>): Promise<string> {


### PR DESCRIPTION
This makes a contract change to configurator, to make `getAssetIndex` public.
It was useful to be able to call this directly when trying to debug these  issues and I think it ought to be public.

Somehow the upgrade path in bumpSupplyCaps was completely broken and had never been used (at least since adding the per-market configuration).
This fixes the call to updateSupplyCap and bypasses governance for this constraint helper to speed it up.

Also remove some whales, since we are voting with all of them and its unnecessary.