### PR TITLE
Fix proposal constraint and fetchQuery

### DIFF
--- a/contracts/IGovernorBravo.sol
+++ b/contracts/IGovernorBravo.sol
@@ -17,6 +17,19 @@ interface IGovernorBravo {
         Executed
     }
 
+    struct Proposal {
+        uint id;
+        address proposer;
+        uint eta;
+        uint startBlock;
+        uint endBlock;
+        uint forVotes;
+        uint againstVotes;
+        uint abstainVotes;
+        bool canceled;
+        bool executed;
+    }
+
     event ProposalCreated(
         uint256 proposalId,
         address proposer,
@@ -38,6 +51,7 @@ interface IGovernorBravo {
 
     function comp() external view returns (address);
     function proposalCount() external view returns (uint256);
+    function proposals(uint256 proposalId) external view returns (Proposal memory);
     function votingDelay() external view returns (uint256);
     function votingPeriod() external view returns (uint256);
     function state(uint256 proposalId) external view returns (ProposalState);

--- a/scenario/context/Gov.ts
+++ b/scenario/context/Gov.ts
@@ -1,0 +1,14 @@
+export { IGovernorBravo } from '../../build/types';
+
+export enum ProposalState {
+  Pending,
+  Active,
+  Canceled,
+  Defeated,
+  Succeeded,
+  Queued,
+  Expired,
+  Executed
+};
+
+export type OpenProposal = { id: number, startBlock: number, endBlock: number };


### PR DESCRIPTION
Scen plugin should not depend on scens.
Errors should be thrown in fetchQuery to avoid misusage.
All open proposals should be executed, not just pending/active.

This increases the need for 'static constraints' as proposal constraint is very expensive.
This also hacks in a constant for timelock buf which should really be computed.