### PR TITLE
UtilizationConstraint; attempt to source from multiple assets

### DIFF
--- a/scenario/constraints/UtilizationConstraint.ts
+++ b/scenario/constraints/UtilizationConstraint.ts
@@ -110,7 +110,7 @@ export class UtilizationConstraint<T extends CometContext, R extends Requirement
           // To borrow as much, we need to supply some collateral.
           const numAssets = await comet.numAssets();
           for (let i = 0; i < numAssets; i++) {
-            console.log(`UtilizatioConstraint: attempting to source from $asset${i}`);
+            console.log(`UtilizationConstraint: attempting to source from $asset${i}`);
 
             const { asset: collateralAsset, borrowCollateralFactor, priceFeed, scale } = await comet.getAssetInfo(i);
 

--- a/scenario/constraints/UtilizationConstraint.ts
+++ b/scenario/constraints/UtilizationConstraint.ts
@@ -146,10 +146,10 @@ export class UtilizationConstraint<T extends CometContext, R extends Requirement
 
               // XXX will also need to make sure there are enough base tokens in the protocol to withdraw
               await comet.connect(borrowActor.signer).withdraw(baseToken.address, toBorrowBase);
-              console.log(`UtilizatioConstraint: successfully sourced from $asset${i}`);
+              console.log(`UtilizationConstraint: successfully sourced from $asset${i}`);
               break;
             } catch (error) {
-              console.log(`UtilizatioConstraint: failed to source from $asset${i} (${error.message})`);
+              console.log(`UtilizationConstraint: failed to source from $asset${i} (${error.message})`);
             }
           }
         }

--- a/scenario/constraints/UtilizationConstraint.ts
+++ b/scenario/constraints/UtilizationConstraint.ts
@@ -107,43 +107,51 @@ export class UtilizationConstraint<T extends CometContext, R extends Requirement
         }
 
         if (toBorrowBase > 0n) {
-          // To borrow as much, we need to supply some collateral. We technically
-          // could provide a solution for each token, but we don't know them in advance,
-          // generally, so let's just pick the first one and source enough of it.
+          // To borrow as much, we need to supply some collateral.
+          const numAssets = await comet.numAssets();
+          for (let i = 0; i < numAssets; i++) {
+            console.log(`UtilizatioConstraint: attempting to source from $asset${i}`);
 
-          let { asset: collateralAsset, borrowCollateralFactor, priceFeed, scale } = await comet.getAssetInfo(0);
+            const { asset: collateralAsset, borrowCollateralFactor, priceFeed, scale } = await comet.getAssetInfo(i);
 
-          let collateralToken = context.getAssetByAddress(collateralAsset);
+            const collateralToken = context.getAssetByAddress(collateralAsset);
 
-          let basePrice = (await comet.getPrice(await comet.baseTokenPriceFeed())).toBigInt();
-          let collateralPrice = (await comet.getPrice(priceFeed)).toBigInt();
+            const basePrice = (await comet.getPrice(await comet.baseTokenPriceFeed())).toBigInt();
+            const collateralPrice = (await comet.getPrice(priceFeed)).toBigInt();
 
-          let baseScale = (await comet.baseScale()).toBigInt();
-          let collateralScale = scale.toBigInt();
+            const baseScale = (await comet.baseScale()).toBigInt();
+            const collateralScale = scale.toBigInt();
 
-          let collateralWeiPerUnitBase = (collateralScale * basePrice) / collateralPrice;
-          let collateralNeeded = (collateralWeiPerUnitBase * toBorrowBase) / baseScale;
-          collateralNeeded = (collateralNeeded * factorScale) / borrowCollateralFactor.toBigInt(); // adjust for borrowCollateralFactor
-          collateralNeeded = (collateralNeeded * 11n) / 10n; // add fudge factor
+            const collateralWeiPerUnitBase = (collateralScale * basePrice) / collateralPrice;
+            let collateralNeeded = (collateralWeiPerUnitBase * toBorrowBase) / baseScale;
+            collateralNeeded = (collateralNeeded * factorScale) / borrowCollateralFactor.toBigInt(); // adjust for borrowCollateralFactor
+            collateralNeeded = (collateralNeeded * 11n) / 10n; // add fudge factor
 
-          let info = {
-            utilization,
-            totalSupplyBase: totalSupplyBase.toString(),
-            totalBorrowBase: totalBorrowBase.toString(),
-            toBorrowBase: toBorrowBase.toString(),
-            collateralAsset,
-            borrowCollateralFactor: borrowCollateralFactor.toString(),
-            collateralNeeded: collateralNeeded.toString(),
-          };
+            const info = {
+              utilization,
+              totalSupplyBase: totalSupplyBase.toString(),
+              totalBorrowBase: totalBorrowBase.toString(),
+              toBorrowBase: toBorrowBase.toString(),
+              collateralAsset,
+              borrowCollateralFactor: borrowCollateralFactor.toString(),
+              collateralNeeded: collateralNeeded.toString(),
+            };
 
-          let borrowActor = await context.allocateActor('UtilizationConstraint{Borrower}', info);
+            const borrowActor = await context.allocateActor('UtilizationConstraint{Borrower}', info);
 
-          await context.sourceTokens(collateralNeeded, collateralToken, borrowActor);
-          await collateralToken.approve(borrowActor, comet);
-          await borrowActor.safeSupplyAsset({ asset: collateralToken.address, amount: collateralNeeded });
+            try {
+              await context.sourceTokens(collateralNeeded, collateralToken, borrowActor);
+              await collateralToken.approve(borrowActor, comet);
+              await borrowActor.safeSupplyAsset({ asset: collateralToken.address, amount: collateralNeeded });
 
-          // XXX will also need to make sure there are enough base tokens in the protocol to withdraw
-          await comet.connect(borrowActor.signer).withdraw(baseToken.address, toBorrowBase);
+              // XXX will also need to make sure there are enough base tokens in the protocol to withdraw
+              await comet.connect(borrowActor.signer).withdraw(baseToken.address, toBorrowBase);
+              console.log(`UtilizatioConstraint: successfully sourced from $asset${i}`);
+              break;
+            } catch (error) {
+              console.log(`UtilizatioConstraint: failed to source from $asset${i} (${error.message})`);
+            }
+          }
         }
 
         return context;


### PR DESCRIPTION
Some of the scenarios that use the UtilizationConstraint are failing for `mainnet` because they're unable to source a sufficient amount of `$asset0` (in this, COMP) in order to hit the required utilization:

```
[mainnet] ... ran Comet#withdraw reverts if borrow is less than minimum borrow on 2 solutions
[mainnet] ❌ Comet#interestRate > above kink rates using hypothetical configuration constants [1 run]: Error Error: No events found within 40000 blocks for 0xc00e94Cb662C3520282E6f5717214004A7f26888
    at fetchQuery (/home/runner/work/comet/comet/plugins/scenario/utils/TokenSourcer.ts:27:11)
    at addTokens (/home/runner/work/comet/comet/plugins/scenario/utils/TokenSourcer.ts:108:43)
    at addTokens (/home/runner/work/comet/comet/plugins/scenario/utils/TokenSourcer.ts:133:11)
```
https://github.com/compound-finance/comet/actions/runs/3283268890/jobs/5407774493

This patch updates the UtilizationConstraint to attempt to source from all of a deployment's assets, not just the first:

```
UtilizatioConstraint: attempting to source from $asset0
Source Tokens: sourcing from logs... 783660982946068774118346n 0xc00e94Cb662C3520282E6f5717214004A7f26888
UtilizatioConstraint: failed to source from $asset0 (No events found within 40000 blocks for 0xc00e94Cb662C3520282E6f5717214004A7f26888)
UtilizatioConstraint: attempting to source from $asset1
Source Tokens: sourcing from logs... 197023264497n 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599
UtilizatioConstraint: successfully sourced from $asset1
[mainnet] ... ran Comet#interestRate > above kink rates using hypothetical configuration constants on 1 solution

✅ Results: 1 success, 0 errors, 189 skipped [avg time: 115001ms] [total time: 115001ms] [mainnet]
```