### PR TITLE
Run scenarios for all collateral assets; Introduce FilterConstraint

### DIFF
--- a/scenario/SupplyScenario.ts
+++ b/scenario/SupplyScenario.ts
@@ -1,6 +1,6 @@
 import { CometContext, scenario } from './context/CometContext';
 import { expect } from 'chai';
-import { expectApproximately, expectRevertMatches, getExpectedBaseBalance, getInterest, isTriviallySourceable, isValidAssetIndex, NUM_ASSETS } from './utils';
+import { expectApproximately, expectRevertMatches, getExpectedBaseBalance, getInterest, isTriviallySourceable, isValidAssetIndex, MAX_ASSETS } from './utils';
 import { ContractReceipt } from 'ethers';
 
 // XXX introduce a SupplyCapConstraint to separately test the happy path and revert path instead
@@ -70,7 +70,7 @@ async function testSupplyFromCollateral(context: CometContext, assetNum: number)
   }
 }
 
-for (let i = 0; i < NUM_ASSETS; i++) {
+for (let i = 0; i < MAX_ASSETS; i++) {
   const amountToSupply = 100; // in units of asset, not wei
   scenario(
     `Comet#supply > collateral asset ${i}`,
@@ -86,7 +86,7 @@ for (let i = 0; i < NUM_ASSETS; i++) {
   );
 }
 
-for (let i = 0; i < NUM_ASSETS; i++) {
+for (let i = 0; i < MAX_ASSETS; i++) {
   const amountToSupply = 100; // in units of asset, not wei
   scenario(
     `Comet#supplyFrom > collateral asset ${i}`,

--- a/scenario/SupplyScenario.ts
+++ b/scenario/SupplyScenario.ts
@@ -1,20 +1,12 @@
 import { CometContext, scenario } from './context/CometContext';
 import { expect } from 'chai';
-import { expectApproximately, expectRevertMatches, getExpectedBaseBalance, getInterest } from './utils';
+import { expectApproximately, expectRevertMatches, getExpectedBaseBalance, getInterest, isValidAssetIndex, NUM_ASSETS } from './utils';
 import { ContractReceipt } from 'ethers';
-
-const NUM_ASSETS = 15;
-
-async function isValidAssetIndex(ctx: CometContext, num: number): Promise<boolean> {
-  const comet = await ctx.getComet();
-  return num < await comet.numAssets();
-}
 
 // XXX introduce a SupplyCapConstraint to separately test the happy path and revert path instead
 // of testing them conditionally
 async function testSupplyCollateral(context: CometContext, assetNum: number): Promise<null | ContractReceipt> {
   const comet = await context.getComet();
-  if (assetNum >= (await comet.numAssets())) return;
   const { albert } = await context.actors;
   const { asset: assetAddress, scale: scaleBN, supplyCap } = await comet.getAssetInfo(assetNum);
   const collateralAsset = context.getAssetByAddress(assetAddress);
@@ -45,7 +37,6 @@ async function testSupplyCollateral(context: CometContext, assetNum: number): Pr
 
 async function testSupplyFromCollateral(context: CometContext, assetNum: number): Promise<null | ContractReceipt> {
   const comet = await context.getComet();
-  if (assetNum >= (await comet.numAssets())) return;
   const { albert, betty } = await context.actors;
   const { asset: assetAddress, scale: scaleBN, supplyCap } = await comet.getAssetInfo(assetNum);
   const collateralAsset = context.getAssetByAddress(assetAddress);
@@ -79,7 +70,6 @@ async function testSupplyFromCollateral(context: CometContext, assetNum: number)
   }
 }
 
-// XXX consider creating these tests for assets0-15
 scenario(
   'Comet#supply > base asset',
   {

--- a/scenario/SupplyScenario.ts
+++ b/scenario/SupplyScenario.ts
@@ -1,6 +1,6 @@
 import { CometContext, scenario } from './context/CometContext';
 import { expect } from 'chai';
-import { expectApproximately, expectRevertMatches, getExpectedBaseBalance, getInterest, isSourceable, isValidAssetIndex, NUM_ASSETS } from './utils';
+import { expectApproximately, expectRevertMatches, getExpectedBaseBalance, getInterest, isTriviallySourceable, isValidAssetIndex, NUM_ASSETS } from './utils';
 import { ContractReceipt } from 'ethers';
 
 // XXX introduce a SupplyCapConstraint to separately test the happy path and revert path instead
@@ -75,7 +75,7 @@ for (let i = 0; i < NUM_ASSETS; i++) {
   scenario(
     `Comet#supply > collateral asset ${i}`,
     {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isSourceable(ctx, i, amountToSupply),
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isTriviallySourceable(ctx, i, amountToSupply),
       tokenBalances: {
         albert: { [`$asset${i}`]: amountToSupply },
       },
@@ -91,7 +91,7 @@ for (let i = 0; i < NUM_ASSETS; i++) {
   scenario(
     `Comet#supplyFrom > collateral asset ${i}`,
     {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isSourceable(ctx, i, amountToSupply),
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isTriviallySourceable(ctx, i, amountToSupply),
       tokenBalances: {
         albert: { [`$asset${i}`]: amountToSupply },
       },

--- a/scenario/SupplyScenario.ts
+++ b/scenario/SupplyScenario.ts
@@ -1,6 +1,6 @@
 import { CometContext, scenario } from './context/CometContext';
 import { expect } from 'chai';
-import { expectApproximately, expectRevertMatches, getExpectedBaseBalance, getInterest, isValidAssetIndex, NUM_ASSETS } from './utils';
+import { expectApproximately, expectRevertMatches, getExpectedBaseBalance, getInterest, isSourceable, isValidAssetIndex, NUM_ASSETS } from './utils';
 import { ContractReceipt } from 'ethers';
 
 // XXX introduce a SupplyCapConstraint to separately test the happy path and revert path instead
@@ -71,12 +71,13 @@ async function testSupplyFromCollateral(context: CometContext, assetNum: number)
 }
 
 for (let i = 0; i < NUM_ASSETS; i++) {
+  const amountToSupply = 100; // in units of asset, not wei
   scenario(
     `Comet#supply > collateral asset ${i}`,
     {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i),
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isSourceable(ctx, i, amountToSupply),
       tokenBalances: {
-        albert: { [`$asset${i}`]: 100 }, // in units of asset, not wei
+        albert: { [`$asset${i}`]: amountToSupply },
       },
     },
     async ({ }, context) => {
@@ -86,12 +87,13 @@ for (let i = 0; i < NUM_ASSETS; i++) {
 }
 
 for (let i = 0; i < NUM_ASSETS; i++) {
+  const amountToSupply = 100; // in units of asset, not wei
   scenario(
     `Comet#supplyFrom > collateral asset ${i}`,
     {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i),
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isSourceable(ctx, i, amountToSupply),
       tokenBalances: {
-        albert: { [`$asset${i}`]: 100 }, // in units of asset, not wei
+        albert: { [`$asset${i}`]: amountToSupply },
       },
     },
     async ({ }, context) => {

--- a/scenario/SupplyScenario.ts
+++ b/scenario/SupplyScenario.ts
@@ -70,6 +70,36 @@ async function testSupplyFromCollateral(context: CometContext, assetNum: number)
   }
 }
 
+for (let i = 0; i < NUM_ASSETS; i++) {
+  scenario(
+    `Comet#supply > collateral asset ${i}`,
+    {
+      filter: async (ctx) => await isValidAssetIndex(ctx, i),
+      tokenBalances: {
+        albert: { [`$asset${i}`]: 100 }, // in units of asset, not wei
+      },
+    },
+    async ({ }, context) => {
+      return await testSupplyCollateral(context, i);
+    }
+  );
+}
+
+for (let i = 0; i < NUM_ASSETS; i++) {
+  scenario(
+    `Comet#supplyFrom > collateral asset ${i}`,
+    {
+      filter: async (ctx) => await isValidAssetIndex(ctx, i),
+      tokenBalances: {
+        albert: { [`$asset${i}`]: 100 }, // in units of asset, not wei
+      },
+    },
+    async ({ }, context) => {
+      return await testSupplyFromCollateral(context, i);
+    }
+  );
+}
+
 scenario(
   'Comet#supply > base asset',
   {
@@ -98,21 +128,6 @@ scenario(
     return txn; // return txn to measure gas
   }
 );
-
-for (let i = 0; i < NUM_ASSETS; i++) {
-  scenario(
-    `Comet#supply > collateral asset ${i}`,
-    {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i),
-      tokenBalances: {
-        albert: { [`$asset${i}`]: 100 }, // in units of asset, not wei
-      },
-    },
-    async ({ }, context) => {
-      return await testSupplyCollateral(context, i);
-    }
-  );
-}
 
 scenario(
   'Comet#supply > repay borrow',
@@ -177,21 +192,6 @@ scenario(
     return txn; // return txn to measure gas
   }
 );
-
-for (let i = 0; i < NUM_ASSETS; i++) {
-  scenario(
-    `Comet#supplyFrom > collateral asset ${i}`,
-    {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i),
-      tokenBalances: {
-        albert: { [`$asset${i}`]: 100 }, // in units of asset, not wei
-      },
-    },
-    async ({ }, context) => {
-      return await testSupplyFromCollateral(context, i);
-    }
-  );
-}
 
 scenario(
   'Comet#supplyFrom > repay borrow',

--- a/scenario/TransferScenario.ts
+++ b/scenario/TransferScenario.ts
@@ -1,6 +1,6 @@
 import { CometContext, scenario } from './context/CometContext';
 import { expect } from 'chai';
-import { expectApproximately, getExpectedBaseBalance, getInterest, isTriviallySourceable, isValidAssetIndex, NUM_ASSETS } from './utils';
+import { expectApproximately, getExpectedBaseBalance, getInterest, isTriviallySourceable, isValidAssetIndex, MAX_ASSETS } from './utils';
 import { ContractReceipt } from 'ethers';
 
 async function testTransferCollateral(context: CometContext, assetNum: number): Promise<null | ContractReceipt> {
@@ -37,7 +37,7 @@ async function testTransferFromCollateral(context: CometContext, assetNum: numbe
   return txn; // return txn to measure gas
 }
 
-for (let i = 0; i < NUM_ASSETS; i++) {
+for (let i = 0; i < MAX_ASSETS; i++) {
   const amountToTransfer = 100; // in units of asset, not wei
   scenario(
     `Comet#transfer > collateral asset ${i}, enough balance`,
@@ -53,7 +53,7 @@ for (let i = 0; i < NUM_ASSETS; i++) {
   );
 }
 
-for (let i = 0; i < NUM_ASSETS; i++) {
+for (let i = 0; i < MAX_ASSETS; i++) {
   const amountToTransfer = 100; // in units of asset, not wei
   scenario(
     `Comet#transferFrom > collateral asset ${i}, enough balance`,

--- a/scenario/TransferScenario.ts
+++ b/scenario/TransferScenario.ts
@@ -1,6 +1,6 @@
 import { CometContext, scenario } from './context/CometContext';
 import { expect } from 'chai';
-import { expectApproximately, getExpectedBaseBalance, getInterest, isValidAssetIndex, NUM_ASSETS } from './utils';
+import { expectApproximately, getExpectedBaseBalance, getInterest, isSourceable, isValidAssetIndex, NUM_ASSETS } from './utils';
 import { ContractReceipt } from 'ethers';
 
 async function testTransferCollateral(context: CometContext, assetNum: number): Promise<null | ContractReceipt> {
@@ -38,12 +38,13 @@ async function testTransferFromCollateral(context: CometContext, assetNum: numbe
 }
 
 for (let i = 0; i < NUM_ASSETS; i++) {
+  const amountToTransfer = 100; // in units of asset, not wei
   scenario(
     `Comet#transfer > collateral asset ${i}, enough balance`,
     {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i),
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isSourceable(ctx, i, amountToTransfer),
       cometBalances: {
-        albert: { [`$asset${i}`]: 100 }, // in units of asset, not wei
+        albert: { [`$asset${i}`]: amountToTransfer },
       },
     },
     async ({ }, context) => {
@@ -53,12 +54,13 @@ for (let i = 0; i < NUM_ASSETS; i++) {
 }
 
 for (let i = 0; i < NUM_ASSETS; i++) {
+  const amountToTransfer = 100; // in units of asset, not wei
   scenario(
     `Comet#transferFrom > collateral asset ${i}, enough balance`,
     {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i),
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isSourceable(ctx, i, amountToTransfer),
       cometBalances: {
-        albert: { [`$asset${i}`]: 100 }, // in units of asset, not wei
+        albert: { [`$asset${i}`]: amountToTransfer },
       },
     },
     async ({ }, context) => {

--- a/scenario/TransferScenario.ts
+++ b/scenario/TransferScenario.ts
@@ -1,6 +1,6 @@
 import { CometContext, scenario } from './context/CometContext';
 import { expect } from 'chai';
-import { expectApproximately, getExpectedBaseBalance, getInterest, isSourceable, isValidAssetIndex, NUM_ASSETS } from './utils';
+import { expectApproximately, getExpectedBaseBalance, getInterest, isTriviallySourceable, isValidAssetIndex, NUM_ASSETS } from './utils';
 import { ContractReceipt } from 'ethers';
 
 async function testTransferCollateral(context: CometContext, assetNum: number): Promise<null | ContractReceipt> {
@@ -42,7 +42,7 @@ for (let i = 0; i < NUM_ASSETS; i++) {
   scenario(
     `Comet#transfer > collateral asset ${i}, enough balance`,
     {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isSourceable(ctx, i, amountToTransfer),
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isTriviallySourceable(ctx, i, amountToTransfer),
       cometBalances: {
         albert: { [`$asset${i}`]: amountToTransfer },
       },
@@ -58,7 +58,7 @@ for (let i = 0; i < NUM_ASSETS; i++) {
   scenario(
     `Comet#transferFrom > collateral asset ${i}, enough balance`,
     {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isSourceable(ctx, i, amountToTransfer),
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isTriviallySourceable(ctx, i, amountToTransfer),
       cometBalances: {
         albert: { [`$asset${i}`]: amountToTransfer },
       },

--- a/scenario/TransferScenario.ts
+++ b/scenario/TransferScenario.ts
@@ -1,30 +1,71 @@
-import { scenario } from './context/CometContext';
+import { CometContext, scenario } from './context/CometContext';
 import { expect } from 'chai';
-import { expectApproximately, getExpectedBaseBalance, getInterest } from './utils';
+import { expectApproximately, getExpectedBaseBalance, getInterest, isValidAssetIndex, NUM_ASSETS } from './utils';
+import { ContractReceipt } from 'ethers';
 
-// XXX consider creating these tests for assets0-15
-scenario(
-  'Comet#transfer > collateral asset, enough balance',
-  {
-    cometBalances: {
-      albert: { $asset0: 100 }, // in units of asset, not wei
+async function testTransferCollateral(context: CometContext, assetNum: number): Promise<null | ContractReceipt> {
+  const comet = await context.getComet();
+  const { albert, betty } = context.actors;
+  const { asset: assetAddress, scale } = await comet.getAssetInfo(assetNum);
+  const collateralAsset = context.getAssetByAddress(assetAddress);
+
+  // Albert transfers 50 units of collateral to Betty
+  const toTransfer = scale.toBigInt() * 50n;
+  const txn = await albert.transferAsset({ dst: betty.address, asset: collateralAsset.address, amount: toTransfer });
+
+  expect(await comet.collateralBalanceOf(albert.address, collateralAsset.address)).to.be.equal(scale.mul(50));
+  expect(await comet.collateralBalanceOf(betty.address, collateralAsset.address)).to.be.equal(scale.mul(50));
+
+  return txn; // return txn to measure gas
+}
+
+async function testTransferFromCollateral(context: CometContext, assetNum: number): Promise<null | ContractReceipt> {
+  const comet = await context.getComet();
+  const { albert, betty, charles } = context.actors;
+  const { asset: assetAddress, scale } = await comet.getAssetInfo(assetNum);
+  const collateralAsset = context.getAssetByAddress(assetAddress);
+
+  await albert.allow(charles, true);
+
+  // Charles transfers 50 units of collateral from Albert to Betty
+  const toTransfer = scale.toBigInt() * 50n;
+  const txn = await charles.transferAssetFrom({ src: albert.address, dst: betty.address, asset: collateralAsset.address, amount: toTransfer });
+
+  expect(await comet.collateralBalanceOf(albert.address, collateralAsset.address)).to.be.equal(scale.mul(50));
+  expect(await comet.collateralBalanceOf(betty.address, collateralAsset.address)).to.be.equal(scale.mul(50));
+
+  return txn; // return txn to measure gas
+}
+
+for (let i = 0; i < NUM_ASSETS; i++) {
+  scenario(
+    `Comet#transfer > collateral asset ${i}, enough balance`,
+    {
+      filter: async (ctx) => await isValidAssetIndex(ctx, i),
+      cometBalances: {
+        albert: { [`$asset${i}`]: 100 }, // in units of asset, not wei
+      },
     },
-  },
-  async ({ comet, actors }, context) => {
-    const { albert, betty } = actors;
-    const { asset: asset0Address, scale } = await comet.getAssetInfo(0);
-    const collateralAsset = context.getAssetByAddress(asset0Address);
+    async ({ }, context) => {
+      return await testTransferCollateral(context, i);
+    }
+  );
+}
 
-    // Albert transfers 50 units of collateral to Betty
-    const toTransfer = scale.toBigInt() * 50n;
-    const txn = await albert.transferAsset({ dst: betty.address, asset: collateralAsset.address, amount: toTransfer });
-
-    expect(await comet.collateralBalanceOf(albert.address, collateralAsset.address)).to.be.equal(scale.mul(50));
-    expect(await comet.collateralBalanceOf(betty.address, collateralAsset.address)).to.be.equal(scale.mul(50));
-
-    return txn; // return txn to measure gas
-  }
-);
+for (let i = 0; i < NUM_ASSETS; i++) {
+  scenario(
+    `Comet#transferFrom > collateral asset ${i}, enough balance`,
+    {
+      filter: async (ctx) => await isValidAssetIndex(ctx, i),
+      cometBalances: {
+        albert: { [`$asset${i}`]: 100 }, // in units of asset, not wei
+      },
+    },
+    async ({ }, context) => {
+      return await testTransferFromCollateral(context, i);
+    }
+  );
+}
 
 scenario(
   'Comet#transfer > base asset, enough balance',

--- a/scenario/WithdrawScenario.ts
+++ b/scenario/WithdrawScenario.ts
@@ -43,6 +43,36 @@ async function testWithdrawFromCollateral(context: CometContext, assetNum: numbe
   return txn; // return txn to measure gas
 }
 
+for (let i = 0; i < NUM_ASSETS; i++) {
+  scenario(
+    `Comet#withdraw > collateral asset ${i}`,
+    {
+      filter: async (ctx) => await isValidAssetIndex(ctx, i),
+      cometBalances: {
+        albert: { [`$asset${i}`]: 100 }, // in units of asset, not wei
+      },
+    },
+    async ({ }, context) => {
+      return await testWithdrawCollateral(context, i);
+    }
+  );
+}
+
+for (let i = 0; i < NUM_ASSETS; i++) {
+  scenario(
+    `Comet#withdrawFrom > collateral asset ${i}`,
+    {
+      filter: async (ctx) => await isValidAssetIndex(ctx, i),
+      cometBalances: {
+        albert: { [`$asset${i}`]: 1000 }, // in units of asset, not wei
+      },
+    },
+    async ({ }, context) => {
+      return await testWithdrawFromCollateral(context, i);
+    }
+  );
+}
+
 scenario(
   'Comet#withdraw > base asset',
   {
@@ -75,21 +105,6 @@ scenario(
     return txn; // return txn to measure gas
   }
 );
-
-for (let i = 0; i < NUM_ASSETS; i++) {
-  scenario(
-    `Comet#withdraw > collateral asset ${i}`,
-    {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i),
-      cometBalances: {
-        albert: { [`$asset${i}`]: 100 }, // in units of asset, not wei
-      },
-    },
-    async ({ }, context) => {
-      return await testWithdrawCollateral(context, i);
-    }
-  );
-}
 
 scenario(
   'Comet#withdraw > borrow base',
@@ -153,21 +168,6 @@ scenario(
     return txn; // return txn to measure gas
   }
 );
-
-for (let i = 0; i < NUM_ASSETS; i++) {
-  scenario(
-    `Comet#withdrawFrom > collateral asset ${i}`,
-    {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i),
-      cometBalances: {
-        albert: { [`$asset${i}`]: 1000 }, // in units of asset, not wei
-      },
-    },
-    async ({ }, context) => {
-      return await testWithdrawFromCollateral(context, i);
-    }
-  );
-}
 
 scenario(
   'Comet#withdrawFrom > borrow base',

--- a/scenario/WithdrawScenario.ts
+++ b/scenario/WithdrawScenario.ts
@@ -1,6 +1,6 @@
 import { CometContext, scenario } from './context/CometContext';
 import { expect } from 'chai';
-import { expectApproximately, getExpectedBaseBalance, isSourceable, isValidAssetIndex, NUM_ASSETS } from './utils';
+import { expectApproximately, getExpectedBaseBalance, isTriviallySourceable, isValidAssetIndex, NUM_ASSETS } from './utils';
 import { ContractReceipt } from 'ethers';
 
 async function testWithdrawCollateral(context: CometContext, assetNum: number): Promise<null | ContractReceipt> {
@@ -48,7 +48,7 @@ for (let i = 0; i < NUM_ASSETS; i++) {
   scenario(
     `Comet#withdraw > collateral asset ${i}`,
     {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isSourceable(ctx, i, amountToWithdraw),
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isTriviallySourceable(ctx, i, amountToWithdraw),
       cometBalances: {
         albert: { [`$asset${i}`]: amountToWithdraw },
       },
@@ -64,7 +64,7 @@ for (let i = 0; i < NUM_ASSETS; i++) {
   scenario(
     `Comet#withdrawFrom > collateral asset ${i}`,
     {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isSourceable(ctx, i, amountToWithdraw),
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isTriviallySourceable(ctx, i, amountToWithdraw),
       cometBalances: {
         albert: { [`$asset${i}`]: amountToWithdraw },
       },

--- a/scenario/WithdrawScenario.ts
+++ b/scenario/WithdrawScenario.ts
@@ -1,6 +1,6 @@
 import { CometContext, scenario } from './context/CometContext';
 import { expect } from 'chai';
-import { expectApproximately, getExpectedBaseBalance, isValidAssetIndex, NUM_ASSETS } from './utils';
+import { expectApproximately, getExpectedBaseBalance, isSourceable, isValidAssetIndex, NUM_ASSETS } from './utils';
 import { ContractReceipt } from 'ethers';
 
 async function testWithdrawCollateral(context: CometContext, assetNum: number): Promise<null | ContractReceipt> {
@@ -44,12 +44,13 @@ async function testWithdrawFromCollateral(context: CometContext, assetNum: numbe
 }
 
 for (let i = 0; i < NUM_ASSETS; i++) {
+  const amountToWithdraw = 100; // in units of asset, not wei
   scenario(
     `Comet#withdraw > collateral asset ${i}`,
     {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i),
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isSourceable(ctx, i, amountToWithdraw),
       cometBalances: {
-        albert: { [`$asset${i}`]: 100 }, // in units of asset, not wei
+        albert: { [`$asset${i}`]: amountToWithdraw },
       },
     },
     async ({ }, context) => {
@@ -59,12 +60,13 @@ for (let i = 0; i < NUM_ASSETS; i++) {
 }
 
 for (let i = 0; i < NUM_ASSETS; i++) {
+  const amountToWithdraw = 1000; // in units of asset, not wei
   scenario(
     `Comet#withdrawFrom > collateral asset ${i}`,
     {
-      filter: async (ctx) => await isValidAssetIndex(ctx, i),
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && await isSourceable(ctx, i, amountToWithdraw),
       cometBalances: {
-        albert: { [`$asset${i}`]: 1000 }, // in units of asset, not wei
+        albert: { [`$asset${i}`]: amountToWithdraw },
       },
     },
     async ({ }, context) => {

--- a/scenario/WithdrawScenario.ts
+++ b/scenario/WithdrawScenario.ts
@@ -1,6 +1,6 @@
 import { CometContext, scenario } from './context/CometContext';
 import { expect } from 'chai';
-import { expectApproximately, getExpectedBaseBalance, isTriviallySourceable, isValidAssetIndex, NUM_ASSETS } from './utils';
+import { expectApproximately, getExpectedBaseBalance, isTriviallySourceable, isValidAssetIndex, MAX_ASSETS } from './utils';
 import { ContractReceipt } from 'ethers';
 
 async function testWithdrawCollateral(context: CometContext, assetNum: number): Promise<null | ContractReceipt> {
@@ -43,7 +43,7 @@ async function testWithdrawFromCollateral(context: CometContext, assetNum: numbe
   return txn; // return txn to measure gas
 }
 
-for (let i = 0; i < NUM_ASSETS; i++) {
+for (let i = 0; i < MAX_ASSETS; i++) {
   const amountToWithdraw = 100; // in units of asset, not wei
   scenario(
     `Comet#withdraw > collateral asset ${i}`,
@@ -59,7 +59,7 @@ for (let i = 0; i < NUM_ASSETS; i++) {
   );
 }
 
-for (let i = 0; i < NUM_ASSETS; i++) {
+for (let i = 0; i < MAX_ASSETS; i++) {
   const amountToWithdraw = 1000; // in units of asset, not wei
   scenario(
     `Comet#withdrawFrom > collateral asset ${i}`,

--- a/scenario/constraints/FilterConstraint.ts
+++ b/scenario/constraints/FilterConstraint.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { Constraint, World } from '../../plugins/scenario';
+import { CometContext } from '../context/CometContext';
+import { Requirements } from './Requirements';
+
+export class FilterConstraint<T extends CometContext, R extends Requirements> implements Constraint<T, R> {
+  async solve(requirements: R, context: T) {
+    const filterFn = requirements.filter;
+    if (!filterFn) {
+      return null;
+    }
+
+    if (await filterFn(context)) {
+      return null;
+    } else {
+      return []; // filter out this solution
+    }
+  }
+
+  async check(requirements: R, context: T, world: World) {
+    const filterFn = requirements.filter;
+    if (!filterFn) {
+      return;
+    }
+
+    expect(await filterFn(context)).to.be.equals(true);
+  }
+}

--- a/scenario/constraints/Requirements.ts
+++ b/scenario/constraints/Requirements.ts
@@ -1,5 +1,6 @@
 // TODO: Could define strict types for these objects
 export interface Requirements {
+    filter?: (context) => Promise<boolean>,
     tokenBalances?: object, // Token balance constraint
     cometBalances?: object, // Comet balance constraint
     upgrade?: boolean | object, // Modern constraint

--- a/scenario/constraints/index.ts
+++ b/scenario/constraints/index.ts
@@ -5,3 +5,4 @@ export { UtilizationConstraint } from './UtilizationConstraint';
 export { CometBalanceConstraint } from './CometBalanceConstraint';
 export { MigrationConstraint } from './MigrationConstraint';
 export { ProposalConstraint } from './ProposalConstraint';
+export { FilterConstraint } from './FilterConstraint';

--- a/scenario/context/CometContext.ts
+++ b/scenario/context/CometContext.ts
@@ -26,6 +26,7 @@ import {
   CometProxyAdmin,
   IGovernorBravo,
   CometRewards,
+  Fauceteer,
 } from '../../build/types';
 import { AssetInfoStructOutput } from '../../build/types/Comet';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
@@ -88,6 +89,10 @@ export class CometContext {
 
   async getRewards(): Promise<CometRewards> {
     return this.deploymentManager.contract('rewards');
+  }
+
+  async getFauceteer(): Promise<Fauceteer> {
+    return this.deploymentManager.contract('fauceteer');
   }
 
   async getConfiguration(): Promise<ProtocolConfiguration> {
@@ -178,8 +183,7 @@ export class CometContext {
     let comet = await this.getComet();
 
     // First, try to source from Fauceteer
-    const contracts = await this.deploymentManager.contracts();
-    const fauceteer = contracts.get('fauceteer');
+    const fauceteer = await this.getFauceteer();
     const fauceteerBalance = fauceteer ? await cometAsset.balanceOf(fauceteer.address) : 0;
     if (amount >= 0 && fauceteerBalance > amount) {
       debug(`Source Tokens: stealing from fauceteer`, amount, cometAsset.address);

--- a/scenario/context/CometContext.ts
+++ b/scenario/context/CometContext.ts
@@ -34,8 +34,8 @@ import { ProtocolConfiguration, deployComet, COMP_WHALES } from '../../src/deplo
 import { AddressLike, getAddressFromNumber, resolveAddress } from './Address';
 import { Requirements } from '../constraints/Requirements';
 
-type ActorMap = { [name: string]: CometActor };
-type AssetMap = { [name: string]: CometAsset };
+export type ActorMap = { [name: string]: CometActor };
+export type AssetMap = { [name: string]: CometAsset };
 
 export interface CometProperties {
   deploymentManager: DeploymentManager;

--- a/scenario/context/CometContext.ts
+++ b/scenario/context/CometContext.ts
@@ -11,6 +11,7 @@ import {
   CometBalanceConstraint,
   MigrationConstraint,
   ProposalConstraint,
+  FilterConstraint,
 } from '../constraints';
 import CometActor from './CometActor';
 import CometAsset from './CometAsset';
@@ -99,7 +100,7 @@ export class CometContext {
     const { world } = this;
 
     const oldComet = await this.getComet();
-    const admin = await world.impersonateAddress(await oldComet.governor(), 10n**18n);
+    const admin = await world.impersonateAddress(await oldComet.governor(), 10n ** 18n);
 
     const deploySpec = { cometMain: true, cometExt: true };
     const deployed = await deployComet(this.deploymentManager, deploySpec, configOverrides, admin);
@@ -133,7 +134,7 @@ export class CometContext {
 
     // Set new supply caps in Configurator and do a deployAndUpgradeTo
     if (shouldUpgrade) {
-      const gov = await this.world.impersonateAddress(await comet.governor(), 10n**18n);
+      const gov = await this.world.impersonateAddress(await comet.governor(), 10n ** 18n);
       const cometAdmin = (await this.getCometAdmin()).connect(gov);
       const configurator = (await this.getConfigurator()).connect(gov);
       for (const [asset, cap] of Object.entries(newSupplyCaps)) {
@@ -376,6 +377,7 @@ async function forkContext(c: CometContext, w: World): Promise<CometContext> {
 }
 
 export const constraints = [
+  new FilterConstraint(),
   new MigrationConstraint(),
   new ProposalConstraint(),
   new ModernConstraint(),

--- a/scenario/utils.ts
+++ b/scenario/utils.ts
@@ -242,7 +242,20 @@ export async function fetchQuery(
   }
 }
 
-export async function isValidAssetIndex(ctx: CometContext, num: number): Promise<boolean> {
+export async function isValidAssetIndex(ctx: CometContext, assetNum: number): Promise<boolean> {
   const comet = await ctx.getComet();
-  return num < await comet.numAssets();
+  return assetNum < await comet.numAssets();
+}
+
+export async function isSourceable(ctx: CometContext, assetNum: number, amount: number): Promise<boolean> {
+  const fauceteer = await ctx.getFauceteer();
+  // If fauceteer does not exist (e.g. mainnet), then token is likely sourceable from events
+  if (fauceteer == null) return true;
+
+  const comet = await ctx.getComet();
+  const assetInfo = await comet.getAssetInfo(assetNum);
+  const asset = ctx.getAssetByAddress(assetInfo.asset);
+  const amountInWei = BigInt(amount) * assetInfo.scale.toBigInt();
+  // Fauceteer should have greater than the expected amount of the asset
+  return await asset.balanceOf(fauceteer.address) > amountInWei;
 }

--- a/scenario/utils.ts
+++ b/scenario/utils.ts
@@ -7,7 +7,7 @@ import { CometContext } from './context/CometContext';
 import CometAsset from './context/CometAsset';
 import { exp } from '../test/helpers';
 
-export const NUM_ASSETS = 15;
+export const MAX_ASSETS = 15;
 
 export interface ComparativeAmount {
   val: number,

--- a/scenario/utils.ts
+++ b/scenario/utils.ts
@@ -247,7 +247,7 @@ export async function isValidAssetIndex(ctx: CometContext, assetNum: number): Pr
   return assetNum < await comet.numAssets();
 }
 
-export async function isSourceable(ctx: CometContext, assetNum: number, amount: number): Promise<boolean> {
+export async function isTriviallySourceable(ctx: CometContext, assetNum: number, amount: number): Promise<boolean> {
   const fauceteer = await ctx.getFauceteer();
   // If fauceteer does not exist (e.g. mainnet), then token is likely sourceable from events
   if (fauceteer == null) return true;

--- a/scenario/utils.ts
+++ b/scenario/utils.ts
@@ -7,6 +7,8 @@ import { CometContext } from './context/CometContext';
 import CometAsset from './context/CometAsset';
 import { exp } from '../test/helpers';
 
+export const NUM_ASSETS = 15;
+
 export interface ComparativeAmount {
   val: number,
   op: ComparisonOp,
@@ -238,4 +240,9 @@ export async function fetchQuery(
       return { err };
     }
   }
+}
+
+export async function isValidAssetIndex(ctx: CometContext, num: number): Promise<boolean> {
+  const comet = await ctx.getComet();
+  return num < await comet.numAssets();
 }


### PR DESCRIPTION
This PR increases the coverage of our supply/transfer/withdraw scenarios to all collateral assets (instead of just the first one). 

I also added a FilterConstraint to filter out solutions early on, before any other constraints that could revert are run.