### PR TITLE
[do not merge] set max-old-space-size

### DIFF
--- a/.github/workflows/run-coverage.yaml
+++ b/.github/workflows/run-coverage.yaml
@@ -8,6 +8,7 @@ jobs:
     name: Run coverage
     runs-on: ubuntu-latest
     env:
+      NODE_OPTIONS: '--max-old-space-size=4096'
       OPTIMIZER_DISABLED: true
       ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_KEY }}
       SNOWTRACE_KEY: ${{ secrets.SNOWTRACE_KEY }}

--- a/.github/workflows/run-coverage.yaml
+++ b/.github/workflows/run-coverage.yaml
@@ -1,8 +1,7 @@
 name: Run Coverage
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+  pull_request:
 jobs:
   run-coverage:
     name: Run coverage


### PR DESCRIPTION
the `Run Coverage` action is running out of memory

https://github.com/compound-finance/comet/actions/runs/3116058799/jobs/5053854291

```
<--- JS stacktrace --->

FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
 1: 0xb02930 node::Abort() [/opt/hostedtoolcache/node/16.17.0/x64/bin/node]
 2: 0xa18149 node::FatalError(char const*, char const*) [/opt/hostedtoolcache/node/16.17.0/x64/bin/node]
```

Attempting to bump max heap size

Temporarily re-enabling `Run Coverage` on PRs, for testing