### PR TITLE
Fix coverage

### DIFF
--- a/.github/workflows/run-coverage.yaml
+++ b/.github/workflows/run-coverage.yaml
@@ -8,6 +8,7 @@ jobs:
     name: Run coverage
     runs-on: ubuntu-latest
     env:
+      NODE_OPTIONS: '--max-old-space-size=4096'
       OPTIMIZER_DISABLED: true
       ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_KEY }}
       SNOWTRACE_KEY: ${{ secrets.SNOWTRACE_KEY }}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -228,6 +228,7 @@ const config: HardhatUserConfig = {
         output: 'test-results.json',
       },
     },
+    timeout: 100_000
   },
 
   paths: {


### PR DESCRIPTION
`--max-old-space-size=4096` fixes the max heap errors:

<img width="882" alt="image" src="https://user-images.githubusercontent.com/2570291/193362612-b7c83f15-50fa-49be-a2b6-ecfa6e0ca5da.png">

https://github.com/compound-finance/comet/actions/runs/3116058799/jobs/5053854291

bumping the Mocha timeout prevents failing for timeouts:

<img width="1130" alt="image" src="https://user-images.githubusercontent.com/2570291/193362520-f91ee75c-1197-43ef-9d15-eff343ef006a.png">

https://github.com/compound-finance/comet/actions/runs/3116323528/jobs/5078730536