### PR TITLE
Emit ERC-20 transfer (mint) event on absorb

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -1181,9 +1181,6 @@ contract Comet is CometMainInterface {
 
         int104 newPrincipal = principalValue(newBalance);
         updateBasePrincipal(account, accountUser, newPrincipal);
-        if (newPrincipal > 0) {
-            emit Transfer(address(0), account, presentValueSupply(baseSupplyIndex, unsigned104(newPrincipal)));
-        }
 
         // reset assetsIn
         userBasic[account].assetsIn = 0;
@@ -1198,6 +1195,10 @@ contract Comet is CometMainInterface {
         uint256 basePaidOut = unsigned256(newBalance - oldBalance);
         uint256 valueOfBasePaidOut = mulPrice(basePaidOut, basePrice, uint64(baseScale));
         emit AbsorbDebt(absorber, account, basePaidOut, valueOfBasePaidOut);
+
+        if (newPrincipal > 0) {
+            emit Transfer(address(0), account, presentValueSupply(baseSupplyIndex, unsigned104(newPrincipal)));
+        }
     }
 
     /**

--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -1181,8 +1181,8 @@ contract Comet is CometMainInterface {
 
         int104 newPrincipal = principalValue(newBalance);
         updateBasePrincipal(account, accountUser, newPrincipal);
-        if (newBalance > 0) {
-            emit Transfer(address(0), account, uint256(newBalance));
+        if (newPrincipal > 0) {
+            emit Transfer(address(0), account, presentValueSupply(baseSupplyIndex, unsigned104(newPrincipal)));
         }
 
         // reset assetsIn

--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -1181,6 +1181,9 @@ contract Comet is CometMainInterface {
 
         int104 newPrincipal = principalValue(newBalance);
         updateBasePrincipal(account, accountUser, newPrincipal);
+        if (newBalance > 0) {
+            emit Transfer(address(0), account, uint256(newBalance));
+        }
 
         // reset assetsIn
         userBasic[account].assetsIn = 0;

--- a/test/absorb-test.ts
+++ b/test/absorb-test.ts
@@ -444,18 +444,18 @@ describe('absorb', function () {
       }
     });
     expect(event(a0, 3)).to.be.deep.equal({
-      Transfer: {
-        amount: finalDebt,
-        from: ethers.constants.AddressZero,
-        to: underwater.address,
-      }
-    });
-    expect(event(a0, 4)).to.be.deep.equal({
       AbsorbDebt: {
         absorber: absorber.address,
         borrower: underwater.address,
         basePaidOut: pU1.internal.USDC - startingDebt,
         usdValue: mulPrice(pU1.internal.USDC - startingDebt, usdcPrice, baseScale),
+      }
+    });
+    expect(event(a0, 4)).to.be.deep.equal({
+      Transfer: {
+        amount: finalDebt,
+        from: ethers.constants.AddressZero,
+        to: underwater.address,
       }
     });
   });


### PR DESCRIPTION
When an absorbed account ends up with a positive balance, we need to emit a ERC-20 transfer event to indicate that some amount of `Comet` tokens are minted.