### PR TITLE
Add back `enacted` step and programmatically set it after running migrations

### DIFF
--- a/.github/workflows/enact-migration.yaml
+++ b/.github/workflows/enact-migration.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Run Enact Migration
         run: |
-          yarn hardhat migrate --network ${{ github.event.inputs.network }} --deployment ${{ github.event.inputs.deployment }} --enact --overwrite ${{ fromJSON('["", "--simulate"]')[github.event.inputs.simulate == 'true'] }} ${{ github.event.inputs.migration }}
+          yarn hardhat migrate --network ${{ github.event.inputs.network }} --deployment ${{ github.event.inputs.deployment }} --enact --set-enacted --overwrite ${{ fromJSON('["", "--simulate"]')[github.event.inputs.simulate == 'true'] }} ${{ github.event.inputs.migration }}
         env:
           DEBUG: true
           ETH_PK: "${{ inputs.eth_pk }}"

--- a/.github/workflows/enact-migration.yaml
+++ b/.github/workflows/enact-migration.yaml
@@ -81,5 +81,5 @@ jobs:
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git add deployments/${{ github.event.inputs.network }}/${{ github.event.inputs.deployment }}/migrations/${{ github.event.inputs.migration }}.ts
-          git commit -m "Modified migration from GitHub Actions"
+          git commit -m "Modified migration from GitHub Actions" || echo "No changes to commit"
           git push origin

--- a/.github/workflows/enact-migration.yaml
+++ b/.github/workflows/enact-migration.yaml
@@ -19,6 +19,9 @@ on:
       simulate:
         type: boolean
         description: Simulate
+      no_enacted:
+        type: boolean
+        description: Do not write Enacted  
       run_id:
         description: Run ID for Artifact
       eth_pk:
@@ -65,7 +68,7 @@ jobs:
 
       - name: Run Enact Migration
         run: |
-          yarn hardhat migrate --network ${{ github.event.inputs.network }} --deployment ${{ github.event.inputs.deployment }} --enact --set-enacted --overwrite ${{ fromJSON('["", "--simulate"]')[github.event.inputs.simulate == 'true'] }} ${{ github.event.inputs.migration }}
+          yarn hardhat migrate --network ${{ github.event.inputs.network }} --deployment ${{ github.event.inputs.deployment }} --enact --overwrite ${{ fromJSON('["", "--simulate"]')[github.event.inputs.simulate == 'true'] }} ${{ fromJSON('["", "--no-enacted"]')[github.event.inputs.no_enacted == 'true'] }} ${{ github.event.inputs.migration }}
         env:
           DEBUG: true
           ETH_PK: "${{ inputs.eth_pk }}"

--- a/.github/workflows/enact-migration.yaml
+++ b/.github/workflows/enact-migration.yaml
@@ -71,3 +71,12 @@ jobs:
           ETH_PK: "${{ inputs.eth_pk }}"
           NETWORK_PROVIDER: ${{ fromJSON('["", "http://localhost:8585"]')[github.event.inputs.eth_pk == ''] }}
           REMOTE_ACCOUNTS: ${{ fromJSON('["", "true"]')[github.event.inputs.eth_pk == ''] }}
+
+      - name: Commit changes
+        if: ${{ github.event.inputs.simulate == 'false' }}
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git add deployments/${{ github.event.inputs.network }}/${{ github.event.inputs.deployment }}/migrations/${{ github.event.inputs.migration }}.ts
+          git commit -m "Modified migration from GitHub Actions"
+          git push origin

--- a/plugins/deployment_manager/Enacted.ts
+++ b/plugins/deployment_manager/Enacted.ts
@@ -1,0 +1,136 @@
+import { DeploymentManager } from './DeploymentManager';
+import * as ts from 'typescript';
+import * as fs from 'fs/promises';
+import { Migration } from './Migration';
+
+export async function writeEnacted<T>(migration: Migration<T>, deploymentManager: DeploymentManager, writeToFile: boolean = true): Promise<string> {
+  const network = deploymentManager.network;
+  const deployment = deploymentManager.deployment;
+  const migrationPath = `./deployments/${network}/${deployment}/migrations/${migration.name}.ts`;
+  const program = ts.createProgram([migrationPath], { allowJs: true });
+  const sourceFile = program.getSourceFile(migrationPath);
+  const newSourceCode = addEnactedToMigration(sourceFile);
+
+  if (writeToFile) {
+    await fs.writeFile(migrationPath, newSourceCode);
+  }
+
+  return newSourceCode;
+}
+
+export function addEnactedToMigration(sourceFile: ts.SourceFile): string {
+  // XXX The following method directly modifying the AST seems less error-prone,
+  // but unfortunately messes with the original formatting of the file
+  // const enactedMethodDeclaration = ts.factory.createMethodDeclaration(
+  //   [],
+  //   [ts.factory.createModifier(ts.SyntaxKind.AsyncKeyword)],
+  //   undefined,
+  //   'enacted',
+  //   undefined,
+  //   [],
+  //   [
+  //     ts.factory.createParameterDeclaration(
+  //       [],
+  //       [],
+  //       undefined,
+  //       'deploymentManager',
+  //     )
+  //   ],
+  //   undefined,
+  //   ts.factory.createBlock([
+  //     ts.factory.createReturnStatement(ts.factory.createTrue())
+  //   ])
+  // ts.factory.createVariableDeclarationList(
+  //   [ts.factory.createVariableDeclaration(
+  //     ts.factory.createIdentifier("testVar"),
+  //     undefined,
+  //     ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+  //     ts.factory.createStringLiteral("test")
+  //   )],
+  //   ts.NodeFlags.Const
+  // );
+
+  // const transformerFactory: ts.TransformerFactory<ts.Node> = (
+  //   context: ts.TransformationContext
+  // ) => {
+  //   return (rootNode) => {
+  //     function visit(node: ts.Node): ts.Node {
+  //       node = ts.visitEachChild(node, visit, context);
+  //       if (ts.isExportAssignment(node)) {
+  //         console.log('IS EXPORT ASSIGNMENT')
+  //         console.log(node)
+  //         const callExpression = node.expression as ts.CallExpression;
+  //         const objectLiteralExpression = callExpression.arguments.find(x => x.kind === ts.SyntaxKind.ObjectLiteralExpression) as ts.ObjectLiteralExpression;
+  //         console.log(objectLiteralExpression)
+  //         console.log('print properties')
+
+  //         const newProperties = objectLiteralExpression.properties.filter(x => (x.name as ts.Identifier).escapedText !== 'enacted');
+  //         newProperties.push(enactedMethodDeclaration)
+  //         const newObjectLiteralExpression = ts.factory.createObjectLiteralExpression(newProperties, true);
+  //         const newCallExpressionArguments = callExpression.arguments.filter(x => x.kind !== ts.SyntaxKind.ObjectLiteralExpression);
+  //         newCallExpressionArguments.push(newObjectLiteralExpression);
+  //         const newCallExpression = ts.factory.createCallExpression(
+  //           callExpression.expression, callExpression.typeArguments,
+  //           newCallExpressionArguments
+  //         )
+
+  //         return ts.factory.createExportAssignment(
+  //           node.decorators, node.modifiers, node.isExportEquals,
+  //           newCallExpression
+  //         )
+  //       }
+  //       return node;
+  //     }
+
+  //     return ts.visitNode(rootNode, visit);
+  //   };
+  // };
+
+  // const transformationResult = ts.transform(
+  //   sourceFile, [transformerFactory]
+  // );
+  // const transformedSourceFile = transformationResult.transformed[0];
+  // const printer = ts.createPrinter();
+  // const result = printer.printNode(
+  //   ts.EmitHint.Unspecified,
+  //   transformedSourceFile,
+  //   undefined
+  // );
+  // console.log(result)
+
+  const sourceFileText = sourceFile.getFullText();
+  const exportAssignment = sourceFile.statements.find(ts.isExportAssignment)!;
+  const callExpression = exportAssignment.expression as ts.CallExpression;
+  const objectLiteralExpression = callExpression.arguments.find(x => x.kind === ts.SyntaxKind.ObjectLiteralExpression) as ts.ObjectLiteralExpression;
+  const enact = objectLiteralExpression.properties.find(x => (x.name as ts.Identifier).escapedText == 'enact')!;
+  const enacted = objectLiteralExpression.properties.find(x => (x.name as ts.Identifier).escapedText == 'enacted');
+  let code =
+    `\n\n  async enacted(deploymentManager: DeploymentManager): Promise<boolean> {\n    return true;\n  },`;
+  let newSourceCode;
+  if (enacted) {
+    // If enacted already exists, just replace it
+    let endPos = enacted.end;
+    if (sourceFileText.charAt(enacted.end) === ',') {
+      endPos = enacted.end + 1;
+    }
+    newSourceCode = sourceFileText.substring(0, enacted.pos)
+      + code
+      + sourceFileText.substring(endPos);
+  } else {
+    // XXX doesn't handle trailing comments well yet
+    // Can use ts.getTrailingCommentRanges to figure that out and use
+    // the last comment end position instead of enact.end
+    let insertPos;
+    if (sourceFileText.charAt(enact.end) === ',') {
+      insertPos = enact.end + 1;
+    } else {
+      insertPos = enact.end;
+      code = ',' + code;
+    }
+    newSourceCode = sourceFileText.substring(0, insertPos)
+      + code
+      + sourceFileText.substring(insertPos);
+  }
+
+  return newSourceCode;
+}

--- a/plugins/deployment_manager/Enacted.ts
+++ b/plugins/deployment_manager/Enacted.ts
@@ -21,85 +21,9 @@ export async function writeEnacted<T>(migration: Migration<T>, deploymentManager
 }
 
 export function addEnactedToMigration(sourceFile: ts.SourceFile): string {
-  // XXX The following method directly modifying the AST seems less error-prone,
-  // but unfortunately messes with the original formatting of the file
-  // const enactedMethodDeclaration = ts.factory.createMethodDeclaration(
-  //   [],
-  //   [ts.factory.createModifier(ts.SyntaxKind.AsyncKeyword)],
-  //   undefined,
-  //   'enacted',
-  //   undefined,
-  //   [],
-  //   [
-  //     ts.factory.createParameterDeclaration(
-  //       [],
-  //       [],
-  //       undefined,
-  //       'deploymentManager',
-  //     )
-  //   ],
-  //   undefined,
-  //   ts.factory.createBlock([
-  //     ts.factory.createReturnStatement(ts.factory.createTrue())
-  //   ])
-  // ts.factory.createVariableDeclarationList(
-  //   [ts.factory.createVariableDeclaration(
-  //     ts.factory.createIdentifier("testVar"),
-  //     undefined,
-  //     ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-  //     ts.factory.createStringLiteral("test")
-  //   )],
-  //   ts.NodeFlags.Const
-  // );
-
-  // const transformerFactory: ts.TransformerFactory<ts.Node> = (
-  //   context: ts.TransformationContext
-  // ) => {
-  //   return (rootNode) => {
-  //     function visit(node: ts.Node): ts.Node {
-  //       node = ts.visitEachChild(node, visit, context);
-  //       if (ts.isExportAssignment(node)) {
-  //         console.log('IS EXPORT ASSIGNMENT')
-  //         console.log(node)
-  //         const callExpression = node.expression as ts.CallExpression;
-  //         const objectLiteralExpression = callExpression.arguments.find(x => x.kind === ts.SyntaxKind.ObjectLiteralExpression) as ts.ObjectLiteralExpression;
-  //         console.log(objectLiteralExpression)
-  //         console.log('print properties')
-
-  //         const newProperties = objectLiteralExpression.properties.filter(x => (x.name as ts.Identifier).escapedText !== 'enacted');
-  //         newProperties.push(enactedMethodDeclaration)
-  //         const newObjectLiteralExpression = ts.factory.createObjectLiteralExpression(newProperties, true);
-  //         const newCallExpressionArguments = callExpression.arguments.filter(x => x.kind !== ts.SyntaxKind.ObjectLiteralExpression);
-  //         newCallExpressionArguments.push(newObjectLiteralExpression);
-  //         const newCallExpression = ts.factory.createCallExpression(
-  //           callExpression.expression, callExpression.typeArguments,
-  //           newCallExpressionArguments
-  //         )
-
-  //         return ts.factory.createExportAssignment(
-  //           node.decorators, node.modifiers, node.isExportEquals,
-  //           newCallExpression
-  //         )
-  //       }
-  //       return node;
-  //     }
-
-  //     return ts.visitNode(rootNode, visit);
-  //   };
-  // };
-
-  // const transformationResult = ts.transform(
-  //   sourceFile, [transformerFactory]
-  // );
-  // const transformedSourceFile = transformationResult.transformed[0];
-  // const printer = ts.createPrinter();
-  // const result = printer.printNode(
-  //   ts.EmitHint.Unspecified,
-  //   transformedSourceFile,
-  //   undefined
-  // );
-  // console.log(result)
-
+  // Note: Another approach is to directly modify the AST, but unfortunately this does not
+  // preserve the original formatting of the source code
+  // Example of the AST approach in commit 73e60480627230d84bb40ab0269722a3e839713a
   const sourceFileText = sourceFile.getFullText();
   const exportAssignment = sourceFile.statements.find(ts.isExportAssignment)!;
   const callExpression = exportAssignment.expression as ts.CallExpression;
@@ -113,6 +37,7 @@ export function addEnactedToMigration(sourceFile: ts.SourceFile): string {
     // If enacted already exists, just replace it
     let endPos = enacted.end;
     if (sourceFileText.charAt(enacted.end) === ',') {
+      // Skip the original comma to avoid double commas
       endPos = enacted.end + 1;
     }
     newSourceCode = sourceFileText.substring(0, enacted.pos)
@@ -124,8 +49,10 @@ export function addEnactedToMigration(sourceFile: ts.SourceFile): string {
     // the last comment end position instead of enact.end
     let insertPos;
     if (sourceFileText.charAt(enact.end) === ',') {
+      // Insert after the comma
       insertPos = enact.end + 1;
     } else {
+      // Prepend a comma
       insertPos = enact.end;
       code = ',' + code;
     }

--- a/plugins/deployment_manager/Enacted.ts
+++ b/plugins/deployment_manager/Enacted.ts
@@ -12,7 +12,9 @@ export async function writeEnacted<T>(migration: Migration<T>, deploymentManager
   const newSourceCode = addEnactedToMigration(sourceFile);
 
   if (writeToFile) {
+    const trace = deploymentManager.tracer();
     await fs.writeFile(migrationPath, newSourceCode);
+    trace(`Wrote \`enacted\` to migration at: ${migrationPath}`)
   }
 
   return newSourceCode;

--- a/plugins/deployment_manager/Enacted.ts
+++ b/plugins/deployment_manager/Enacted.ts
@@ -44,9 +44,6 @@ export function addEnactedToMigration(sourceFile: ts.SourceFile): string {
       + code
       + sourceFileText.substring(endPos);
   } else {
-    // XXX doesn't handle trailing comments well yet
-    // Can use ts.getTrailingCommentRanges to figure that out and use
-    // the last comment end position instead of enact.end
     let insertPos;
     if (sourceFileText.charAt(enact.end) === ',') {
       // Insert after the comma

--- a/plugins/deployment_manager/Enacted.ts
+++ b/plugins/deployment_manager/Enacted.ts
@@ -14,7 +14,7 @@ export async function writeEnacted<T>(migration: Migration<T>, deploymentManager
   if (writeToFile) {
     const trace = deploymentManager.tracer();
     await fs.writeFile(migrationPath, newSourceCode);
-    trace(`Wrote \`enacted\` to migration at: ${migrationPath}`)
+    trace(`Wrote \`enacted\` to migration at: ${migrationPath}`);
   }
 
   return newSourceCode;

--- a/plugins/deployment_manager/Migration.ts
+++ b/plugins/deployment_manager/Migration.ts
@@ -1,9 +1,10 @@
 import { DeploymentManager } from './DeploymentManager';
 import { FileSpec } from './Cache';
 
-interface Actions<T> {
+export interface Actions<T> {
   prepare: (dm: DeploymentManager) => Promise<T>;
   enact: (dm: DeploymentManager, t: T) => Promise<void>;
+  enacted?: (dm: DeploymentManager) => Promise<boolean>;
   verify?: (dm: DeploymentManager) => Promise<void>;
 }
 
@@ -37,5 +38,5 @@ export function migration<T>(name: string, actions: Actions<T>) {
 }
 
 export function getArtifactSpec<T>(migration: Migration<T>): FileSpec {
-  return { rel: [ 'artifacts', `${migration.name}.json` ] };
+  return { rel: ['artifacts', `${migration.name}.json`] };
 }

--- a/plugins/deployment_manager/test/EnactedTest.ts
+++ b/plugins/deployment_manager/test/EnactedTest.ts
@@ -1,0 +1,101 @@
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { addEnactedToMigration } from '../Enacted';
+import * as ts from 'typescript';
+
+use(chaiAsPromised);
+
+const migrationWithoutEnacted = `import { DeploymentManager } from '../../../../plugins/deployment_manager/DeploymentManager';
+import { migration } from '../../../../plugins/deployment_manager/Migration';
+
+interface Vars {};
+
+export default migration('1_cool', {
+  async prepare(deploymentManager: DeploymentManager) {
+    return {};
+  },
+
+  async enact(deploymentManager: DeploymentManager) {
+    // No governance changes
+  },
+});
+`;
+
+const migrationWithoutEnactedAndTrailingComma = `import { DeploymentManager } from '../../../../plugins/deployment_manager/DeploymentManager';
+import { migration } from '../../../../plugins/deployment_manager/Migration';
+
+interface Vars {};
+
+export default migration('1_cool', {
+  async prepare(deploymentManager: DeploymentManager) {
+    return {};
+  },
+
+  async enact(deploymentManager: DeploymentManager) {
+    // No governance changes
+  }
+});
+`;
+
+const migrationWithEnactedWithoutTrailingComma = `import { DeploymentManager } from '../../../../plugins/deployment_manager/DeploymentManager';
+import { migration } from '../../../../plugins/deployment_manager/Migration';
+
+interface Vars {};
+
+export default migration('1_cool', {
+  async prepare(deploymentManager: DeploymentManager) {
+    return {};
+  },
+
+  async enact(deploymentManager: DeploymentManager) {
+    // No governance changes
+  },
+
+  async enacted(deploymentManager: DeploymentManager): Promise<boolean> {
+    return true;
+  }
+});
+`;
+
+const migrationWithEnacted = `import { DeploymentManager } from '../../../../plugins/deployment_manager/DeploymentManager';
+import { migration } from '../../../../plugins/deployment_manager/Migration';
+
+interface Vars {};
+
+export default migration('1_cool', {
+  async prepare(deploymentManager: DeploymentManager) {
+    return {};
+  },
+
+  async enact(deploymentManager: DeploymentManager) {
+    // No governance changes
+  },
+
+  async enacted(deploymentManager: DeploymentManager): Promise<boolean> {
+    return true;
+  },
+});
+`;
+
+// XXX add tests for trailing comment
+describe.only('Enacted', () => {
+  it('writes enacted to migration', async () => {
+    const startingSourceFile = ts.createSourceFile('test', migrationWithoutEnacted, ts.ScriptTarget.Latest);
+    expect(addEnactedToMigration(startingSourceFile)).to.equal(migrationWithEnacted);
+  });
+
+  it('handles no trailing comma', async () => {
+    const startingSourceFile = ts.createSourceFile('test', migrationWithoutEnactedAndTrailingComma, ts.ScriptTarget.Latest);
+    expect(addEnactedToMigration(startingSourceFile)).to.equal(migrationWithEnacted);
+  });
+
+  it('handles existing enacted', async () => {
+    const startingSourceFile = ts.createSourceFile('test', migrationWithEnacted, ts.ScriptTarget.Latest);
+    expect(addEnactedToMigration(startingSourceFile)).to.equal(migrationWithEnacted);
+  });
+
+  it('handles existing enacted without trailing comma', async () => {
+    const startingSourceFile = ts.createSourceFile('test', migrationWithEnactedWithoutTrailingComma, ts.ScriptTarget.Latest);
+    expect(addEnactedToMigration(startingSourceFile)).to.equal(migrationWithEnacted);
+  });
+});

--- a/plugins/deployment_manager/test/EnactedTest.ts
+++ b/plugins/deployment_manager/test/EnactedTest.ts
@@ -21,7 +21,7 @@ export default migration('1_cool', {
 });
 `;
 
-const migrationWithoutEnactedAndTrailingComma = `import { DeploymentManager } from '../../../../plugins/deployment_manager/DeploymentManager';
+const migrationWithoutEnactedWithoutTrailingComma = `import { DeploymentManager } from '../../../../plugins/deployment_manager/DeploymentManager';
 import { migration } from '../../../../plugins/deployment_manager/Migration';
 
 interface Vars {};
@@ -37,7 +37,7 @@ export default migration('1_cool', {
 });
 `;
 
-const migrationWithEnactedWithoutTrailingComma = `import { DeploymentManager } from '../../../../plugins/deployment_manager/DeploymentManager';
+const migrationWithoutEnactedWithTrailingComment = `import { DeploymentManager } from '../../../../plugins/deployment_manager/DeploymentManager';
 import { migration } from '../../../../plugins/deployment_manager/Migration';
 
 interface Vars {};
@@ -49,11 +49,23 @@ export default migration('1_cool', {
 
   async enact(deploymentManager: DeploymentManager) {
     // No governance changes
+  }, // Trailing comment
+});
+`;
+
+const migrationWithoutEnactedWithoutTrailingCommaWithTrailingComment = `import { DeploymentManager } from '../../../../plugins/deployment_manager/DeploymentManager';
+import { migration } from '../../../../plugins/deployment_manager/Migration';
+
+interface Vars {};
+
+export default migration('1_cool', {
+  async prepare(deploymentManager: DeploymentManager) {
+    return {};
   },
 
-  async enacted(deploymentManager: DeploymentManager): Promise<boolean> {
-    return true;
-  }
+  async enact(deploymentManager: DeploymentManager) {
+    // No governance changes
+  } // Trailing comment without trailing comma
 });
 `;
 
@@ -77,15 +89,74 @@ export default migration('1_cool', {
 });
 `;
 
-// XXX add tests for trailing comment
-describe.only('Enacted', () => {
+const migrationWithEnactedWithoutTrailingComma = `import { DeploymentManager } from '../../../../plugins/deployment_manager/DeploymentManager';
+import { migration } from '../../../../plugins/deployment_manager/Migration';
+
+interface Vars {};
+
+export default migration('1_cool', {
+  async prepare(deploymentManager: DeploymentManager) {
+    return {};
+  },
+
+  async enact(deploymentManager: DeploymentManager) {
+    // No governance changes
+  },
+
+  async enacted(deploymentManager: DeploymentManager): Promise<boolean> {
+    return true;
+  }
+});
+`;
+
+const migrationWithEnactedWithTrailingComment = `import { DeploymentManager } from '../../../../plugins/deployment_manager/DeploymentManager';
+import { migration } from '../../../../plugins/deployment_manager/Migration';
+
+interface Vars {};
+
+export default migration('1_cool', {
+  async prepare(deploymentManager: DeploymentManager) {
+    return {};
+  },
+
+  async enact(deploymentManager: DeploymentManager) {
+    // No governance changes
+  },
+
+  async enacted(deploymentManager: DeploymentManager): Promise<boolean> {
+    return true;
+  }, // Trailing comment
+});
+`;
+
+const migrationWithEnactedWithoutTrailingCommaWithTrailingComment = `import { DeploymentManager } from '../../../../plugins/deployment_manager/DeploymentManager';
+import { migration } from '../../../../plugins/deployment_manager/Migration';
+
+interface Vars {};
+
+export default migration('1_cool', {
+  async prepare(deploymentManager: DeploymentManager) {
+    return {};
+  },
+
+  async enact(deploymentManager: DeploymentManager) {
+    // No governance changes
+  },
+
+  async enacted(deploymentManager: DeploymentManager): Promise<boolean> {
+    return true;
+  }, // Trailing comment without trailing comma
+});
+`;
+
+describe('Enacted', () => {
   it('writes enacted to migration', async () => {
     const startingSourceFile = ts.createSourceFile('test', migrationWithoutEnacted, ts.ScriptTarget.Latest);
     expect(addEnactedToMigration(startingSourceFile)).to.equal(migrationWithEnacted);
   });
 
   it('handles no trailing comma', async () => {
-    const startingSourceFile = ts.createSourceFile('test', migrationWithoutEnactedAndTrailingComma, ts.ScriptTarget.Latest);
+    const startingSourceFile = ts.createSourceFile('test', migrationWithoutEnactedWithoutTrailingComma, ts.ScriptTarget.Latest);
     expect(addEnactedToMigration(startingSourceFile)).to.equal(migrationWithEnacted);
   });
 
@@ -97,5 +168,15 @@ describe.only('Enacted', () => {
   it('handles existing enacted without trailing comma', async () => {
     const startingSourceFile = ts.createSourceFile('test', migrationWithEnactedWithoutTrailingComma, ts.ScriptTarget.Latest);
     expect(addEnactedToMigration(startingSourceFile)).to.equal(migrationWithEnacted);
+  });
+
+  it('handles existing enacted with trailing comment', async () => {
+    const startingSourceFile = ts.createSourceFile('test', migrationWithoutEnactedWithTrailingComment, ts.ScriptTarget.Latest);
+    expect(addEnactedToMigration(startingSourceFile)).to.equal(migrationWithEnactedWithTrailingComment);
+  });
+
+  it('handles existing enacted without trailing comma with trailing comment', async () => {
+    const startingSourceFile = ts.createSourceFile('test', migrationWithoutEnactedWithoutTrailingCommaWithTrailingComment, ts.ScriptTarget.Latest);
+    expect(addEnactedToMigration(startingSourceFile)).to.equal(migrationWithEnactedWithoutTrailingCommaWithTrailingComment);
   });
 });

--- a/tasks/deployment_manager/task.ts
+++ b/tasks/deployment_manager/task.ts
@@ -1,5 +1,6 @@
 import { task } from 'hardhat/config';
 import { Migration, loadMigrations } from '../../plugins/deployment_manager/Migration';
+import { writeEnacted } from '../../plugins/deployment_manager/Enacted';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { DeploymentManager, VerifyArgs } from '../../plugins/deployment_manager';
 import hreForBase from '../../plugins/scenario/utils/hreForBase';
@@ -162,5 +163,9 @@ task('migrate', 'Runs migration')
       }
 
       await runMigration(dm, prepare, enact, migration, overwrite);
+
+      if (!simulate && enact) {
+        await writeEnacted(migration, dm, true);
+      }
     }
   );

--- a/tasks/deployment_manager/task.ts
+++ b/tasks/deployment_manager/task.ts
@@ -136,11 +136,11 @@ task('migrate', 'Runs migration')
   .addParam('deployment', 'The deployment to apply the migration to')
   .addFlag('prepare', 'runs preparation [defaults to true if enact not specified]')
   .addFlag('enact', 'enacts migration [implies prepare]')
-  .addFlag('setEnacted', 'write enacted to the migration script')
+  .addFlag('noEnacted', 'do not write enacted to the migration script')
   .addFlag('simulate', 'only simulates the blockchain effects')
   .addFlag('overwrite', 'overwrites artifact if exists, fails otherwise')
   .setAction(
-    async ({ migration: migrationName, prepare, enact, setEnacted, simulate, overwrite, deployment }, env) => {
+    async ({ migration: migrationName, prepare, enact, noEnacted, simulate, overwrite, deployment }, env) => {
       const maybeForkEnv = simulate ? getForkEnv(env) : env;
       const network = env.network.name;
       const dm = new DeploymentManager(
@@ -165,7 +165,7 @@ task('migrate', 'Runs migration')
 
       await runMigration(dm, prepare, enact, migration, overwrite);
 
-      if (enact && setEnacted) {
+      if (enact && !noEnacted) {
         await writeEnacted(migration, dm, true);
       }
     }

--- a/tasks/deployment_manager/task.ts
+++ b/tasks/deployment_manager/task.ts
@@ -136,10 +136,11 @@ task('migrate', 'Runs migration')
   .addParam('deployment', 'The deployment to apply the migration to')
   .addFlag('prepare', 'runs preparation [defaults to true if enact not specified]')
   .addFlag('enact', 'enacts migration [implies prepare]')
+  .addFlag('setEnacted', 'write enacted to the migration script')
   .addFlag('simulate', 'only simulates the blockchain effects')
   .addFlag('overwrite', 'overwrites artifact if exists, fails otherwise')
   .setAction(
-    async ({ migration: migrationName, prepare, enact, simulate, overwrite, deployment }, env) => {
+    async ({ migration: migrationName, prepare, enact, setEnacted, simulate, overwrite, deployment }, env) => {
       const maybeForkEnv = simulate ? getForkEnv(env) : env;
       const network = env.network.name;
       const dm = new DeploymentManager(
@@ -164,7 +165,7 @@ task('migrate', 'Runs migration')
 
       await runMigration(dm, prepare, enact, migration, overwrite);
 
-      if (!simulate && enact) {
+      if (enact && setEnacted) {
         await writeEnacted(migration, dm, true);
       }
     }


### PR DESCRIPTION
This PR adds back an optional `enacted` step in our migrations and programmatically sets it whenever a migration is run with `enact` on. We are bringing `enacted` back so we have a way to prevent scenarios from running the same migration again once it has already been enacted on-chain.

Example commits of GHA adding `enacted` after running a migration:
https://github.com/compound-finance/comet/pull/566/commits/04aab559697102d09d580fb688bfa6012cc13555
https://github.com/compound-finance/comet/pull/566/commits/16b3daf885609aae3ff48c604941408315500153