### PR TITLE
Separate whales for testnet

### DIFF
--- a/scenario/context/CometContext.ts
+++ b/scenario/context/CometContext.ts
@@ -67,8 +67,12 @@ export class CometContext {
     this.assets = {};
   }
 
+  async getCompWhales(): Promise<string[]> {
+    return COMP_WHALES[this.world.base.name === 'mainnet' ? 'mainnet' : 'testnet'];
+  }
+
   async getProposer(): Promise<SignerWithAddress> {
-    return this.world.impersonateAddress(COMP_WHALES[0]);
+    return this.world.impersonateAddress((await this.getCompWhales())[0]);
   }
 
   async getComet(): Promise<CometInterface> {
@@ -257,7 +261,7 @@ export class CometContext {
     }
 
     if (blocksUntilEnd > 0) {
-      for (const whale of COMP_WHALES) {
+      for (const whale of await this.getCompWhales()) {
         try {
           // Voting can fail if voter has already voted
           const voter = await this.world.impersonateAddress(whale);

--- a/src/deploy/Network.ts
+++ b/src/deploy/Network.ts
@@ -11,7 +11,7 @@ export function sameAddress(a: string, b: string) {
 //  to preserve local development speed and without network
 export async function cloneGov(
   deploymentManager: DeploymentManager,
-  voterAddress = COMP_WHALES[0],
+  voterAddress = COMP_WHALES.testnet[0],
   adminSigner?: SignerWithAddress
 ): Promise<Deployed> {
   const trace = deploymentManager.tracer();

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -63,13 +63,20 @@ export type Proposal = [
   string          // description
 ];
 
-// Note: this list could change over time, based on mainnet
-export const COMP_WHALES = [
-  '0xea6c3db2e7fca00ea9d7211a03e83f568fc13bf7',
-  '0x61258f12c459984f32b83c86a6cc10aa339396de',
-  '0x9aa835bc7b8ce13b9b0c9764a52fbf71ac62ccf1',
-  '0x683a4f9915d6216f73d6df50151725036bd26c02',
-];
+// Note: this list could change over time
+// Ideally these wouldn't be hardcoded, but other solutions are much more complex, and slower
+export const COMP_WHALES = {
+  mainnet: [
+    '0xea6c3db2e7fca00ea9d7211a03e83f568fc13bf7',
+    '0x61258f12c459984f32b83c86a6cc10aa339396de',
+    '0x9aa835bc7b8ce13b9b0c9764a52fbf71ac62ccf1',
+    '0x683a4f9915d6216f73d6df50151725036bd26c02',
+  ],
+
+  testnet: [
+    '0xbbfe34e868343e6f4f5e8b5308de980d7bd88c46',
+  ]
+};
 
 export async function calldata(req: Promise<PopulatedTransaction>): Promise<string> {
   // Splice out the first 4 bytes (function selector) of the tx data


### PR DESCRIPTION
For prior testnets, we completely controlled the COMP allocation, so we were able to delegate to the top mainnet whale when cloning gov. For new goerli, we are leveraging an existing gov installation, so we need to know about some external COMP whales. The current mechanism is sort of a compromise to keep complexity down and prevent scens from being even slower. We shouldn't necessarily need any sets of whales beyond 'mainnet' and 'testnet'.