### PR TITLE
additional strategy for pulling Contract Creation code

### DIFF
--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -117,14 +117,15 @@ async function pullFirstTransactionForContract(network: string, address: string)
     apikey: getEtherscanApiKey(network)
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
+  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({ ...params, ...{ apikey: '[API_KEY]'}})}`;
 
-  debug(`Attempting to pull Contract Creation code from first tx at ${url}`);
+  debug(`Attempting to pull Contract Creation code from first tx at ${debugUrl}`);
   const result = await get(url, {});
   const contractCreationCode = result.result[0].input;
   if (!contractCreationCode) {
-    throw new Error(`Unable to find Contract Creation tx at ${url}`);
+    throw new Error(`Unable to find Contract Creation tx at ${debugUrl}`);
   }
-  debug(`Creation Code found in first tx at ${url}`);
+  debug(`Creation Code found in first tx at ${debugUrl}`);
   return contractCreationCode.slice(2);
 }
 

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -125,7 +125,7 @@ async function getContractCreationCode(network: string, address: string) {
       errors.push(error);
     }
   }
-  throw new Error(errors.join("; "));
+  throw new Error(errors.join('; '));
 }
 
 function parseSources({ source, contract, optimized, optimizationRuns }: EtherscanData) {

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -1,5 +1,15 @@
 import { get, getEtherscanApiKey, getEtherscanApiUrl, getEtherscanUrl } from './etherscan';
 
+export function debug(...args: any[]) {
+  if (process.env['DEBUG']) {
+    if (typeof args[0] === 'function') {
+      console.log(...args[0]());
+    } else {
+      console.log(...args);
+    }
+  }
+}
+
 /**
  * Copied from Saddle import with some small modifications.
  *
@@ -73,11 +83,12 @@ async function getEtherscanApiData(network: string, address: string, apiKey: str
   };
 }
 
-async function getContractCreationCode(network: string, address: string) {
-  let url = `${await getEtherscanUrl(network)}/address/${address}#code`;
-  let result = <string>await get(url, {});
-  let regex = /<div id='verifiedbytecode2'>[\s\r\n]*([0-9a-fA-F]*)[\s\r\n]*<\/div>/g;
-  let matches = [...result.matchAll(regex)];
+async function scrapeContractCreationCode(network: string, address: string) {
+  const url = `${getEtherscanUrl(network)}/address/${address}#code`;
+  debug(`Attempting to scrape Contract Creation at ${url}`);
+  const result = <string>await get(url, {});
+  const regex = /<div id='verifiedbytecode2'>[\s\r\n]*([0-9a-fA-F]*)[\s\r\n]*<\/div>/g;
+  const matches = [...result.matchAll(regex)];
   if (matches.length === 0) {
     if (result.match(/request throttled/i) || result.match(/try again later/i)) {
       throw new Error(`Request throttled: ${url}`);
@@ -85,7 +96,36 @@ async function getContractCreationCode(network: string, address: string) {
       throw new Error(`Failed to pull deployed contract code from Etherscan: ${url}`);
     }
   }
+  debug(`Scraping successful for ${url}`);
   return matches[0][1];
+}
+
+async function pullFirstTransaction(network: string, address: string) {
+  const url = `${getEtherscanApiUrl(network)}?module=account&action=txlist&address=${address}&startblock=0&endblock=99999999&page=1&offset=10&sort=asc&apikey=${getEtherscanApiKey(network)}`;
+  debug(`Attempting to pull Contract Creation code from first tx at ${url}`);
+  const result = await get(url, {});
+  const contractCreationCode = result.result[0].input;
+  if (!contractCreationCode) {
+    throw new Error(`Unable to find Contract Creation event at ${url}`);
+  }
+  debug(`Creation Code found in first tx at ${url}`);
+  return contractCreationCode.slice(2);
+}
+
+async function getContractCreationCode(network: string, address: string) {
+  const strategies = [
+    scrapeContractCreationCode,
+    pullFirstTransaction
+  ];
+  let errors = [];
+  for (const strategy of strategies) {
+    try {
+      return await strategy(network, address);
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  throw new Error(errors.join("; "));
 }
 
 function parseSources({ source, contract, optimized, optimizationRuns }: EtherscanData) {

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -100,13 +100,13 @@ async function scrapeContractCreationCodeFromEtherscan(network: string, address:
   return matches[0][1];
 }
 
-function paramString(params: Object) {
+function paramString(params: { [k: string]: string | number }) {
   return Object.entries(params).map(([k,v]) => `${k}=${v}`).join('&');
 }
 
 async function pullFirstTransactionForContract(network: string, address: string) {
   const params = {
-    module: "account",
+    module: 'account',
     action: 'txlist',
     address,
     startblock: 0,

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -85,7 +85,7 @@ async function getEtherscanApiData(network: string, address: string, apiKey: str
 
 async function scrapeContractCreationCode(network: string, address: string) {
   const url = `${getEtherscanUrl(network)}/address/${address}#code`;
-  debug(`Attempting to scrape Contract Creation at ${url}`);
+  debug(`Attempting to scrape Contract Creation code at ${url}`);
   const result = <string>await get(url, {});
   const regex = /<div id='verifiedbytecode2'>[\s\r\n]*([0-9a-fA-F]*)[\s\r\n]*<\/div>/g;
   const matches = [...result.matchAll(regex)];
@@ -106,7 +106,7 @@ async function pullFirstTransaction(network: string, address: string) {
   const result = await get(url, {});
   const contractCreationCode = result.result[0].input;
   if (!contractCreationCode) {
-    throw new Error(`Unable to find Contract Creation event at ${url}`);
+    throw new Error(`Unable to find Contract Creation tx at ${url}`);
   }
   debug(`Creation Code found in first tx at ${url}`);
   return contractCreationCode.slice(2);

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -100,8 +100,24 @@ async function scrapeContractCreationCodeFromEtherscan(network: string, address:
   return matches[0][1];
 }
 
+function paramString(params: Object) {
+  return Object.entries(params).map(([k,v]) => `${k}=${v}`).join('&');
+}
+
 async function pullFirstTransactionForContract(network: string, address: string) {
-  const url = `${getEtherscanApiUrl(network)}?module=account&action=txlist&address=${address}&startblock=0&endblock=99999999&page=1&offset=10&sort=asc&apikey=${getEtherscanApiKey(network)}`;
+  const params = {
+    module: "account",
+    action: 'txlist',
+    address,
+    startblock: 0,
+    endblock: 99999999,
+    page: 1,
+    offset: 10,
+    sort: 'asc',
+    apikey: getEtherscanApiKey(network)
+  };
+  const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
+
   debug(`Attempting to pull Contract Creation code from first tx at ${url}`);
   const result = await get(url, {});
   const contractCreationCode = result.result[0].input;

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -83,7 +83,7 @@ async function getEtherscanApiData(network: string, address: string, apiKey: str
   };
 }
 
-async function scrapeContractCreationCode(network: string, address: string) {
+async function scrapeContractCreationCodeFromEtherscan(network: string, address: string) {
   const url = `${getEtherscanUrl(network)}/address/${address}#code`;
   debug(`Attempting to scrape Contract Creation code at ${url}`);
   const result = <string>await get(url, {});
@@ -100,7 +100,7 @@ async function scrapeContractCreationCode(network: string, address: string) {
   return matches[0][1];
 }
 
-async function pullFirstTransaction(network: string, address: string) {
+async function pullFirstTransactionForContract(network: string, address: string) {
   const url = `${getEtherscanApiUrl(network)}?module=account&action=txlist&address=${address}&startblock=0&endblock=99999999&page=1&offset=10&sort=asc&apikey=${getEtherscanApiKey(network)}`;
   debug(`Attempting to pull Contract Creation code from first tx at ${url}`);
   const result = await get(url, {});
@@ -114,8 +114,8 @@ async function pullFirstTransaction(network: string, address: string) {
 
 async function getContractCreationCode(network: string, address: string) {
   const strategies = [
-    scrapeContractCreationCode,
-    pullFirstTransaction
+    scrapeContractCreationCodeFromEtherscan,
+    pullFirstTransactionForContract
   ];
   let errors = [];
   for (const strategy of strategies) {


### PR DESCRIPTION
I posted some of this in Discord; adding here for posterity.

Currently, when we want to grab Contract Creation code, we attempt to scrape the content directly from Etherscan.

We make a request for the page data at `https://etherscan.io/address/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599#code`, for example, and search for the contents of a div with a particular ID.

Recently, Polygonscan put a Cloudflare challenge page in front of their pages, so our attempts to scrape their pages fail with a 503 and some page content that includes the text `polygonscan.com needs to review the security of your connection before proceeding`. This breaks our scenarios/deploys for Mumbai/Polygon.

Sometimes, the Contract Creation code can be pulled via the Etherscan API. For example, the "input" data for the first transaction for WBTC here:

https://api.etherscan.io/api?module=account&action=txlist&address=0x2260fac5e5542a773aa44fbcfedf7c193bc2c599&startblock=0&endblock=99999999&page=1&offset=10&sort=asc

...matches the Contract Creation code here: https://etherscan.io/address/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599#code

It's not true for all contracts, unfortunately. DAI, for example, does not have its Contract Creation listed in the `txlist` endpoint:

https://api.etherscan.io/api?module=account&action=txlist&address=0x6b175474e89094c44da98b954eedeac495271d0f&startblock=0&endblock=99999999&page=1&offset=10&sort=asc

This appears to be because DAI was created as part of an "internal" transaction:

https://etherscan.io/address/0x6b175474e89094c44da98b954eedeac495271d0f#internaltx

It's possible to retrieve that internal transaction via the Etherscan API, but the "input" value (which would give the constructor args) is inexplicably empty:

https://api.etherscan.io/api?module=account&action=txlistinternal&txhash=0x495402df7d45fe36329b0bd94487f49baee62026d50f654600f6771bd2a596ab

For the time-being, we can get away with a combination of these two strategies (sometimes scraping, sometimes pulling from transaction data). But if Etherscan puts Cloudflare in front of their other block explorer instances, we may have to resort to an even more elaborate strategy to reproduce Contract Creation code.