### PR TITLE
Intercept sendTransaction in NonceManager to reset pending counts

### DIFF
--- a/plugins/deployment_manager/NonceManager.ts
+++ b/plugins/deployment_manager/NonceManager.ts
@@ -1,6 +1,8 @@
 import { NonceManager } from '@ethersproject/experimental';
+import { TransactionRequest, TransactionResponse } from '@ethersproject/abstract-provider';
 import { TypedDataDomain, TypedDataField, TypedDataSigner } from '@ethersproject/abstract-signer';
 import { _TypedDataEncoder } from '@ethersproject/hash';
+import { Deferrable } from '@ethersproject/properties';
 import { providers } from 'ethers';
 
 // NonceManager does not implement `_signTypedData`, which is needed for the EIP-712 functions
@@ -23,5 +25,12 @@ export class ExtendedNonceManager extends NonceManager implements TypedDataSigne
       address.toLowerCase(),
       JSON.stringify(_TypedDataEncoder.getPayload(populated.domain, types, populated.value))
     ]);
+  }
+
+  async sendTransaction(transaction: Deferrable<TransactionRequest>): Promise<TransactionResponse> {
+    return super.sendTransaction(transaction).catch((e) => {
+      this._reset();
+      throw(e);
+    });
   }
 }

--- a/scenario/context/CometContext.ts
+++ b/scenario/context/CometContext.ts
@@ -256,7 +256,7 @@ export class CometContext {
         await this.setNextBaseFeeToZero();
         await governor.connect(voter).castVote(proposalId, 1, { gasPrice: 0 });
       } catch (err) {
-        debug(`Error while voting for ${whale}`, err);
+        debug(`Error while voting for ${whale}`, err.message);
       }
     }
     await this.mineBlocks(blocksFromStartToEnd);


### PR DESCRIPTION
If there's an error sending a transaction we want to reset the nonce.
This sneakily intercepts errors and resets in our NonceManager subclass.