### PR TITLE
Add a `safeSupplyAsset` instead of bumping everywhere first

### DIFF
--- a/scenario/RewardsScenario.ts
+++ b/scenario/RewardsScenario.ts
@@ -40,7 +40,7 @@ scenario(
     expect(await rewardToken.balanceOf(albert.address)).to.be.equal(0n);
 
     await baseAsset.approve(albert, comet.address);
-    await albert.supplyAsset({ asset: baseAssetAddress, amount: 1_000_000n * baseScale })
+    await albert.safeSupplyAsset({ asset: baseAssetAddress, amount: 1_000_000n * baseScale })
 
     const supplyTimestamp = await world.timestamp();
     const albertBalance = await albert.getCometBaseBalance();
@@ -95,7 +95,7 @@ scenario(
 
     await albert.allow(betty, true); // Albert allows Betty to manage his account
     await baseAsset.approve(albert, comet.address);
-    await albert.supplyAsset({ asset: baseAssetAddress, amount: 1_000_000n * baseScale });
+    await albert.safeSupplyAsset({ asset: baseAssetAddress, amount: 1_000_000n * baseScale });
 
     const supplyTimestamp = await world.timestamp();
     const albertBalance = await albert.getCometBaseBalance();

--- a/scenario/constraints/UtilizationConstraint.ts
+++ b/scenario/constraints/UtilizationConstraint.ts
@@ -140,8 +140,7 @@ export class UtilizationConstraint<T extends CometContext, R extends Requirement
 
           await context.sourceTokens(collateralNeeded, collateralToken, borrowActor);
           await collateralToken.approve(borrowActor, comet);
-          await context.bumpSupplyCaps({ [collateralToken.address]: collateralNeeded })
-          await comet.connect(borrowActor.signer).supply(collateralToken.address, collateralNeeded);
+          await borrowActor.safeSupplyAsset({ asset: collateralToken.address, amount: collateralNeeded });
 
           // XXX will also need to make sure there are enough base tokens in the protocol to withdraw
           await comet.connect(borrowActor.signer).withdraw(baseToken.address, toBorrowBase);

--- a/scenario/context/CometActor.ts
+++ b/scenario/context/CometActor.ts
@@ -49,17 +49,17 @@ export default class CometActor {
   }
 
   async getErc20Balance(tokenAddress: string): Promise<bigint> {
-    let erc20 = ERC20__factory.connect(tokenAddress, this.signer);
+    const erc20 = ERC20__factory.connect(tokenAddress, this.signer);
     return (await erc20.balanceOf(this.signer.address)).toBigInt();
   }
 
   async getCometBaseBalance(): Promise<bigint> {
-    let comet = await this.context.getComet();
+    const comet = await this.context.getComet();
     return baseBalanceOf(comet, this.signer.address);
   }
 
   async sendEth(recipient: AddressLike, amount: number) {
-    let tx = await this.signer.sendTransaction({
+    const tx = await this.signer.sendTransaction({
       to: resolveAddress(recipient),
       value: floor(amount * 1e18),
     });
@@ -67,47 +67,53 @@ export default class CometActor {
   }
 
   async transferErc20(tokenAddress: string, dst: string, amount: bigint): Promise<ContractReceipt> {
-    let erc20 = ERC20__factory.connect(tokenAddress, this.signer);
+    const erc20 = ERC20__factory.connect(tokenAddress, this.signer);
     return await (await erc20.transfer(dst, amount)).wait();
   }
 
   async allow(manager: CometActor, isAllowed: boolean): Promise<ContractReceipt> {
-    let comet = await this.context.getComet();
+    const comet = await this.context.getComet();
     return await (await comet.connect(this.signer).allow(manager.address, isAllowed)).wait();
   }
 
+  async safeSupplyAsset({ asset, amount }): Promise<ContractReceipt> {
+    const comet = await this.context.getComet();
+    await this.context.bumpSupplyCaps({ [asset]: amount });
+    return await (await comet.connect(this.signer).supply(asset, amount)).wait();
+  }
+
   async supplyAsset({ asset, amount }): Promise<ContractReceipt> {
-    let comet = await this.context.getComet();
+    const comet = await this.context.getComet();
     return await (await comet.connect(this.signer).supply(asset, amount)).wait();
   }
 
   async supplyAssetFrom({ src, dst, asset, amount }): Promise<ContractReceipt> {
-    let comet = await this.context.getComet();
+    const comet = await this.context.getComet();
     return await (await comet.connect(this.signer).supplyFrom(src, dst, asset, amount)).wait();
   }
 
   async transferAsset({ dst, asset, amount }): Promise<ContractReceipt> {
-    let comet = await this.context.getComet();
+    const comet = await this.context.getComet();
     return await (await comet.connect(this.signer).transferAsset(dst, asset, amount)).wait();
   }
 
   async transferAssetFrom({ src, dst, asset, amount }): Promise<ContractReceipt> {
-    let comet = await this.context.getComet();
+    const comet = await this.context.getComet();
     return await (await comet.connect(this.signer).transferAssetFrom(src, dst, asset, amount)).wait();
   }
 
   async withdrawAsset({ asset, amount }): Promise<ContractReceipt> {
-    let comet = await this.context.getComet();
+    const comet = await this.context.getComet();
     return await (await comet.connect(this.signer).withdraw(asset, amount)).wait();
   }
 
   async withdrawAssetFrom({ src, dst, asset, amount }): Promise<ContractReceipt> {
-    let comet = await this.context.getComet();
+    const comet = await this.context.getComet();
     return await (await comet.connect(this.signer).withdrawFrom(src, dst, asset, amount)).wait();
   }
 
   async absorb({ absorber, accounts }): Promise<ContractReceipt> {
-    let comet = await this.context.getComet();
+    const comet = await this.context.getComet();
     return await (await comet.connect(this.signer).absorb(absorber, accounts)).wait();
   }
 
@@ -124,7 +130,7 @@ export default class CometActor {
     expiry: number;
     chainId: number;
   }): Promise<Signature> {
-    let comet = await this.context.getComet();
+    const comet = await this.context.getComet();
     const domain = {
       name: await comet.name(),
       version: await comet.version(),
@@ -157,7 +163,7 @@ export default class CometActor {
     expiry: number;
     signature: Signature;
   }): Promise<ContractReceipt> {
-    let comet = await this.context.getComet();
+    const comet = await this.context.getComet();
     return await (await comet
       .connect(this.signer)
       .allowBySig(owner, manager, isAllowed, nonce, expiry, signature.v, signature.r, signature.s)).wait();
@@ -170,7 +176,7 @@ export default class CometActor {
   /* ===== Admin-only functions ===== */
 
   async withdrawReserves(to: string, amount: BigNumberish, overrides?: Overrides): Promise<ContractReceipt> {
-    let comet = await this.context.getComet();
+    const comet = await this.context.getComet();
     return await (await comet.connect(this.signer).withdrawReserves(to, amount, { ...overrides })).wait();
   }
 
@@ -182,7 +188,7 @@ export default class CometActor {
     buyPaused = false,
   }, overrides?: Overrides
   ): Promise<ContractReceipt> {
-    let comet = await this.context.getComet();
+    const comet = await this.context.getComet();
     return await (
       await comet
         .connect(this.signer)
@@ -191,12 +197,12 @@ export default class CometActor {
   }
 
   async approveThis(manager: string, asset: string, amount: BigNumberish, overrides?: Overrides): Promise<ContractReceipt> {
-    let comet = await this.context.getComet();
+    const comet = await this.context.getComet();
     return await (await comet.connect(this.signer).approveThis(manager, asset, amount, { ...overrides })).wait();
   }
 
   async deployAndUpgradeTo(configuratorProxy: string, cometProxy: string, overrides?: Overrides): Promise<ContractReceipt> {
-    let proxyAdmin = await this.context.getCometAdmin();
+    const proxyAdmin = await this.context.getCometAdmin();
     return await (await proxyAdmin.connect(this.signer).deployAndUpgradeTo(configuratorProxy, cometProxy, { ...overrides })).wait();
   }
 }

--- a/scenario/context/CometContext.ts
+++ b/scenario/context/CometContext.ts
@@ -114,17 +114,20 @@ export class CometContext {
 
   async bumpSupplyCaps(supplyAmountPerAsset: Record<string, bigint>) {
     const comet = await this.getComet();
+    const baseToken = await comet.baseToken();
 
     // Update supply cap in asset configs if new collateral supply will exceed the supply cap
     let shouldUpgrade = false;
     const newSupplyCaps: Record<string, bigint> = {};
     for (const asset in supplyAmountPerAsset) {
-      const assetInfo = await comet.getAssetInfoByAddress(asset);
-      const currentTotalSupply = (await comet.totalsCollateral(asset)).totalSupplyAsset.toBigInt();
-      const newTotalSupply = currentTotalSupply + supplyAmountPerAsset[asset];
-      if (newTotalSupply > assetInfo.supplyCap.toBigInt()) {
-        shouldUpgrade = true;
-        newSupplyCaps[asset] = newTotalSupply * 2n;
+      if (asset != baseToken) {
+        const assetInfo = await comet.getAssetInfoByAddress(asset);
+        const currentTotalSupply = (await comet.totalsCollateral(asset)).totalSupplyAsset.toBigInt();
+        const newTotalSupply = currentTotalSupply + supplyAmountPerAsset[asset];
+        if (newTotalSupply > assetInfo.supplyCap.toBigInt()) {
+          shouldUpgrade = true;
+          newSupplyCaps[asset] = newTotalSupply * 2n;
+        }
       }
     }
 


### PR DESCRIPTION
We often get the bumping wrong, as in the case of borrowing.
This also makes bumping slightly more efficient and correct, since it doesn't allow arbitrary unknown assets, but just ignores the case of base token.
With this, mainnet scenarios pass even without the proposal!