### PR TITLE
Generic Bulker

### DIFF
--- a/contracts/Bulker.sol
+++ b/contracts/Bulker.sol
@@ -14,10 +14,7 @@ interface IClaimable {
 contract Bulker {
     /** General configuration constants **/
     address public immutable admin;
-    address public immutable comet;
-    address public immutable rewards;
     address payable public immutable weth;
-    address public immutable baseToken;
 
     /** Actions **/
     uint public constant ACTION_SUPPLY_ASSET = 1;
@@ -32,12 +29,9 @@ contract Bulker {
     error FailedToSendEther();
     error Unauthorized();
 
-    constructor(address admin_, address comet_, address rewards_, address payable weth_) {
+    constructor(address admin_, address payable weth_) {
         admin = admin_;
-        comet = comet_;
-        rewards = rewards_;
         weth = weth_;
-        baseToken = CometInterface(comet_).baseToken();
     }
 
     /**
@@ -81,24 +75,24 @@ contract Bulker {
         for (uint i = 0; i < actions.length; ) {
             uint action = actions[i];
             if (action == ACTION_SUPPLY_ASSET) {
-                (address to, address asset, uint amount) = abi.decode(data[i], (address, address, uint));
-                supplyTo(to, asset, amount);
+                (address comet, address to, address asset, uint amount) = abi.decode(data[i], (address, address, address, uint));
+                supplyTo(comet, to, asset, amount);
             } else if (action == ACTION_SUPPLY_ETH) {
-                (address to, uint amount) = abi.decode(data[i], (address, uint));
+                (address comet, address to, uint amount) = abi.decode(data[i], (address, address, uint));
                 unusedEth -= amount;
-                supplyEthTo(to, amount);
+                supplyEthTo(comet, to, amount);
             } else if (action == ACTION_TRANSFER_ASSET) {
-                (address to, address asset, uint amount) = abi.decode(data[i], (address, address, uint));
-                transferTo(to, asset, amount);
+                (address comet, address to, address asset, uint amount) = abi.decode(data[i], (address, address, address, uint));
+                transferTo(comet, to, asset, amount);
             } else if (action == ACTION_WITHDRAW_ASSET) {
-                (address to, address asset, uint amount) = abi.decode(data[i], (address, address, uint));
-                withdrawTo(to, asset, amount);
+                (address comet, address to, address asset, uint amount) = abi.decode(data[i], (address, address, address, uint));
+                withdrawTo(comet, to, asset, amount);
             } else if (action == ACTION_WITHDRAW_ETH) {
-                (address to, uint amount) = abi.decode(data[i], (address, uint));
-                withdrawEthTo(to, amount);
+                (address comet, address to, uint amount) = abi.decode(data[i], (address, address, uint));
+                withdrawEthTo(comet, to, amount);
             } else if (action == ACTION_CLAIM_REWARD) {
-                (address src, bool shouldAccrue) = abi.decode(data[i], (address, bool));
-                claimReward(src, shouldAccrue);
+                (address comet, address rewards, address src, bool shouldAccrue) = abi.decode(data[i], (address, address, address, bool));
+                claimReward(comet, rewards, src, shouldAccrue);
             }
             unchecked { i++; }
         }
@@ -113,14 +107,14 @@ contract Bulker {
     /**
      * @notice Supplies an asset to a user in Comet
      */
-    function supplyTo(address to, address asset, uint amount) internal {
+    function supplyTo(address comet, address to, address asset, uint amount) internal {
         CometInterface(comet).supplyFrom(msg.sender, to, asset, amount);
     }
 
     /**
      * @notice Wraps ETH and supplies WETH to a user in Comet
      */
-    function supplyEthTo(address to, uint amount) internal {
+    function supplyEthTo(address comet, address to, uint amount) internal {
         IWETH9(weth).deposit{ value: amount }();
         IWETH9(weth).approve(comet, amount);
         CometInterface(comet).supplyFrom(address(this), to, weth, amount);
@@ -129,21 +123,21 @@ contract Bulker {
     /**
      * @notice Transfers an asset to a user in Comet
      */
-    function transferTo(address to, address asset, uint amount) internal {
+    function transferTo(address comet, address to, address asset, uint amount) internal {
         CometInterface(comet).transferAssetFrom(msg.sender, to, asset, amount);
     }
 
     /**
      * @notice Withdraws an asset to a user in Comet
      */
-    function withdrawTo(address to, address asset, uint amount) internal {
+    function withdrawTo(address comet, address to, address asset, uint amount) internal {
         CometInterface(comet).withdrawFrom(msg.sender, to, asset, amount);
     }
 
     /**
      * @notice Withdraws WETH from Comet to a user after unwrapping it to ETH
      */
-    function withdrawEthTo(address to, uint amount) internal {
+    function withdrawEthTo(address comet, address to, uint amount) internal {
         CometInterface(comet).withdrawFrom(msg.sender, address(this), weth, amount);
         IWETH9(weth).withdraw(amount);
         (bool success, ) = to.call{ value: amount }("");
@@ -153,7 +147,7 @@ contract Bulker {
     /**
      * @notice Claim reward for a user
      */
-    function claimReward(address src, bool shouldAccrue) internal {
+    function claimReward(address comet, address rewards, address src, bool shouldAccrue) internal {
         IClaimable(rewards).claim(comet, src, shouldAccrue);
     }
 }

--- a/deployments/kovan/usdc/deploy.ts
+++ b/deployments/kovan/usdc/deploy.ts
@@ -71,7 +71,7 @@ async function deployContracts(deploymentManager: DeploymentManager, deploySpec:
   const bulker = await deploymentManager.deploy(
     'bulker',
     'Bulker.sol',
-    [timelock.address, comet.address, rewards.address, WETH.address]
+    [timelock.address, WETH.address]
   );
 
   await deploymentManager.idempotent(

--- a/deployments/mainnet/usdc/deploy.ts
+++ b/deployments/mainnet/usdc/deploy.ts
@@ -17,7 +17,7 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
   const bulker = await deploymentManager.deploy(
     'bulker',
     'Bulker.sol',
-    [await comet.governor(), comet.address, rewards.address, WETH.address]
+    [await comet.governor(), WETH.address]
   );
 
   return { ...deployed, bulker };

--- a/test/bulker-test.ts
+++ b/test/bulker-test.ts
@@ -366,7 +366,7 @@ describe('bulker', function () {
   describe('admin functions', function () {
     it('sweep ERC20 token', async () => {
       const protocol = await makeProtocol({});
-      const { comet, governor, tokens: { USDC, WETH }, users: [alice] } = protocol;
+      const { governor, tokens: { USDC, WETH }, users: [alice] } = protocol;
       const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
       const { bulker } = bulkerInfo;
 
@@ -390,7 +390,7 @@ describe('bulker', function () {
 
     it('sweep ETH', async () => {
       const protocol = await makeProtocol({});
-      const { comet, governor, tokens: { WETH }, users: [alice] } = protocol;
+      const { governor, tokens: { WETH }, users: [alice] } = protocol;
       const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
       const { bulker } = bulkerInfo;
 
@@ -413,7 +413,7 @@ describe('bulker', function () {
 
     it('reverts if sweepToken is called by non-admin', async () => {
       const protocol = await makeProtocol({});
-      const { comet, governor, tokens: { USDC, WETH }, users: [alice] } = protocol;
+      const { governor, tokens: { USDC, WETH }, users: [alice] } = protocol;
       const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
       const { bulker } = bulkerInfo;
 
@@ -424,7 +424,7 @@ describe('bulker', function () {
 
     it('reverts if sweepEth is called by non-admin', async () => {
       const protocol = await makeProtocol({});
-      const { comet, governor, tokens: { WETH }, users: [alice] } = protocol;
+      const { governor, tokens: { WETH }, users: [alice] } = protocol;
       const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
       const { bulker } = bulkerInfo;
 

--- a/test/bulker-test.ts
+++ b/test/bulker-test.ts
@@ -7,7 +7,7 @@ describe('bulker', function () {
   it('supply base asset', async () => {
     const protocol = await makeProtocol({});
     const { comet, tokens: { USDC, WETH }, users: [alice] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     // Alice approves 10 USDC to Comet
@@ -19,7 +19,7 @@ describe('bulker', function () {
     await comet.connect(alice).allow(bulker.address, true);
 
     // Alice supplies 10 USDC through the bulker
-    let supplyAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [alice.address, USDC.address, supplyAmount]);
+    const supplyAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, alice.address, USDC.address, supplyAmount]);
     await bulker.connect(alice).invoke([await bulker.ACTION_SUPPLY_ASSET()], [supplyAssetCalldata]);
 
     expect(await baseBalanceOf(comet, alice.address)).to.be.equal(supplyAmount);
@@ -28,7 +28,7 @@ describe('bulker', function () {
   it('supply collateral asset', async () => {
     const protocol = await makeProtocol({});
     const { comet, tokens: { COMP, WETH }, users: [alice] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     // Alice approves 10 COMP to Comet
@@ -40,7 +40,7 @@ describe('bulker', function () {
     await comet.connect(alice).allow(bulker.address, true);
 
     // Alice supplies 10 COMP through the bulker
-    let supplyAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [alice.address, COMP.address, supplyAmount]);
+    const supplyAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, alice.address, COMP.address, supplyAmount]);
     await bulker.connect(alice).invoke([await bulker.ACTION_SUPPLY_ASSET()], [supplyAssetCalldata]);
 
     expect(await comet.collateralBalanceOf(alice.address, COMP.address)).to.be.equal(supplyAmount);
@@ -49,7 +49,7 @@ describe('bulker', function () {
   it('supply collateral asset to a different account', async () => {
     const protocol = await makeProtocol({});
     const { comet, tokens: { COMP, WETH }, users: [alice, bob] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     // Alice approves 10 COMP to Comet
@@ -61,7 +61,7 @@ describe('bulker', function () {
     await comet.connect(alice).allow(bulker.address, true);
 
     // Alice supplies 10 COMP to Bob through the bulker
-    let supplyAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [bob.address, COMP.address, supplyAmount]);
+    const supplyAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, bob.address, COMP.address, supplyAmount]);
     await bulker.connect(alice).invoke([await bulker.ACTION_SUPPLY_ASSET()], [supplyAssetCalldata]);
 
     expect(await comet.collateralBalanceOf(alice.address, COMP.address)).to.be.equal(0);
@@ -75,14 +75,14 @@ describe('bulker', function () {
       })
     });
     const { comet, tokens: { WETH }, users: [alice] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     // No approval is actually needed on the supplyEth action!
 
     // Alice supplies 10 ETH through the bulker
     const supplyAmount = exp(10, 18);
-    let supplyEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'uint'], [alice.address, supplyAmount]);
+    const supplyEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, supplyAmount]);
     await bulker.connect(alice).invoke([await bulker.ACTION_SUPPLY_ETH()], [supplyEthCalldata], { value: supplyAmount });
 
     expect(await comet.collateralBalanceOf(alice.address, WETH.address)).to.be.equal(supplyAmount);
@@ -95,7 +95,7 @@ describe('bulker', function () {
       })
     });
     const { comet, tokens: { WETH }, users: [alice] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     // No approval is actually needed on the supplyEth action!
@@ -103,7 +103,7 @@ describe('bulker', function () {
     // Alice supplies 10 ETH through the bulker but actually sends 20 ETH
     const aliceBalanceBefore = await alice.getBalance();
     const supplyAmount = exp(10, 18);
-    let supplyEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'uint'], [alice.address, supplyAmount]);
+    const supplyEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, supplyAmount]);
     const txn = await wait(bulker.connect(alice).invoke([await bulker.ACTION_SUPPLY_ETH()], [supplyEthCalldata], { value: supplyAmount * 2n }));
     const aliceBalanceAfter = await alice.getBalance();
 
@@ -118,14 +118,14 @@ describe('bulker', function () {
       })
     });
     const { comet, tokens: { WETH }, users: [alice] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     // No approval is actually needed on the supplyEth action!
 
     // Alice supplies 10 ETH through the bulker but only sends 5 ETH
     const supplyAmount = exp(10, 18);
-    let supplyEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'uint'], [alice.address, supplyAmount]);
+    const supplyEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, supplyAmount]);
     await expect(bulker.connect(alice).invoke([await bulker.ACTION_SUPPLY_ETH()], [supplyEthCalldata], { value: supplyAmount / 2n }))
       .to.be.revertedWith('code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)');
   });
@@ -133,7 +133,7 @@ describe('bulker', function () {
   it('transfer base asset', async () => {
     const protocol = await makeProtocol({});
     const { comet, tokens: { USDC, WETH }, users: [alice, bob] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     const transferAmount = exp(10, 6);
@@ -143,7 +143,7 @@ describe('bulker', function () {
     await comet.connect(alice).allow(bulker.address, true);
 
     // Alice transfer 10 USDC to Bob through the bulker
-    let transferAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [bob.address, USDC.address, transferAmount]);
+    const transferAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, bob.address, USDC.address, transferAmount]);
     await bulker.connect(alice).invoke([await bulker.ACTION_TRANSFER_ASSET()], [transferAssetCalldata]);
 
     expect(await baseBalanceOf(comet, alice.address)).to.be.equal(0n);
@@ -153,7 +153,7 @@ describe('bulker', function () {
   it('transfer collateral asset', async () => {
     const protocol = await makeProtocol({});
     const { comet, tokens: { COMP, WETH }, users: [alice, bob] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     const transferAmount = exp(10, 18);
@@ -163,7 +163,7 @@ describe('bulker', function () {
     await comet.connect(alice).allow(bulker.address, true);
 
     // Alice transfer 10 COMP to Bob through the bulker
-    let transferAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [bob.address, COMP.address, transferAmount]);
+    const transferAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, bob.address, COMP.address, transferAmount]);
     await bulker.connect(alice).invoke([await bulker.ACTION_TRANSFER_ASSET()], [transferAssetCalldata]);
 
     expect(await comet.collateralBalanceOf(alice.address, COMP.address)).to.be.equal(0);
@@ -173,7 +173,7 @@ describe('bulker', function () {
   it('withdraw base asset', async () => {
     const protocol = await makeProtocol({});
     const { comet, tokens: { USDC, WETH }, users: [alice] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     // Allocate base asset to Comet and Alice's Comet balance
@@ -189,7 +189,7 @@ describe('bulker', function () {
     await comet.connect(alice).allow(bulker.address, true);
 
     // Alice withdraws 10 USDC through the bulker
-    let withdrawAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [alice.address, USDC.address, withdrawAmount]);
+    const withdrawAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, alice.address, USDC.address, withdrawAmount]);
     await bulker.connect(alice).invoke([await bulker.ACTION_WITHDRAW_ASSET()], [withdrawAssetCalldata]);
 
     expect(await baseBalanceOf(comet, alice.address)).to.be.equal(0n);
@@ -199,7 +199,7 @@ describe('bulker', function () {
   it('withdraw collateral asset', async () => {
     const protocol = await makeProtocol({});
     const { comet, tokens: { COMP, WETH }, users: [alice] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     // Allocate collateral asset to Comet and Alice's Comet balance
@@ -215,7 +215,7 @@ describe('bulker', function () {
     await comet.connect(alice).allow(bulker.address, true);
 
     // Alice withdraws 10 COMP through the bulker
-    let withdrawAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [alice.address, COMP.address, withdrawAmount]);
+    const withdrawAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, alice.address, COMP.address, withdrawAmount]);
     await bulker.connect(alice).invoke([await bulker.ACTION_WITHDRAW_ASSET()], [withdrawAssetCalldata]);
 
     expect(await comet.collateralBalanceOf(alice.address, COMP.address)).to.be.equal(0);
@@ -225,7 +225,7 @@ describe('bulker', function () {
   it('withdraw collateral asset to a different account', async () => {
     const protocol = await makeProtocol({});
     const { comet, tokens: { COMP, WETH }, users: [alice, bob] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     // Allocate collateral asset to Comet and Alice's Comet balance
@@ -241,7 +241,7 @@ describe('bulker', function () {
     await comet.connect(alice).allow(bulker.address, true);
 
     // Alice withdraws 10 COMP through the bulker
-    let withdrawAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [bob.address, COMP.address, withdrawAmount]);
+    const withdrawAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, bob.address, COMP.address, withdrawAmount]);
     await bulker.connect(alice).invoke([await bulker.ACTION_WITHDRAW_ASSET()], [withdrawAssetCalldata]);
 
     expect(await comet.collateralBalanceOf(alice.address, COMP.address)).to.be.equal(0);
@@ -256,7 +256,7 @@ describe('bulker', function () {
       })
     });
     const { comet, tokens: { WETH }, users: [alice], governor } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     // Allocate WETH to Comet and Alice's Comet balance
@@ -274,7 +274,7 @@ describe('bulker', function () {
 
     // Alice supplies 10 ETH through the bulker
     const aliceBalanceBefore = await alice.getBalance();
-    let withdrawEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'uint'], [alice.address, withdrawAmount]);
+    const withdrawEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, withdrawAmount]);
     const txn = await wait(bulker.connect(alice).invoke([await bulker.ACTION_WITHDRAW_ETH()], [withdrawEthCalldata]));
     const aliceBalanceAfter = await alice.getBalance();
 
@@ -293,7 +293,7 @@ describe('bulker', function () {
       users: [alice],
     } = protocol;
     const { rewards } = await makeRewards({ governor, configs: [[comet, COMP]] });
-    const bulkerInfo = await makeBulker({ comet: comet.address, rewards: rewards.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     // Allocate and approve transfers
@@ -309,7 +309,7 @@ describe('bulker', function () {
     expect(await COMP.balanceOf(alice.address)).to.be.equal(0);
 
     // Alice claims rewards through the bulker
-    const claimRewardCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'bool'], [alice.address, true]);
+    const claimRewardCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'address', 'bool'], [comet.address, rewards.address, alice.address, true]);
     await bulker.connect(alice).invoke([await bulker.ACTION_CLAIM_REWARD()], [claimRewardCalldata]);
 
     expect(await COMP.balanceOf(alice.address)).to.be.equal(exp(86400, 18));
@@ -318,10 +318,10 @@ describe('bulker', function () {
   it('reverts on supply asset if no permission granted to bulker', async () => {
     const protocol = await makeProtocol({});
     const { comet, tokens: { USDC, WETH }, users: [alice] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
-    let supplyAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [alice.address, USDC.address, 1]);
+    const supplyAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, alice.address, USDC.address, 1]);
     await expect(bulker.connect(alice).invoke([await bulker.ACTION_SUPPLY_ASSET()], [supplyAssetCalldata]))
       .to.be.reverted; // Should revert with "custom error 'Unauthorized()'"
   });
@@ -329,10 +329,10 @@ describe('bulker', function () {
   it('reverts on transfer asset if no permission granted to bulker', async () => {
     const protocol = await makeProtocol({});
     const { comet, tokens: { COMP, WETH }, users: [alice, bob] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
-    let transferAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [bob.address, COMP.address, 1]);
+    const transferAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, bob.address, COMP.address, 1]);
     await expect(bulker.connect(alice).invoke([await bulker.ACTION_TRANSFER_ASSET()], [transferAssetCalldata]))
       .to.be.reverted; // Should revert with "custom error 'Unauthorized()'"
   });
@@ -340,10 +340,10 @@ describe('bulker', function () {
   it('reverts on withdraw asset if no permission granted to bulker', async () => {
     const protocol = await makeProtocol({});
     const { comet, tokens: { COMP, WETH }, users: [alice] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
-    let withdrawAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [alice.address, COMP.address, 1]);
+    const withdrawAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, alice.address, COMP.address, 1]);
     await expect(bulker.connect(alice).invoke([await bulker.ACTION_WITHDRAW_ASSET()], [withdrawAssetCalldata]))
       .to.be.reverted; // Should revert with "custom error 'Unauthorized()'"
   });
@@ -355,10 +355,10 @@ describe('bulker', function () {
       })
     });
     const { comet, tokens: { WETH }, users: [alice] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
-    let withdrawEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'uint'], [alice.address, 1]);
+    const withdrawEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, 1]);
     await expect(bulker.connect(alice).invoke([await bulker.ACTION_WITHDRAW_ETH()], [withdrawEthCalldata]))
       .to.be.reverted; // Should revert with "custom error 'Unauthorized()'"
   });
@@ -367,7 +367,7 @@ describe('bulker', function () {
     it('sweep ERC20 token', async () => {
       const protocol = await makeProtocol({});
       const { comet, governor, tokens: { USDC, WETH }, users: [alice] } = protocol;
-      const bulkerInfo = await makeBulker({ admin: governor, comet: comet.address, weth: WETH.address });
+      const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
       const { bulker } = bulkerInfo;
 
       // Alice "accidentally" sends 10 USDC to the Bulker
@@ -391,7 +391,7 @@ describe('bulker', function () {
     it('sweep ETH', async () => {
       const protocol = await makeProtocol({});
       const { comet, governor, tokens: { WETH }, users: [alice] } = protocol;
-      const bulkerInfo = await makeBulker({ admin: governor, comet: comet.address, weth: WETH.address });
+      const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
       const { bulker } = bulkerInfo;
 
       // Alice "accidentally" sends 1 ETH to the Bulker
@@ -414,7 +414,7 @@ describe('bulker', function () {
     it('reverts if sweepToken is called by non-admin', async () => {
       const protocol = await makeProtocol({});
       const { comet, governor, tokens: { USDC, WETH }, users: [alice] } = protocol;
-      const bulkerInfo = await makeBulker({ admin: governor, comet: comet.address, weth: WETH.address });
+      const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
       const { bulker } = bulkerInfo;
 
       // Alice sweeps tokens
@@ -425,7 +425,7 @@ describe('bulker', function () {
     it('reverts if sweepEth is called by non-admin', async () => {
       const protocol = await makeProtocol({});
       const { comet, governor, tokens: { WETH }, users: [alice] } = protocol;
-      const bulkerInfo = await makeBulker({ admin: governor, comet: comet.address, weth: WETH.address });
+      const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
       const { bulker } = bulkerInfo;
 
       // Alice sweeps ETH
@@ -439,7 +439,7 @@ describe('bulker multiple actions', function () {
   it('supply collateral + borrow base asset', async () => {
     const protocol = await makeProtocol({});
     const { comet, tokens: { USDC, COMP, WETH }, users: [alice] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     // Allocate base asset to Comet
@@ -459,9 +459,9 @@ describe('bulker multiple actions', function () {
     await comet.connect(alice).allow(bulker.address, true);
 
     // Alice supplies 10 COMP through the bulker
-    let supplyAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [alice.address, COMP.address, supplyAmount]);
+    const supplyAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, alice.address, COMP.address, supplyAmount]);
     // Alice withdraws 10 USDC through the bulker
-    let withdrawAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [alice.address, USDC.address, borrowAmount]);
+    const withdrawAssetCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, alice.address, USDC.address, borrowAmount]);
     await bulker.connect(alice).invoke(
       [await bulker.ACTION_SUPPLY_ASSET(), await bulker.ACTION_WITHDRAW_ASSET()],
       [supplyAssetCalldata, withdrawAssetCalldata]
@@ -479,15 +479,15 @@ describe('bulker multiple actions', function () {
       })
     });
     const { comet, tokens: { WETH }, users: [alice, bob] } = protocol;
-    const bulkerInfo = await makeBulker({ comet: comet.address, weth: WETH.address });
+    const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
     // No approval is actually needed on the supplyEth action!
 
     // Alice supplies 10 ETH through the bulker
     const supplyAmount = exp(10, 18);
-    let supplyAliceEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'uint'], [alice.address, supplyAmount / 2n]);
-    let supplyBobEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'uint'], [bob.address, supplyAmount / 2n]);
+    const supplyAliceEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, supplyAmount / 2n]);
+    const supplyBobEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, bob.address, supplyAmount / 2n]);
     await bulker.connect(alice).invoke(
       [await bulker.ACTION_SUPPLY_ETH(), await bulker.ACTION_SUPPLY_ETH()],
       [supplyAliceEthCalldata, supplyBobEthCalldata],

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -125,8 +125,6 @@ export type Rewards = {
 
 export type BulkerOpts = {
   admin?: SignerWithAddress;
-  comet?: string;
-  rewards?: string;
   weth?: string;
 };
 
@@ -493,12 +491,10 @@ export async function makeBulker(opts: BulkerOpts): Promise<BulkerInfo> {
   const signers = await ethers.getSigners();
 
   const admin = opts.admin || signers[0];
-  const comet = opts.comet;
-  const rewards = opts.rewards || ethers.constants.AddressZero;
   const weth = opts.weth;
 
   const BulkerFactory = (await ethers.getContractFactory('Bulker')) as Bulker__factory;
-  const bulker = await BulkerFactory.deploy(admin.address, comet, rewards, weth);
+  const bulker = await BulkerFactory.deploy(admin.address, weth);
   await bulker.deployed();
 
   return {


### PR DESCRIPTION
This PR updates Bulker to no longer constantize the Comet and reward contract addresses. Instead, these addresses are passed in as calldata in the `invoke` function. This allows one Bulker contract to generically work across different Comet deployments and reward contracts.