### PR TITLE
Cross-chain migrations

### DIFF
--- a/plugins/deployment_manager/MigrationTemplate.ts
+++ b/plugins/deployment_manager/MigrationTemplate.ts
@@ -16,7 +16,7 @@ export default migration('${timestamp}_${name}', {
     return {};
   },
 
-  enact: async (deploymentManager: DeploymentManager, vars: Vars) => {
+  enact: async (governanceDeploymentManager: DeploymentManager, vars: Vars) => {
     // No governance changes
   }
 });\n`;

--- a/plugins/deployment_manager/test/MigrationTemplateTest.ts
+++ b/plugins/deployment_manager/test/MigrationTemplateTest.ts
@@ -18,7 +18,7 @@ export default migration('1_cool', {
     return {};
   },
 
-  enact: async (deploymentManager: DeploymentManager, vars: Vars) => {
+  enact: async (governanceDeploymentManager: DeploymentManager, vars: Vars) => {
     // No governance changes
   }
 });

--- a/tasks/deployment_manager/task.ts
+++ b/tasks/deployment_manager/task.ts
@@ -15,6 +15,7 @@ function getForkEnv(env: HardhatRuntimeEnvironment): HardhatRuntimeEnvironment {
 
 async function runMigration<T>(
   deploymentManager: DeploymentManager,
+  governanceDeploymentManager: DeploymentManager,
   prepare: boolean,
   enact: boolean,
   migration: Migration<T>,
@@ -41,7 +42,7 @@ async function runMigration<T>(
 
   if (enact) {
     console.log('Running enactment step with artifact...', artifact);
-    await migration.actions.enact(deploymentManager, artifact);
+    await migration.actions.enact(governanceDeploymentManager, artifact);
     console.log('Enactment complete');
   }
 }
@@ -152,6 +153,27 @@ task('migrate', 'Runs migration')
       );
       await dm.spider();
 
+      let governanceDm: DeploymentManager;
+      const base = env.config.scenario.bases.find(b => b.network === network && b.deployment === deployment);
+      const isBridgedDeployment = base.auxiliaryBase !== undefined;
+      const governanceBase = isBridgedDeployment ? env.config.scenario.bases.find(b => b.name === base.auxiliaryBase) : undefined;
+
+      if (governanceBase) {
+        const governanceEnv = hreForBase(governanceBase, simulate);
+        governanceDm = new DeploymentManager(
+          governanceBase.network,
+          governanceBase.deployment,
+          governanceEnv,
+          {
+            writeCacheToDisk: !simulate || overwrite, // Don't write to disk when simulating, unless overwrite is set
+            verificationStrategy: 'lazy',
+          }
+        );
+        await governanceDm.spider();
+      } else {
+        governanceDm = dm;
+      }
+
       const migrationPath = `${__dirname}/../../deployments/${network}/${deployment}/migrations/${migrationName}.ts`;
       const [migration] = await loadMigrations([migrationPath]);
       if (!migration) {
@@ -161,6 +183,6 @@ task('migrate', 'Runs migration')
         prepare = true;
       }
 
-      await runMigration(dm, prepare, enact, migration, overwrite);
+      await runMigration(dm, governanceDm, prepare, enact, migration, overwrite);
     }
   );


### PR DESCRIPTION
Updating the migration flow to reflect the changes for L2s/bridged chains.

In migrations, the `prepare` step will receive a `deploymentManager` for the current chain.

The `enact` step will receive a `governanceDeploymentManager` for the governing chain (most likely the mainnet deployment or the Goerli deployment).

Requires extending `hreForBase` to return non-forked HREs (the current implementation assumes that the HRE you're constructing should be a fork).

The migration task determines whether a given deployment is a bridged deployment using the `scenario.bases` config, which is somewhat strange but is currently the only place that we store whether a given deployment is governed by a different chain.