### PR TITLE
WIP CToken Migrator

### DIFF
--- a/contracts/migrator/Compound_Migrate_V2_USDC_to_V3_USDC.sol
+++ b/contracts/migrator/Compound_Migrate_V2_USDC_to_V3_USDC.sol
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import "./vendor/@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3FlashCallback.sol";
+import "./vendor/@uniswap/v3-periphery/contracts/base/PeripheryPayments.sol";
+import "./vendor/@uniswap/v3-periphery/contracts/base/PeripheryImmutableState.sol";
+import "./vendor/@uniswap/v3-periphery/contracts/libraries/PoolAddress.sol";
+import "./vendor/@uniswap/v3-periphery/contracts/libraries/CallbackValidation.sol";
+import "./vendor/@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol";
+import "./vendor/@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
+
+import "../CometInterface.sol";
+import "../ERC20.sol";
+
+/**
+ * @title Compound Migrate V2 USDC to V3 USDC
+ * @notice A contract to help migrate a Compound v2 position where a user is borrowing USDC, to a similar Compound v3 position.
+ * @author Compound
+ */
+contract Compound_Migrate_V2_USDC_to_V3_USDC is IUniswapV3FlashCallback, PeripheryImmutableState, PeripheryPayments {
+    /** Events **/
+    event Absorb(address indexed initiator, address[] accounts);
+
+    /// @notice The Comet Ethereum mainnet USDC contract
+    CometInterface immutable comet;
+
+    /// @notice The Uniswap pool used by this contract to source liquidity (i.e. flash loans).
+    UniswapPool immutable uniswapLiquidityPool;
+
+    /// @notice True if borrow token is token 0 in the Uniswap liquidity pool, otherwise false if token 1.
+    bool immutable uniswapLiquidityPoolToken0;
+
+    /// @notice Fee for a flash loan from the liquidity pool as a fixed decimal (e.g. `0.001e18 = 0.1%`)
+    uint256 immutable uniswapLiquidityPoolFee;
+
+    /// @notice A list of valid collateral tokens
+    Erc20[] public collateralTokens;
+
+    /// @notice The Compound II market for the borrowed token (e.g. `cUSDC`).
+    CToken immutable borrowCToken; 
+
+    /// @notice The underlying borrow token (e.g. `USDC`).
+    Erc20 immutable borrowToken;
+
+    /// @notice Address to send swept tokens to, if for any reason they remain locked in this contract.
+    address immutable sweepee;
+
+    /**
+     * @notice Construct a new Compound_Migrate_V2_USDC_to_V3_USDC
+     * @param comet_ The Comet Ethereum mainnet USDC contract.
+     * @param uniswapLiquidityPool_ The Uniswap pool used by this contract to source liquidity (i.e. flash loans).
+     * @param collateralTokens_ A list of valid collateral tokens
+     * @param borrowCToken The Compound II market for the borrowed token (e.g. `cUSDC`).
+     **/
+    constructor(Comet comet_, CToken borrowCToken_, UniswapPool uniswapLiquidityPool_, Erc20[] collateralTokens_, address sweepee_) {
+      comet = comet_;
+      borrowCToken = borrowCToken_;
+      borrowToken = borrowCToken_.underlying();
+      uniswapLiquidityPool = uniswapLiquidityPool_;
+      uniswapLiquidityPoolFee = uniswapLiquidityPool.fee();
+      uniswapLiquidityPoolToken0 = uniswapLiquidityPool.token0() == borrowToken;
+      sweepee = sweepee_;
+      for (uint8 i = 0; i < collateralTokens_.length; i++) {
+        colllateralTokens.push(collateralTokens_[i]);
+      }
+    }
+
+    /**
+     * @notice This is the core function of this contract, migrating a position from Compound II to Compound III. We use a flash loan from Uniswap to provide liquidity to move the position.
+     * @param collateral Array of collateral to transfer into Compound III. See notes below.
+     * @param borrowAmount Amount of borrow to migrate (i.e. close in Compound II, and borrow from Compound III). See notes below.
+     * @dev **N.B.** Collateral requirements may be different in Compound II and Compound III. This may lead to a migration failing or being less collateralized after the migration. There are fees associated with the flash loan, which may affect position or cause migration to fail.
+     * @dev Note: each `collateral` market must exist in `collateralTokens` array, defined on contract creation.
+     * @dev Note: each `collateral` market must be supported in Compound III.
+     * @dev Note: `collateral` amounts of 0 are strictly ignored. Collateral amounts of max uint256 are set to the user's current balance.
+     * @dev Note: `borrowAmount` may be set to max uint256 to migrate the entire current borrow balance.
+     **/
+    function migrate(collateral: (CToken, uint256)[], borrowAmount: uint256) external {
+
+    }
+
+    /**
+     * @notice This function handles a callback from the Uniswap Liquidity Pool after it has sent this contract the requested tokens. We are responsible for repaying those tokens, with a fee, before we return from this function call.
+     * @param fee0 The fee for borrowing token0 from pool. Ingored.
+     * @param fee1 The fee for borrowing token1 from pool. Ingored.
+     * @param data The data encoded above, which is the ABI-encoding of XXX.
+     **/
+    function uniswapV3FlashCallback(uint256 fee0, uint256 fee1, bytes calldata data) external {
+
+    }
+
+    /**
+     * @notice Sends any tokens in this contract to the sweepee address. This contract should never hold tokens, so this is just to fix any anomalistic situations where tokens end up locked in the contract.
+     * @param token The token to sweep
+     **/
+    function sweep(Erc20 token) external {
+
+    }
+
+    // /**
+    //  * @notice Uniswap flashloan callback
+    //  * @param fee0 The fee for borrowing token0 from pool
+    //  * @param fee1 The fee for borrowing token1 from pool
+    //  * @param data The encoded data passed from loan initiation function
+    //  */
+    // function uniswapV3FlashCallback(
+    //     uint256 fee0,
+    //     uint256 fee1,
+    //     bytes calldata data
+    // ) external override {
+    //     // Verify uniswap callback, recommended security measure
+    //     FlashCallbackData memory decoded = abi.decode(data, (FlashCallbackData));
+    //     CallbackValidation.verifyCallback(factory, decoded.poolKey);
+
+    //     address[] memory assets = decoded.assets;
+
+    //     // Allow Comet protocol to withdraw USDC (base token) for collateral purchase
+    //     TransferHelper.safeApprove(comet.baseToken(), address(comet), decoded.amount);
+
+    //     uint256 totalAmountOut = 0;
+    //     for (uint i = 0; i < assets.length; i++) {
+    //         address asset = assets[i];
+    //         uint256 baseAmount = decoded.baseAmounts[i];
+
+    //         if (baseAmount == 0) continue;
+
+    //         comet.buyCollateral(asset, 0, baseAmount, address(this));
+    //         uint256 amountOut = swapCollateral(asset);
+    //         totalAmountOut += amountOut;
+    //     }
+
+    //     // We borrow only 1 asset, so one of fees will be 0
+    //     uint256 fee = fee0 + fee1;
+    //     // Payback flashloan to Uniswap pool and profit to the caller
+    //     payback(decoded.amount, fee, comet.baseToken(), totalAmountOut);
+    // }
+
+    // /**
+    //  * @dev Returns loan to Uniswap pool and sends USDC (base token) profit to caller
+    //  * @param amount The loan amount that need to be repaid
+    //  * @param fee The fee for taking the loan
+    //  * @param token The base token which was borrowed for successful liquidation
+    //  * @param amountOut The total amount of base token received after liquidation
+    //  */
+    // function payback(
+    //     uint256 amount,
+    //     uint256 fee,
+    //     address token,
+    //     uint256 amountOut
+    // ) internal {
+    //     uint256 amountOwed = amount + fee;
+    //     TransferHelper.safeApprove(token, address(this), amountOwed);
+
+    //     // Repay the loan
+    //     if (amountOwed > 0) {
+    //         pay(token, address(this), msg.sender, amountOwed);
+    //         emit Pay(token, address(this), msg.sender, amountOwed);
+    //     }
+
+    //     // If profitable, pay profits to the caller
+    //     if (amountOut > amountOwed) {
+    //         uint256 profit = amountOut - amountOwed;
+    //         TransferHelper.safeApprove(token, address(this), profit);
+    //         pay(token, address(this), recipient, profit);
+    //         emit Pay(token, address(this), recipient, profit);
+    //     }
+    // }
+
+    // /**
+    //  * @dev Calculates the total amount of base asset needed to buy all the discounted collateral from the protocol
+    //  */
+    // function calculateTotalBaseAmount() internal view returns (uint256, uint256[] memory, address[] memory) {
+    //     uint256 totalBaseAmount = 0;
+    //     uint8 numAssets = comet.numAssets();
+    //     uint256[] memory assetBaseAmounts = new uint256[](numAssets);
+    //     address[] memory cometAssets = new address[](numAssets);
+    //     for (uint8 i = 0; i < numAssets; i++) {
+    //         address asset = comet.getAssetInfo(i).asset;
+    //         cometAssets[i] = asset;
+    //         uint256 collateralBalance = comet.collateralBalanceOf(address(comet), asset);
+
+    //         if (collateralBalance == 0) continue;
+
+    //         // Find the price in asset needed to base QUOTE_PRICE_SCALE of USDC (base token) of collateral
+    //         uint256 quotePrice = comet.quoteCollateral(asset, QUOTE_PRICE_SCALE * comet.baseScale());
+    //         uint256 assetBaseAmount = comet.baseScale() * QUOTE_PRICE_SCALE * collateralBalance / quotePrice;
+
+    //         // Liquidate only positions with adequate size, no need to collect residue from protocol
+    //         if (assetBaseAmount < liquidationThreshold) continue;
+
+    //         assetBaseAmounts[i] = assetBaseAmount;
+    //         totalBaseAmount += assetBaseAmount;
+    //     }
+
+    //     return (totalBaseAmount, assetBaseAmounts, cometAssets);
+    // }
+
+    // /**
+    //  * @notice Calls the pools flash function with data needed in `uniswapV3FlashCallback`
+    //  * @param params The parameters necessary for flash and the callback, passed in as FlashParams
+    //  */
+    // function initFlash(FlashParams memory params) external {
+    //     // Absorb Comet underwater accounts
+    //     comet.absorb(address(this), params.accounts);
+    //     emit Absorb(msg.sender, params.accounts);
+
+    //     (uint256 totalBaseAmount, uint256[] memory assetBaseAmounts, address[] memory cometAssets) = calculateTotalBaseAmount();
+
+    //     address poolToken0 = params.pairToken;
+    //     address poolToken1 = comet.baseToken();
+    //     bool reversedPair = poolToken0 > poolToken1;
+    //     // Use Uniswap approach to determining order of tokens https://github.com/Uniswap/v3-periphery/blob/main/contracts/libraries/PoolAddress.sol#L20-L27
+    //     if (reversedPair) (poolToken0, poolToken1) = (poolToken1, poolToken0);
+
+    //     // Find the desired Uniswap pool to borrow base token from, for ex DAI-USDC
+    //     PoolAddress.PoolKey memory poolKey =
+    //         PoolAddress.PoolKey({token0: poolToken0, token1: poolToken1, fee: params.poolFee});
+    //     IUniswapV3Pool pool = IUniswapV3Pool(PoolAddress.computeAddress(factory, poolKey));
+
+    //     // recipient of borrowed amounts
+    //     // amount of token0 requested to borrow, 0 for non reversed pair
+    //     // amount of token1 requested to borrow, 0 for reversed pair
+    //     // need amount in callback to pay back pool
+    //     // need assets addresses to buy collateral from protocol
+    //     // need baseAmounts to buy collateral from protocol
+    //     // recipient of flash should be THIS contract
+    //     pool.flash(
+    //         address(this),
+    //         reversedPair ? totalBaseAmount : 0,
+    //         reversedPair ? 0 : totalBaseAmount,
+    //         abi.encode(
+    //             FlashCallbackData({
+    //                 amount: totalBaseAmount,
+    //                 recipient: msg.sender,
+    //                 poolKey: poolKey,
+    //                 assets: cometAssets,
+    //                 baseAmounts: assetBaseAmounts
+    //             })
+    //         )
+    //     );
+    // }
+}

--- a/contracts/migrator/README.md
+++ b/contracts/migrator/README.md
@@ -24,6 +24,10 @@ Users can specify the following parameters, generally:
  * `borrowToken: Erc20` **immutable**: The underlying borrow token (e.g. `USDC`).
  * `sweepee: address` **immutable**: Address of an address to send swept tokens to, if for any reason they remain locked in this contract.
 
+## Events
+
+TODO
+
 ## Contract Functions
 
 ### Constructor
@@ -119,9 +123,8 @@ This function may only be called during a migration command. We ensure this by m
 
 #### Inputs
 
- - `sender: address`: The address which called `swap` on Uniswap. Should be this contract's address.
- - `uint amount0`: The amount of token 0 transfered. Ingored.
- - `uint amount1`: The amount of token 1 transfered. Ingored.
+ - `uint fee0`: The fee for borrowing token0 from pool. Ingored.
+ - `uint fee1`: The fee for borrowing token1 from pool. Ingored.
  - `calldata data`: The data encoded above, which is the ABI-encoding of XXX.
 
 #### Bindings
@@ -130,7 +133,7 @@ This function may only be called during a migration command. We ensure this by m
 
 #### Function Spec
 
-`function uniswapV2Call(address sender, uint amount0, uint amount1, bytes calldata data)`
+`function uniswapV3FlashCallback(uint256 fee0, uint256 fee1, bytes calldata data)`
 
   - **REQUIRE** `inMigration == 1`
   - **REQUIRE** `msg.sender == uniswapLiquidityPool`

--- a/contracts/migrator/README.md
+++ b/contracts/migrator/README.md
@@ -1,0 +1,53 @@
+## CToken Migrator
+
+The CToken Migrator is a contract that allows a user to transfer a position from Compound II to Compound III.
+
+### Migration Process
+
+Knobs:
+
+ - CToken balances: Choose how much collateral to migrate (0 = don't migrate, -1 = full balance)
+ - Borrow token: Choose which borrow token to migrate (e.g. USDC or DAI)
+ - Repay amount: Choose how much to repay (-1 = full balance)
+ - Min swap ratio: If borrow token is not USDC, minimum price for swap to USDC (e.g. 0.98)
+
+Contracts:
+
+ - `migrator`: An instance of this CTokenMigrator contract
+ - `uniswap`: Uniswap used for flash loans and borrow trades
+ 
+Contract Inputs:
+
+ - `user`: The account initiating the migration
+ - `{cToken, amt}[]`: A set of cTokens and relative amounts to be used as collateral
+ - `borrowCToken`: The borrowed token position to migrate (e.g. cUSDC or cDAI)
+ - `repayAmount`: Amount of borrow to repay, -1 for all.
+ - `minSwapRatio` - Minimum ratio to receive in swap (e.g. 0.98 = 98 USDC for each DAI)
+
+Bindings:
+
+- `usdcSwapAmount` - Amount of USDC required to swap for `repayAmount`
+- `collateral[]`: An alias of `cToken.underlying()` for all cTokens
+- `borrowToken`: Alias for `borrowCToken.underlying()`
+
+Note: this doesn't currently support `CEther`.
+Note: each collateral must be supported in v3.
+Note: collateral factors or liquidity may cause a migration to fail.
+Note: This migrator must already have called full approvals for Comet for all collateral on initialization.
+
+TODO: We need to spend some time thinking about how much to flash loan and how much to borrow from v3
+
+a) The user approves this contract as an operator for v3 `comet.allow(migrator, true)`
+b) The user approves this contract to control each v2 cToken `cToken.approve(migrator, amt)`
+c) If `repayAmount` == -1, `repayAmount` = `borrowCToken.borrowBalance(user)`
+d) USDC: Let `usdcSwapAmount` = `repayAmount`
+e) Non-USDC: Let `usdcSwapAmount` = `quotePrice(USDC, borrowToken, repayAmount)`
+f) We take out a `USDC` flash loan from Uniswap for `usdcSwapAmount`
+g) Non-USDC: Swap `usdcSwapAmount` of `USDC` for `borrowToken` on Uniswap for exactly `repayAmount` (TODO: Exactly??)
+h) We repay the user's borrow `borrowCToken.repayBehalf(user, repayAmount)`
+e) We transfer to ourselves all of the user's cTokens `cToken.transferFrom(user, amt)` [for each `cToken, amt`]
+f) We redeem all cTokens. `cToken.redeem(cToken.balanceOf(migrator))` [for each `cToken, amt`]
+g) We supply each underlying on behalf of the user to v3 as collateral. `comet.supplyCollateral(migrator, user, collateral, collateral.balanceOf(migrator))` [for each `collateral`]
+h) We borrow USDC from Comet `comet.withdrawBase(user, migrator, usdcSwapAmount)`
+i) Repay flash loan for `usdcSwapAmount`
+```

--- a/contracts/migrator/README.md
+++ b/contracts/migrator/README.md
@@ -1,53 +1,160 @@
-## CToken Migrator
+# CToken Migrator
 
-The CToken Migrator is a contract that allows a user to transfer a position from Compound II to Compound III.
+The CToken Migrator is a set of contracts to transfer a positions from Compound II to Compound III.
 
-### Migration Process
+# Migration Spec Compound_Migrate_V2_USDC_to_V3_USDC
 
-Knobs:
+The Compound_Migrate_V2_USDC_to_V3_USDC contract is used to transfer a position where a user is borrowing USDC from Compound II to a position where that user is now borrowing USDC in Compound III. We use a flash loan to faciliate the transition, but there are no swaps otherwise involved in this transfer. Positions can be transferred in whole or in part.
 
- - CToken balances: Choose how much collateral to migrate (0 = don't migrate, -1 = full balance)
- - Borrow token: Choose which borrow token to migrate (e.g. USDC or DAI)
- - Repay amount: Choose how much to repay (-1 = full balance)
- - Min swap ratio: If borrow token is not USDC, minimum price for swap to USDC (e.g. 0.98)
+## Knobs
 
-Contracts:
+Users can specify the following parameters, generally:
 
- - `migrator`: An instance of this CTokenMigrator contract
- - `uniswap`: Uniswap used for flash loans and borrow trades
- 
-Contract Inputs:
+ - Collateral to transfer: A user may choose how much collateral to transfer, e.g. all of my UNI and part of my COMP.
+ - Amount to repay: The user may choose how much to repay of USDC (e.g. all of it or 2000 USDC).
 
- - `user`: The account initiating the migration
- - `{cToken, amt}[]`: A set of cTokens and relative amounts to be used as collateral
- - `borrowCToken`: The borrowed token position to migrate (e.g. cUSDC or cDAI)
- - `repayAmount`: Amount of borrow to repay, -1 for all.
- - `minSwapRatio` - Minimum ratio to receive in swap (e.g. 0.98 = 98 USDC for each DAI)
+## Contract Storage
 
-Bindings:
+ * `comet: Comet` **immutable**: The Comet Ethereum mainnet USDC contract.
+ * `uniswapLiquidityPool: UniswapPool` **immutable**: The Uniswap pool used by this contract to source liquidity (i.e. flash loans).
+ * `uniswapLiquidityPoolToken0: boolean` **immutable**: True if borrow token is token 0 in the Uniswap liquidity pool, otherwise false if token 1.
+ * `uniswapLiquidityPoolFee: uint256` **immutable**: Fee for a flash loan from the liquidity pool as a fixed decimal (e.g. `0.001e18 = 0.1%`)
+ * `collateralTokens: Erc20[]`: A list of valid collateral tokens
+ * `borrowCToken: CToken` **immutable**: The Compound II market for the borrowed token (e.g. `cUSDC`).
+ * `borrowToken: Erc20` **immutable**: The underlying borrow token (e.g. `USDC`).
+ * `sweepee: address` **immutable**: Address of an address to send swept tokens to, if for any reason they remain locked in this contract.
 
-- `usdcSwapAmount` - Amount of USDC required to swap for `repayAmount`
-- `collateral[]`: An alias of `cToken.underlying()` for all cTokens
-- `borrowToken`: Alias for `borrowCToken.underlying()`
+## Contract Functions
 
-Note: this doesn't currently support `CEther`.
-Note: each collateral must be supported in v3.
-Note: collateral factors or liquidity may cause a migration to fail.
-Note: This migrator must already have called full approvals for Comet for all collateral on initialization.
+### Constructor
 
-TODO: We need to spend some time thinking about how much to flash loan and how much to borrow from v3
+This function describes the initialization process for this contract. We set the Compound III contract address and track valid collateral tokens.
 
-a) The user approves this contract as an operator for v3 `comet.allow(migrator, true)`
-b) The user approves this contract to control each v2 cToken `cToken.approve(migrator, amt)`
-c) If `repayAmount` == -1, `repayAmount` = `borrowCToken.borrowBalance(user)`
-d) USDC: Let `usdcSwapAmount` = `repayAmount`
-e) Non-USDC: Let `usdcSwapAmount` = `quotePrice(USDC, borrowToken, repayAmount)`
-f) We take out a `USDC` flash loan from Uniswap for `usdcSwapAmount`
-g) Non-USDC: Swap `usdcSwapAmount` of `USDC` for `borrowToken` on Uniswap for exactly `repayAmount` (TODO: Exactly??)
-h) We repay the user's borrow `borrowCToken.repayBehalf(user, repayAmount)`
-e) We transfer to ourselves all of the user's cTokens `cToken.transferFrom(user, amt)` [for each `cToken, amt`]
-f) We redeem all cTokens. `cToken.redeem(cToken.balanceOf(migrator))` [for each `cToken, amt`]
-g) We supply each underlying on behalf of the user to v3 as collateral. `comet.supplyCollateral(migrator, user, collateral, collateral.balanceOf(migrator))` [for each `collateral`]
-h) We borrow USDC from Comet `comet.withdrawBase(user, migrator, usdcSwapAmount)`
-i) Repay flash loan for `usdcSwapAmount`
-```
+#### Inputs
+
+ * `comet_: Comet`: The Comet Ethereum mainnet USDC contract.
+ * `uniswapLiquidityPool_: UniswapPool` : The Uniswap pool used by this contract to source liquidity (i.e. flash loans).
+ * `collateralTokens_: Erc20[]`: A list of valid collateral tokens
+ * `borrowCToken`: The Compound II market for the borrowed token (e.g. `cUSDC`).
+
+#### Function Spec
+
+`function Compound_Migrate_V2_USDC_to_V3_USDC(Comet comet_, CToken borrowCToken_, UniswapPool uniswapLiquidityPool_, Erc20[] collateralTokens_, address sweepee_)`
+
+ * **WRITE IMMUTABLE** `comet = comet_`
+ * **WRITE IMMUTABLE** `borrowCToken = borrowCToken_`
+ * **WRITE IMMUTABLE** `borrowToken = borrowCToken_.underlying()`
+ * **WRITE IMMUTABLE** `uniswapLiquidityPool = uniswapLiquidityPool_`
+ * **WRITE IMMUTABLE** `uniswapLiquidityPoolFee = uniswapLiquidityPool.fee()`
+ * **WRITE IMMUTABLE** `uniswapLiquidityPoolToken0 = uniswapLiquidityPool.token0() == borrowToken`
+ * **WRITE IMMUTABLE** `sweepee = sweepee_`
+ * **FOREACH** `collateralToken` in `collateralTokens_`
+   * **WRITE** `colllateralTokens.push(collateralToken)`
+
+### Migrate Function
+
+This is the core function of this contract, migrating a position from Compound II to Compound III. We use a flash loan from Uniswap to provide liquidity to move the position.
+
+**N.B.** Collateral requirements may be different in Compound II and Compound III. This may lead to a migration failing or being less collateralized after the migration. There are fees associated with the flash loan, which may affect position or cause migration to fail.
+
+#### Pre-conditions
+
+Before calling this function, a user is required to:
+
+ - a) Call `comet.allow(migrator, true)`
+ - b) For each `{collateralCToken, amount}` in `collateral`, call `collateralCToken.approve(migrator, amount)`.
+
+Notes for (b):
+
+ - allowance may be greater than `amount`, such as max uint256, but may not be less.
+ - allowances are in native cToken, not underlying amounts.
+
+#### Inputs
+
+ * `collateral: (cToken: CToken, amount: uint256)[]` - Array of collateral to transfer into Compound III. See notes below.
+ * `borrowAmount: uint256` - Amount of borrow to migrate (i.e. close in Compound II, and borrow from Compound III). See notes below.
+
+Notes:
+ - Each `collateral` market must exist in `collateralTokens` array, defined on contract creation.
+ - Each `collateral` market must be supported in Compound III.
+ - `collateral` amounts of 0 are strictly ignored. Collateral amounts of max uint256 are set to the user's current balance.
+ - `borrowAmount` may be set to max uint256 to migrate the entire current borrow balance.
+
+#### Bindings
+
+ * `user: address`: Alias for `msg.sender`
+ * `underlyings[]: Erc20[]`: Alias for `cToken.underlying()` for collateral tokens.
+ * `repayAmountActual: uint256`: The repay amount, after accounting for max.
+ * `borrowAmountTotal: uint256`: The amount to borrow from Compound III, accounting for fees.
+ * `data: bytes[]`: The ABI-encoding of the following data, to be passed to the Uniswap Liquidity Pool Callback:
+   * `(user: address, repayAmountActual: uint256, repayBorrowBehalf: uint256, collateral: (CToken, uint256)[])`
+
+#### Function Spec
+
+`function migrate(collateral: (CToken, uint256)[], borrowAmount: uint256) external`
+
+- **REQUIRE** `inMigration == 0`
+- **STORE** `inMigration += 1`
+- **BIND** `user = msg.sender`
+- **WHEN** `repayAmount == type(uint256).max)`:
+  - **BIND READ** `repayAmountActual = cToken.borrowBalanceCurrent(user)`
+- **ELSE**
+  - **BIND** `repayAmountActual = repayAmount`
+- **BIND** `borrowAmountTotal = repayAmountActual * 1e18 / uniswapLiquidityPoolFee + 1`
+- **BIND** `data = abi.encode((user, repayAmountActual, repayBorrowBehalf, collateral))`
+- **CALL** `uniswapLiquidityPool.swap(uniswapLiquidityPoolToken0 ? repayAmount : 0, uniswapLiquidityPoolToken0 ? 0 : repayAmount, address(this), data)`
+- **STORE** `inMigration -= 1`
+
+Note: for fee calculation see [Uniswap Flash Loans - Single Token](https://docs.uniswap.org/protocol/V2/guides/smart-contract-integration/using-flash-swaps#single-token), and the calculation formula: `DAIReturned >= DAIWithdrawn / .997`. We add one to tokens to borrow to "round up" (TODO: is this necessary?)
+
+Note: we may modify the above to sweep any lingering tokens (?).
+
+### Uniswap Liquidity Pool Callback Function
+
+This function handles a callback from the Uniswap Liquidity Pool after it has sent this contract the requested tokens. We are responsible for repaying those tokens, with a fee, before we return from this function call.
+
+#### Pre-conditions
+
+This function may only be called during a migration command. We ensure this by making sure this function, itself, is the caller of the `swap` command. We check that the call originates from the expected Uniswap pool, and we check that we are actively processing a migration. This combination of events should ensure that no external party can trigger this code, though it's not clear it would be dangerous even if such a party did.
+
+#### Inputs
+
+ - `sender: address`: The address which called `swap` on Uniswap. Should be this contract's address.
+ - `uint amount0`: The amount of token 0 transfered. Ingored.
+ - `uint amount1`: The amount of token 1 transfered. Ingored.
+ - `calldata data`: The data encoded above, which is the ABI-encoding of XXX.
+
+#### Bindings
+
+ * `repayAmountActual`: The repay amount, after accounting for max.
+
+#### Function Spec
+
+`function uniswapV2Call(address sender, uint amount0, uint amount1, bytes calldata data)`
+
+  - **REQUIRE** `inMigration == 1`
+  - **REQUIRE** `msg.sender == uniswapLiquidityPool`
+  - **REQUIRE** `sender == address(this)`
+  - **BIND** `(user, repayAmountActual, borrowAmountTotal, collateral) = abi.decode(data, (address, uint256, uint256, (CToken, uint256)[]))`
+  - **CALL** `borrowCToken.repayBorrowBehalf(user, repayAmountActual)`
+  - **FOREACH** `(cToken, amount)` in `collateral`:
+    - **CALL** `cToken.transferFrom(user, amount == type(uint256).max ? cToken.balanceOf(user) : amount)`
+    - **CALL** `cToken.redeem(cToken.balanceOf(address(this)))`
+    - **CALL** `comet.supplyCollateral(address(this), user, cToken.underlying(), cToken.underlying().balanceOf(address(this)))`
+  - **CALL** `comet.withdrawBase(user, address(this), borrowAmountTotal)`
+  - **CALL** `borrowToken.transfer(uniswapLiquidityPool, borrowAmountTotal)`
+
+### Sweep Function
+
+Sends any tokens in this contract to the sweepee address. This contract should never hold tokens, so this is just to fix any anomalistic situations where tokens end up locked in the contract.
+
+#### Inputs
+
+ - `token: Erc20`: The token to sweep
+
+#### Function Spec
+
+`function sweep(Erc20 token)`
+
+  - **REQUIRE** `inMigration == 0`
+  - **CALL** `token.transfer(sweepee, token.balanceOf(address(this)))`


### PR DESCRIPTION
This patch starts to describe the CToken Migrator machine, which allows users to easily move a position from v2 to v3 in one transaction*. This includes using Uniswap for a flash loan for migration, and exchanging borrow token types (e.g. for DAI).

* Offer not valid in Illinois, Utah and.. err, "one transaction after various required approvals"