### PR TITLE
Disable fail-fast in matrix configuration

### DIFF
--- a/.github/workflows/run-scenarios.yaml
+++ b/.github/workflows/run-scenarios.yaml
@@ -5,6 +5,7 @@ on:
 jobs:
   run-scenarios:
     strategy:
+      fail-fast: false
       matrix:
         bases: [ development, mainnet, goerli, fuji, mumbai ]
     name: Run scenarios


### PR DESCRIPTION
This means that one matrix job failing will no longer cancel all the other running matrix jobs.