### PR TITLE
Do not commit when simulating, patch token sourcer and scen

### DIFF
--- a/.github/workflows/deploy-market.yaml
+++ b/.github/workflows/deploy-market.yaml
@@ -62,6 +62,7 @@ jobs:
           DEBUG: true
 
       - name: Commit changes
+        if: ${{ github.events.inputs.simulate == 'false' }}
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"

--- a/plugins/deployment_manager/DeploymentManager.ts
+++ b/plugins/deployment_manager/DeploymentManager.ts
@@ -411,7 +411,12 @@ export class DeploymentManager {
     const withoutContracts = ({ contracts: _, ...rest }) => rest;
     const new_ = { ...delta.new, spider: withoutContracts(delta.new.spider) };
     const old_ = { ...delta.old, spider: withoutContracts(delta.old.spider) };
-    return diff(new_, old_, {aAnnotation: 'New addresses', bAnnotation: 'Old addresses'});
+    return diff(new_, old_, {
+      aAnnotation: 'New addresses',
+      aIndicator: '+',
+      bAnnotation: 'Old addresses',
+      bIndicator: '-',
+    });
   }
 
   fork(): DeploymentManager {

--- a/plugins/scenario/utils/TokenSourcer.ts
+++ b/plugins/scenario/utils/TokenSourcer.ts
@@ -49,7 +49,8 @@ async function removeTokens(
   let tokenContract = new ethers.Contract(asset, erc20, signer);
   let currentBalance = await tokenContract.balanceOf(address);
   if (currentBalance.lt(amount)) throw 'Error: Insufficient address balance';
-  await tokenContract.transfer('0x0000000000000000000000000000000000000001', amount);
+  await dm.hre.network.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x0']);
+  await tokenContract.transfer('0x0000000000000000000000000000000000000001', amount, { gasPrice: 0 });
   await dm.hre.network.provider.request({
     method: 'hardhat_stopImpersonatingAccount',
     params: [address],

--- a/scenario/WithdrawReservesScenario.ts
+++ b/scenario/WithdrawReservesScenario.ts
@@ -53,7 +53,7 @@ scenario(
   'Comet#withdrawReserves > reverts if not enough reserves are owned by protocol',
   {
     tokenBalances: {
-      $comet: { $base: 100 },
+      $comet: { $base: '== 100' },
     },
   },
   async ({ comet, actors }, context) => {

--- a/scenario/context/CometContext.ts
+++ b/scenario/context/CometContext.ts
@@ -120,7 +120,7 @@ export class CometContext {
     let shouldUpgrade = false;
     const newSupplyCaps: Record<string, bigint> = {};
     for (const asset in supplyAmountPerAsset) {
-      if (asset != baseToken) {
+      if (asset !== baseToken) {
         const assetInfo = await comet.getAssetInfoByAddress(asset);
         const currentTotalSupply = (await comet.totalsCollateral(asset)).totalSupplyAsset.toBigInt();
         const newTotalSupply = currentTotalSupply + supplyAmountPerAsset[asset];


### PR DESCRIPTION
We shouldn't try to commit when we are simulating (it fails the workflow bc no roots).
Also an enhancement for the diff output, a fix for token sourcer and withdraw reserves scen, which should be the last one failing for mainnet.