### PR TITLE
Mainnet WETH Bulker

### DIFF
--- a/contracts/IWstETH.sol
+++ b/contracts/IWstETH.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.15;
 
-import "../ERC20.sol";
+import "./ERC20.sol";
 
 /**
  * @dev Interface for interacting with WstETH contract

--- a/contracts/bulkers/BaseBulker.sol
+++ b/contracts/bulkers/BaseBulker.sol
@@ -17,12 +17,12 @@ contract BaseBulker {
     address payable public immutable weth;
 
     /** Actions **/
-    bytes32 public constant ACTION_SUPPLY_ASSET = 'ACTION_SUPPLY_ASSET';
-    bytes32 public constant ACTION_SUPPLY_ETH = 'ACTION_SUPPLY_ETH';
-    bytes32 public constant ACTION_TRANSFER_ASSET = 'ACTION_TRANSFER_ASSET';
-    bytes32 public constant ACTION_WITHDRAW_ASSET = 'ACTION_WITHDRAW_ASSET';
-    bytes32 public constant ACTION_WITHDRAW_ETH = 'ACTION_WITHDRAW_ETH';
-    bytes32 public constant ACTION_CLAIM_REWARD = 'ACTION_CLAIM_REWARD';
+    bytes32 public constant ACTION_SUPPLY_ASSET = "ACTION_SUPPLY_ASSET";
+    bytes32 public constant ACTION_SUPPLY_ETH = "ACTION_SUPPLY_ETH";
+    bytes32 public constant ACTION_TRANSFER_ASSET = "ACTION_TRANSFER_ASSET";
+    bytes32 public constant ACTION_WITHDRAW_ASSET = "ACTION_WITHDRAW_ASSET";
+    bytes32 public constant ACTION_WITHDRAW_ETH = "ACTION_WITHDRAW_ETH";
+    bytes32 public constant ACTION_CLAIM_REWARD = "ACTION_CLAIM_REWARD";
 
     /** Custom errors **/
     error InvalidArgument();

--- a/contracts/bulkers/IWstETH.sol
+++ b/contracts/bulkers/IWstETH.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.15;
+
+import "../ERC20.sol";
+
+/**
+ * @dev Interface for interacting with WstETH contract
+ * Note Not a comprehensive interface
+ */
+interface IWstETH is ERC20 {
+    function stETH() external returns (address);
+
+    function wrap(uint256 _stETHAmount) external returns (uint256);
+    function unwrap(uint256 _wstETHAmount) external returns (uint256);
+
+    function receive() external payable;
+
+    function getWstETHByStETH(uint256 _stETHAmount) external view returns (uint256);
+    function getStETHByWstETH(uint256 _wstETHAmount) external view returns (uint256);
+
+    function stEthPerToken() external view returns (uint256);
+    function tokensPerStEth() external view returns (uint256);
+}

--- a/contracts/bulkers/MainnetBulker.sol
+++ b/contracts/bulkers/MainnetBulker.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.15;
+
+import "./BaseBulker.sol";
+
+interface IWstETH {
+    function wrap(uint256 _stETHAmount) external returns (uint256);
+    function unwrap(uint256 _wstETHAmount) external returns (uint256);
+}
+
+contract MainnetBulker is BaseBulker {
+    address payable public immutable steth;
+    address payable public immutable wsteth;
+
+    bytes32 public constant ACTION_SUPPLY_STETH = 'ACTION_SUPPLY_STETH';
+    bytes32 public constant ACTION_WITHDRAW_STETH = 'ACTION_WITHDRAW_STETH';
+
+    constructor(
+        address admin_,
+        address payable weth_,
+        address payable steth_,
+        address payable wsteth_
+    ) BaseBulker(admin_, weth_) {
+        steth = steth_;
+        wsteth = wsteth_;
+    }
+
+    function handleAction(bytes32 action, bytes calldata data) override internal {
+        if (action == ACTION_SUPPLY_STETH) {
+            (address comet, address to, uint stETHAmount) = abi.decode(data, (address, address, uint));
+            supplyStEthTo(comet, to, stETHAmount);
+        } else {
+            revert UnhandledAction();
+        }
+    }
+
+    /**
+     * @notice
+     */
+    function supplyStEthTo(address comet, address to, uint stETHAmount) internal {
+        // transfer in from stETH
+        ERC20(steth).transferFrom(msg.sender, address(this), stETHAmount);
+        // approve stETHAmount to the wstETH contract
+        ERC20(steth).approve(wsteth, stETHAmount);
+        // wrap stETHAmount
+        uint wstETHAmount = IWstETH(wsteth).wrap(stETHAmount);
+        // approve Comet for the wstETH amount
+        ERC20(wsteth).approve(comet, wstETHAmount);
+        // supply
+        CometInterface(comet).supplyFrom(address(this), to, wsteth, wstETHAmount);
+    }
+}

--- a/contracts/bulkers/MainnetBulker.sol
+++ b/contracts/bulkers/MainnetBulker.sol
@@ -13,9 +13,9 @@ contract MainnetBulker is BaseBulker {
 
     constructor(
         address admin_,
-        address payable wrappedNativeToken_,
+        address payable weth_,
         address wsteth_
-    ) BaseBulker(admin_, wrappedNativeToken_) {
+    ) BaseBulker(admin_, weth_) {
         wsteth = wsteth_;
         steth = IWstETH(wsteth_).stETH();
     }

--- a/contracts/bulkers/MainnetBulker.sol
+++ b/contracts/bulkers/MainnetBulker.sol
@@ -13,9 +13,9 @@ contract MainnetBulker is BaseBulker {
 
     constructor(
         address admin_,
-        address payable weth_,
+        address payable wrappedNativeToken_,
         address wsteth_
-    ) BaseBulker(admin_, weth_) {
+    ) BaseBulker(admin_, wrappedNativeToken_) {
         wsteth = wsteth_;
         steth = IWstETH(wsteth_).stETH();
     }

--- a/contracts/bulkers/MainnetBulker.sol
+++ b/contracts/bulkers/MainnetBulker.sol
@@ -2,11 +2,7 @@
 pragma solidity 0.8.15;
 
 import "./BaseBulker.sol";
-
-interface IWstETH {
-    function wrap(uint256 _stETHAmount) external returns (uint256);
-    function unwrap(uint256 _wstETHAmount) external returns (uint256);
-}
+import "./IWstETH.sol";
 
 contract MainnetBulker is BaseBulker {
     address payable public immutable steth;

--- a/contracts/bulkers/MainnetBulker.sol
+++ b/contracts/bulkers/MainnetBulker.sol
@@ -5,8 +5,8 @@ import "./BaseBulker.sol";
 import "./IWstETH.sol";
 
 contract MainnetBulker is BaseBulker {
-    address payable public immutable steth;
-    address payable public immutable wsteth;
+    address public immutable steth;
+    address public immutable wsteth;
 
     bytes32 public constant ACTION_SUPPLY_STETH = "ACTION_SUPPLY_STETH";
     bytes32 public constant ACTION_WITHDRAW_STETH = "ACTION_WITHDRAW_STETH";
@@ -14,11 +14,10 @@ contract MainnetBulker is BaseBulker {
     constructor(
         address admin_,
         address payable weth_,
-        address payable steth_,
-        address payable wsteth_
+        address wsteth_
     ) BaseBulker(admin_, weth_) {
-        steth = steth_;
         wsteth = wsteth_;
+        steth = IWstETH(wsteth_).stETH();
     }
 
     function handleAction(bytes32 action, bytes calldata data) override internal {

--- a/contracts/bulkers/MainnetBulker.sol
+++ b/contracts/bulkers/MainnetBulker.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 import "./BaseBulker.sol";
-import "./IWstETH.sol";
+import "../IWstETH.sol";
 
 contract MainnetBulker is BaseBulker {
     address public immutable steth;

--- a/deployments/mainnet/weth/deploy.ts
+++ b/deployments/mainnet/weth/deploy.ts
@@ -26,7 +26,6 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
     [
       await comet.governor(),  // admin_
       await comet.baseToken(), // weth_
-      stETH.address,           // steth_
       wstETH.address           // wsteth_
     ]
   );

--- a/deployments/mainnet/weth/deploy.ts
+++ b/deployments/mainnet/weth/deploy.ts
@@ -25,7 +25,7 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
     'bulkers/MainnetBulker.sol',
     [
       await comet.governor(),  // admin_
-      await comet.baseToken(), // weth_
+      await comet.baseToken(), // wrappedNativeToken_
       wstETH.address           // wsteth_
     ]
   );

--- a/deployments/mainnet/weth/deploy.ts
+++ b/deployments/mainnet/weth/deploy.ts
@@ -1,6 +1,8 @@
 import { Deployed, DeploymentManager } from '../../../plugins/deployment_manager';
 import { DeploySpec, deployComet } from '../../../src/deploy';
-import { getConfiguration, NetworkConfiguration } from '../../../src/deploy/NetworkConfiguration';
+
+const stETH = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84';
+const wstETH = '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0';
 
 export default async function deploy(deploymentManager: DeploymentManager, deploySpec: DeploySpec): Promise<Deployed> {
   // Deploy WstETHPriceFeed
@@ -9,7 +11,7 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
     'WstETHPriceFeed.sol',
     [
       '0xcfe54b5cd566ab89272946f602d76ea879cab4a8', // stETHtoUSDPriceFeed
-      '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0'  // wstETH
+      wstETH                                        // wstETH
     ]
   );
 
@@ -20,8 +22,13 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
   // Deploy Bulker
   const bulker = await deploymentManager.deploy(
     'bulker',
-    'Bulker.sol',
-    [await comet.governor(), await comet.baseToken()]
+    'bulkers/MainnetBulker.sol',
+    [
+      await comet.governor(),  // admin_
+      await comet.baseToken(), // weth_
+      stETH,                   // steth_
+      wstETH                   // wsteth_
+    ]
   );
 
   return { ...deployed, bulker };

--- a/deployments/mainnet/weth/deploy.ts
+++ b/deployments/mainnet/weth/deploy.ts
@@ -25,7 +25,7 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
     'bulkers/MainnetBulker.sol',
     [
       await comet.governor(),  // admin_
-      await comet.baseToken(), // wrappedNativeToken_
+      await comet.baseToken(), // weth_
       wstETH.address           // wsteth_
     ]
   );

--- a/deployments/mainnet/weth/deploy.ts
+++ b/deployments/mainnet/weth/deploy.ts
@@ -1,17 +1,17 @@
 import { Deployed, DeploymentManager } from '../../../plugins/deployment_manager';
 import { DeploySpec, deployComet } from '../../../src/deploy';
 
-const stETH = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84';
-const wstETH = '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0';
-
 export default async function deploy(deploymentManager: DeploymentManager, deploySpec: DeploySpec): Promise<Deployed> {
+  const stETH = await deploymentManager.existing('stETH', '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84');
+  const wstETH = await deploymentManager.existing('wstETH', '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0');
+
   // Deploy WstETHPriceFeed
   const wstETHPriceFeed = await deploymentManager.deploy(
     'wstETH:priceFeed',
     'WstETHPriceFeed.sol',
     [
       '0xcfe54b5cd566ab89272946f602d76ea879cab4a8', // stETHtoUSDPriceFeed
-      wstETH                                        // wstETH
+      wstETH.address                                // wstETH
     ]
   );
 
@@ -26,8 +26,8 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
     [
       await comet.governor(),  // admin_
       await comet.baseToken(), // weth_
-      stETH,                   // steth_
-      wstETH                   // wsteth_
+      stETH.address,           // steth_
+      wstETH.address           // wsteth_
     ]
   );
 

--- a/deployments/mainnet/weth/relations.ts
+++ b/deployments/mainnet/weth/relations.ts
@@ -4,6 +4,7 @@ import baseRelationConfig from '../../relations';
 export default {
   ...baseRelationConfig,
   'wstETH': {
+    artifact: 'contracts/bulkers/IWstETH.sol',
     relations: {
       stETH: {
         field: async (wstETH) => wstETH.stETH()

--- a/deployments/mainnet/weth/relations.ts
+++ b/deployments/mainnet/weth/relations.ts
@@ -1,0 +1,16 @@
+import { RelationConfigMap } from '../../../plugins/deployment_manager/RelationConfig';
+import baseRelationConfig from '../../relations';
+
+export default {
+  ...baseRelationConfig,
+  'wstETH': {
+    relations: {
+      stETH: {
+        field: async (wstETH) => wstETH.stETH()
+      }
+    }
+  },
+  'AppProxyUpgradeable': {
+    artifact: 'contracts/ERC20.sol:ERC20',
+  }
+};

--- a/deployments/mumbai/usdc/deploy.ts
+++ b/deployments/mumbai/usdc/deploy.ts
@@ -112,7 +112,7 @@ async function deployContracts(deploymentManager: DeploymentManager, deploySpec:
   // Deploy Bulker
   const bulker = await deploymentManager.deploy(
     'bulker',
-    'Bulker.sol',
+    'bulkers/BaseBulker.sol',
     [localTimelock.address, WETH.address]
   );
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -19,6 +19,7 @@ import './tasks/scenario/task.ts';
 import relationConfigMap from './deployments/relations';
 import goerliRelationConfigMap from './deployments/goerli/usdc/relations';
 import mumbaiRelationConfigMap from './deployments/mumbai/usdc/relations';
+import mainnetWethRelationConfigMap from './deployments/mainnet/weth/relations';
 
 task('accounts', 'Prints the list of accounts', async (taskArgs, hre) => {
   for (const account of await hre.ethers.getSigners()) console.log(account.address);
@@ -179,6 +180,9 @@ const config: HardhatUserConfig = {
       },
       mumbai: {
         usdc: mumbaiRelationConfigMap
+      },
+      mainnet: {
+        weth: mainnetWethRelationConfigMap
       }
     },
   },

--- a/scenario/BulkerScenario.ts
+++ b/scenario/BulkerScenario.ts
@@ -119,21 +119,21 @@ scenario(
     const supplyAssetCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, albert.address, collateralAsset.address, toSupplyCollateral]);
     const withdrawAssetCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, albert.address, baseAsset.address, toBorrowBase]);
     const transferAssetCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, betty.address, baseAsset.address, toTransferBase]);
-    const supplyEthCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, albert.address, toSupplyEth]);
-    const withdrawEthCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, albert.address, toWithdrawEth]);
+    const supplyNativeTokenCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, albert.address, toSupplyEth]);
+    const withdrawNativeTokenCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, albert.address, toWithdrawEth]);
     const calldata = [
       supplyAssetCalldata,
       withdrawAssetCalldata,
       transferAssetCalldata,
-      supplyEthCalldata,
-      withdrawEthCalldata
+      supplyNativeTokenCalldata,
+      withdrawNativeTokenCalldata
     ];
     const actions = [
       await bulker.ACTION_SUPPLY_ASSET(),
       await bulker.ACTION_WITHDRAW_ASSET(),
       await bulker.ACTION_TRANSFER_ASSET(),
-      await bulker.ACTION_SUPPLY_ETH(),
-      await bulker.ACTION_WITHDRAW_ETH(),
+      await bulker.ACTION_SUPPLY_NATIVE_TOKEN(),
+      await bulker.ACTION_WITHDRAW_NATIVE_TOKEN(),
     ];
     const txn = await albert.invoke({ actions, calldata }, { value: toSupplyEth });
 
@@ -297,23 +297,23 @@ scenario(
     const supplyAssetCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, albert.address, collateralAsset.address, toSupplyCollateral]);
     const withdrawAssetCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, albert.address, baseAsset.address, toBorrowBase]);
     const transferAssetCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'address', 'uint'], [comet.address, betty.address, baseAsset.address, toTransferBase]);
-    const supplyEthCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, albert.address, toSupplyEth]);
-    const withdrawEthCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, albert.address, toWithdrawEth]);
+    const supplyNativeTokenCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, albert.address, toSupplyEth]);
+    const withdrawNativeTokenCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, albert.address, toWithdrawEth]);
     const claimRewardCalldata = utils.defaultAbiCoder.encode(['address', 'address', 'address', 'bool'], [comet.address, rewards.address, albert.address, true]);
     const calldata = [
       supplyAssetCalldata,
       withdrawAssetCalldata,
       transferAssetCalldata,
-      supplyEthCalldata,
-      withdrawEthCalldata,
+      supplyNativeTokenCalldata,
+      withdrawNativeTokenCalldata,
       claimRewardCalldata
     ];
     const actions = [
       await bulker.ACTION_SUPPLY_ASSET(),
       await bulker.ACTION_WITHDRAW_ASSET(),
       await bulker.ACTION_TRANSFER_ASSET(),
-      await bulker.ACTION_SUPPLY_ETH(),
-      await bulker.ACTION_WITHDRAW_ETH(),
+      await bulker.ACTION_SUPPLY_NATIVE_TOKEN(),
+      await bulker.ACTION_WITHDRAW_NATIVE_TOKEN(),
       await bulker.ACTION_CLAIM_REWARD(),
     ];
     const txn = await albert.invoke({ actions, calldata }, { value: toSupplyEth });

--- a/scenario/BulkerScenario.ts
+++ b/scenario/BulkerScenario.ts
@@ -1,5 +1,5 @@
 import { scenario } from './context/CometContext';
-import { constants, utils } from 'ethers';
+import { constants, ethers, utils } from 'ethers';
 import { expect } from 'chai';
 import { isRewardSupported, isBulkerSupported, getExpectedBaseBalance, matchesDeployment } from './utils';
 import { exp } from '../test/helpers';
@@ -330,5 +330,26 @@ scenario(
     expect(await albert.getErc20Balance(rewardTokenAddress)).to.be.equal(expectedFinalRewardBalance);
 
     return txn; // return txn to measure gas
+  }
+);
+
+scenario(
+  'Comet#bulker > it reverts when passed an action that does not exist',
+  {},
+  async ({ comet, actors }) => {
+    const { betty } = actors;
+
+    const supplyGalacticCreditsCalldata = utils.defaultAbiCoder.encode(
+      ['address', 'address', 'uint'],
+      [comet.address, betty.address, exp(1, 18)]
+    );
+    const calldata = [supplyGalacticCreditsCalldata];
+    const actions = [
+      ethers.utils.formatBytes32String('ACTION_SUPPLY_GALACTIC_CREDITS')
+    ];
+
+    await expect(
+      betty.invoke({ actions, calldata })
+    ).to.be.revertedWith("custom error 'UnhandledAction()'");
   }
 );

--- a/scenario/BulkerScenario.ts
+++ b/scenario/BulkerScenario.ts
@@ -1,5 +1,5 @@
 import { scenario } from './context/CometContext';
-import { constants, ethers, utils } from 'ethers';
+import { constants, utils } from 'ethers';
 import { expect } from 'chai';
 import { isRewardSupported, isBulkerSupported, getExpectedBaseBalance, matchesDeployment } from './utils';
 import { exp } from '../test/helpers';
@@ -330,26 +330,5 @@ scenario(
     expect(await albert.getErc20Balance(rewardTokenAddress)).to.be.equal(expectedFinalRewardBalance);
 
     return txn; // return txn to measure gas
-  }
-);
-
-scenario(
-  'Comet#bulker > it reverts when passed an action that does not exist',
-  {},
-  async ({ comet, actors }) => {
-    const { betty } = actors;
-
-    const supplyGalacticCreditsCalldata = utils.defaultAbiCoder.encode(
-      ['address', 'address', 'uint'],
-      [comet.address, betty.address, exp(1, 18)]
-    );
-    const calldata = [supplyGalacticCreditsCalldata];
-    const actions = [
-      ethers.utils.formatBytes32String('ACTION_SUPPLY_GALACTIC_CREDITS')
-    ];
-
-    await expect(
-      betty.invoke({ actions, calldata })
-    ).to.be.revertedWith("custom error 'UnhandledAction()'");
   }
 );

--- a/scenario/BulkerScenario.ts
+++ b/scenario/BulkerScenario.ts
@@ -7,7 +7,7 @@ import { exp } from '../test/helpers';
 scenario(
   'Comet#bulker > (non-WETH base) all non-reward actions in one txn',
   {
-    filter: async (ctx) => await isBulkerSupported(ctx) && !matchesDeployment(ctx, [{deployment: 'weth'}]),
+    filter: async (ctx) => await isBulkerSupported(ctx) && !matchesDeployment(ctx, [{deployment: 'weth'}, {network: 'mumbai'}]),
     tokenBalances: {
       albert: { $base: '== 0', $asset0: 3000 },
       $comet: { $base: 5000 },

--- a/scenario/MainnetBulkerScenario.ts
+++ b/scenario/MainnetBulkerScenario.ts
@@ -1,0 +1,49 @@
+import { utils } from 'ethers';
+import { expect } from 'chai';
+import { scenario } from './context/CometContext';
+import CometAsset from './context/CometAsset';
+import { ERC20 } from '../build/types';
+import { exp } from '../test/helpers';
+import { isBulkerSupported, matchesDeployment } from './utils';
+
+scenario.only(
+  'MainnetBulker > wraps stETH before supplying',
+  {
+    filter: async (ctx) => await isBulkerSupported(ctx) && matchesDeployment(ctx, [{deployment: 'weth'}]),
+    tokenBalances: {
+      albert: { $asset1: '== 0' },
+    },
+  },
+  async ({ comet, actors, assets, bulker }, context) => {
+    const { albert } = actors;
+    const { wstETH } = assets;
+
+    const toSupplyStEth = exp(.1, 18);
+
+    const stETH = await context.world.deploymentManager.contract('stETH') as ERC20;
+    const stETHAsset = new CometAsset(stETH);
+    // source some stETH for albert
+    await context.sourceTokens(toSupplyStEth, stETHAsset, albert);
+
+    expect(await stETH.balanceOf(albert.address)).to.be.approximately(toSupplyStEth, 1);
+
+    // approve bulker as albert
+    await stETHAsset.approve(albert, bulker.address, toSupplyStEth);
+
+    const supplyStEthCalldata = utils.defaultAbiCoder.encode(
+      ['address', 'address', 'uint'],
+      [comet.address, albert.address, toSupplyStEth]
+    );
+    const calldata = [supplyStEthCalldata];
+    const actions = [await bulker.ACTION_SUPPLY_STETH()];
+
+    const txn = await albert.invoke({ actions, calldata });
+
+    expect(await wstETH.balanceOf(albert.address)).to.be.equal(0n);
+    // XXX pretty weak exepectation
+    expect(await comet.collateralBalanceOf(albert.address, wstETH.address)).to.be.within(
+      0,
+      toSupplyStEth
+    );
+  }
+);

--- a/scenario/MainnetBulkerScenario.ts
+++ b/scenario/MainnetBulkerScenario.ts
@@ -41,7 +41,7 @@ scenario(
 
     const txn = await albert.invoke({ actions, calldata });
 
-    expect(await wstETH.balanceOf(albert.address)).to.be.equal(0n);
+    expect(await stETH.balanceOf(albert.address)).to.be.equal(0n);
     expectApproximately(
       await comet.collateralBalanceOf(albert.address, wstETH.address),
       await wstETH.getWstETHByStETH(toSupplyStEth),

--- a/scenario/MainnetBulkerScenario.ts
+++ b/scenario/MainnetBulkerScenario.ts
@@ -2,11 +2,14 @@ import { utils } from 'ethers';
 import { expect } from 'chai';
 import { scenario } from './context/CometContext';
 import CometAsset from './context/CometAsset';
-import { ERC20 } from '../build/types';
+import {
+  ERC20,
+  IWstETH
+} from '../build/types';
 import { exp } from '../test/helpers';
-import { isBulkerSupported, matchesDeployment } from './utils';
+import { expectApproximately, isBulkerSupported, matchesDeployment } from './utils';
 
-scenario.only(
+scenario(
   'MainnetBulker > wraps stETH before supplying',
   {
     filter: async (ctx) => await isBulkerSupported(ctx) && matchesDeployment(ctx, [{deployment: 'weth'}]),
@@ -40,10 +43,52 @@ scenario.only(
     const txn = await albert.invoke({ actions, calldata });
 
     expect(await wstETH.balanceOf(albert.address)).to.be.equal(0n);
-    // XXX pretty weak exepectation
+    // XXX pretty weak expectation
     expect(await comet.collateralBalanceOf(albert.address, wstETH.address)).to.be.within(
       0,
       toSupplyStEth
     );
+  }
+);
+
+scenario(
+  'MainnetBulker > wraps wstETH before withdrawing',
+  {
+    filter: async (ctx) => await isBulkerSupported(ctx) && matchesDeployment(ctx, [{deployment: 'weth'}]),
+    tokenBalances: {
+      albert: { $asset1: 2 },
+      $comet: { $asset1: 5 },
+    },
+  },
+  async ({ comet, actors, assets, bulker }, context) => {
+    const { albert } = actors;
+
+    const stETH = await context.world.deploymentManager.contract('stETH') as ERC20;
+    const wstETH = await context.world.deploymentManager.contract('wstETH') as IWstETH;
+
+    const toWithdrawStEth = exp(1, 18);
+
+    // approvals/allowances
+    await albert.allow(bulker.address, true);
+    await wstETH.connect(albert.signer).approve(comet.address, toWithdrawStEth);
+
+    // supply wstETH
+    await albert.supplyAsset({asset: wstETH.address, amount: toWithdrawStEth });
+
+    const withdrawStEthCalldata = utils.defaultAbiCoder.encode(
+      ['address', 'address', 'uint'],
+      [comet.address, albert.address, toWithdrawStEth]
+    );
+    const calldata = [withdrawStEthCalldata];
+    const actions = [await bulker.ACTION_WITHDRAW_STETH()];
+
+    const txn = await albert.invoke({ actions, calldata });
+
+    expectApproximately(
+      await stETH.balanceOf(albert.address),
+      await wstETH.getStETHByWstETH(toWithdrawStEth),
+      1n
+    );
+    expect(await comet.collateralBalanceOf(albert.address, wstETH.address)).to.equal(0);
   }
 );

--- a/scenario/MainnetBulkerScenario.ts
+++ b/scenario/MainnetBulkerScenario.ts
@@ -1,4 +1,4 @@
-import { utils } from 'ethers';
+import { ethers, utils } from 'ethers';
 import { expect } from 'chai';
 import { scenario } from './context/CometContext';
 import CometAsset from './context/CometAsset';
@@ -89,5 +89,28 @@ scenario(
       1n
     );
     expect(await comet.collateralBalanceOf(albert.address, wstETH.address)).to.equal(0);
+  }
+);
+
+scenario(
+  'MainnetBulker > it reverts when passed an action that does not exist',
+  {
+    filter: async (ctx) => await isBulkerSupported(ctx) && matchesDeployment(ctx, [{network: 'mainnet', deployment: 'weth'}]),
+  },
+  async ({ comet, actors }) => {
+    const { betty } = actors;
+
+    const supplyGalacticCreditsCalldata = utils.defaultAbiCoder.encode(
+      ['address', 'address', 'uint'],
+      [comet.address, betty.address, exp(1, 18)]
+    );
+    const calldata = [supplyGalacticCreditsCalldata];
+    const actions = [
+      ethers.utils.formatBytes32String('ACTION_SUPPLY_GALACTIC_CREDITS')
+    ];
+
+    await expect(
+      betty.invoke({ actions, calldata })
+    ).to.be.revertedWith("custom error 'UnhandledAction()'");
   }
 );

--- a/scenario/MainnetBulkerScenario.ts
+++ b/scenario/MainnetBulkerScenario.ts
@@ -17,7 +17,7 @@ scenario(
       albert: { $asset1: '== 0' },
     },
   },
-  async ({ comet, actors, assets, bulker }, context) => {
+  async ({ comet, actors, bulker }, context) => {
     const { albert } = actors;
 
     const stETH = await context.world.deploymentManager.contract('stETH') as ERC20;
@@ -39,7 +39,7 @@ scenario(
     const calldata = [supplyStEthCalldata];
     const actions = [await bulker.ACTION_SUPPLY_STETH()];
 
-    const txn = await albert.invoke({ actions, calldata });
+    await albert.invoke({ actions, calldata });
 
     expect(await stETH.balanceOf(albert.address)).to.be.equal(0n);
     expectApproximately(
@@ -59,7 +59,7 @@ scenario(
       $comet: { $asset1: 5 },
     },
   },
-  async ({ comet, actors, assets, bulker }, context) => {
+  async ({ comet, actors, bulker }, context) => {
     const { albert } = actors;
 
     const stETH = await context.world.deploymentManager.contract('stETH') as ERC20;
@@ -81,7 +81,7 @@ scenario(
     const calldata = [withdrawStEthCalldata];
     const actions = [await bulker.ACTION_WITHDRAW_STETH()];
 
-    const txn = await albert.invoke({ actions, calldata });
+    await albert.invoke({ actions, calldata });
 
     expectApproximately(
       await stETH.balanceOf(albert.address),

--- a/test/bulker-test.ts
+++ b/test/bulker-test.ts
@@ -68,7 +68,7 @@ describe('bulker', function () {
     expect(await comet.collateralBalanceOf(bob.address, COMP.address)).to.be.equal(supplyAmount);
   });
 
-  it('supply ETH', async () => {
+  it('supply native token', async () => {
     const protocol = await makeProtocol({
       assets: defaultAssets({}, {
         WETH: { factory: await ethers.getContractFactory('FaucetWETH') as FaucetWETH__factory }
@@ -82,13 +82,13 @@ describe('bulker', function () {
 
     // Alice supplies 10 ETH through the bulker
     const supplyAmount = exp(10, 18);
-    const supplyEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, supplyAmount]);
-    await bulker.connect(alice).invoke([await bulker.ACTION_SUPPLY_ETH()], [supplyEthCalldata], { value: supplyAmount });
+    const supplyNativeTokenCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, supplyAmount]);
+    await bulker.connect(alice).invoke([await bulker.ACTION_SUPPLY_NATIVE_TOKEN()], [supplyNativeTokenCalldata], { value: supplyAmount });
 
     expect(await comet.collateralBalanceOf(alice.address, WETH.address)).to.be.equal(supplyAmount);
   });
 
-  it('supply ETH refunds unused ETH', async () => {
+  it('supply native token refunds unused native token', async () => {
     const protocol = await makeProtocol({
       assets: defaultAssets({}, {
         WETH: { factory: await ethers.getContractFactory('FaucetWETH') as FaucetWETH__factory }
@@ -103,15 +103,15 @@ describe('bulker', function () {
     // Alice supplies 10 ETH through the bulker but actually sends 20 ETH
     const aliceBalanceBefore = await alice.getBalance();
     const supplyAmount = exp(10, 18);
-    const supplyEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, supplyAmount]);
-    const txn = await wait(bulker.connect(alice).invoke([await bulker.ACTION_SUPPLY_ETH()], [supplyEthCalldata], { value: supplyAmount * 2n }));
+    const supplyNativeTokenCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, supplyAmount]);
+    const txn = await wait(bulker.connect(alice).invoke([await bulker.ACTION_SUPPLY_NATIVE_TOKEN()], [supplyNativeTokenCalldata], { value: supplyAmount * 2n }));
     const aliceBalanceAfter = await alice.getBalance();
 
     expect(await comet.collateralBalanceOf(alice.address, WETH.address)).to.be.equal(supplyAmount);
     expect(aliceBalanceBefore.sub(aliceBalanceAfter)).to.be.equal(supplyAmount + getGasUsed(txn));
   });
 
-  it('supply ETH with insufficient ETH', async () => {
+  it('supply native token with insufficient native token', async () => {
     const protocol = await makeProtocol({
       assets: defaultAssets({}, {
         WETH: { factory: await ethers.getContractFactory('FaucetWETH') as FaucetWETH__factory }
@@ -125,8 +125,8 @@ describe('bulker', function () {
 
     // Alice supplies 10 ETH through the bulker but only sends 5 ETH
     const supplyAmount = exp(10, 18);
-    const supplyEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, supplyAmount]);
-    await expect(bulker.connect(alice).invoke([await bulker.ACTION_SUPPLY_ETH()], [supplyEthCalldata], { value: supplyAmount / 2n }))
+    const supplyNativeTokenCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, supplyAmount]);
+    await expect(bulker.connect(alice).invoke([await bulker.ACTION_SUPPLY_NATIVE_TOKEN()], [supplyNativeTokenCalldata], { value: supplyAmount / 2n }))
       .to.be.revertedWith('code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)');
   });
 
@@ -249,7 +249,7 @@ describe('bulker', function () {
     expect(await COMP.balanceOf(bob.address)).to.be.equal(withdrawAmount);
   });
 
-  it('withdraw ETH', async () => {
+  it('withdraw native token', async () => {
     const protocol = await makeProtocol({
       assets: defaultAssets({}, {
         WETH: { factory: await ethers.getContractFactory('FaucetWETH') as FaucetWETH__factory }
@@ -274,8 +274,8 @@ describe('bulker', function () {
 
     // Alice supplies 10 ETH through the bulker
     const aliceBalanceBefore = await alice.getBalance();
-    const withdrawEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, withdrawAmount]);
-    const txn = await wait(bulker.connect(alice).invoke([await bulker.ACTION_WITHDRAW_ETH()], [withdrawEthCalldata]));
+    const withdrawNativeTokenCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, withdrawAmount]);
+    const txn = await wait(bulker.connect(alice).invoke([await bulker.ACTION_WITHDRAW_NATIVE_TOKEN()], [withdrawNativeTokenCalldata]));
     const aliceBalanceAfter = await alice.getBalance();
 
     expect(await comet.collateralBalanceOf(alice.address, WETH.address)).to.be.equal(0);
@@ -348,7 +348,7 @@ describe('bulker', function () {
       .to.be.reverted; // Should revert with "custom error 'Unauthorized()'"
   });
 
-  it('reverts on withdraw ETH if no permission granted to bulker', async () => {
+  it('reverts on withdraw native token if no permission granted to bulker', async () => {
     const protocol = await makeProtocol({
       assets: defaultAssets({}, {
         WETH: { factory: await ethers.getContractFactory('FaucetWETH') as FaucetWETH__factory }
@@ -358,8 +358,8 @@ describe('bulker', function () {
     const bulkerInfo = await makeBulker({ weth: WETH.address });
     const { bulker } = bulkerInfo;
 
-    const withdrawEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, 1]);
-    await expect(bulker.connect(alice).invoke([await bulker.ACTION_WITHDRAW_ETH()], [withdrawEthCalldata]))
+    const withdrawNativeTokenCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, 1]);
+    await expect(bulker.connect(alice).invoke([await bulker.ACTION_WITHDRAW_NATIVE_TOKEN()], [withdrawNativeTokenCalldata]))
       .to.be.reverted; // Should revert with "custom error 'Unauthorized()'"
   });
 
@@ -388,7 +388,7 @@ describe('bulker', function () {
       expect(newGovBalance.sub(oldGovBalance)).to.be.equal(transferAmount);
     });
 
-    it('sweep ETH', async () => {
+    it('sweep native token', async () => {
       const protocol = await makeProtocol({});
       const { governor, tokens: { WETH }, users: [alice] } = protocol;
       const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
@@ -402,7 +402,7 @@ describe('bulker', function () {
       const oldGovBalance = await ethers.provider.getBalance(governor.address);
 
       // Governor sweeps ETH
-      const txn = await wait(bulker.connect(governor).sweepEth(governor.address));
+      const txn = await wait(bulker.connect(governor).sweepNativeToken(governor.address));
 
       const newBulkerBalance = await ethers.provider.getBalance(bulker.address);
       const newGovBalance = await ethers.provider.getBalance(governor.address);
@@ -422,14 +422,14 @@ describe('bulker', function () {
         .to.be.revertedWith("custom error 'Unauthorized()'");
     });
 
-    it('reverts if sweepEth is called by non-admin', async () => {
+    it('reverts if sweepNativeToken is called by non-admin', async () => {
       const protocol = await makeProtocol({});
       const { governor, tokens: { WETH }, users: [alice] } = protocol;
       const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
       const { bulker } = bulkerInfo;
 
       // Alice sweeps ETH
-      await expect(bulker.connect(alice).sweepEth(governor.address))
+      await expect(bulker.connect(alice).sweepNativeToken(governor.address))
         .to.be.revertedWith("custom error 'Unauthorized()'");
     });
   });
@@ -472,7 +472,7 @@ describe('bulker multiple actions', function () {
     expect(await USDC.balanceOf(alice.address)).to.be.equal(borrowAmount);
   });
 
-  it('supply ETH to multiple accounts', async () => {
+  it('supply native token to multiple accounts', async () => {
     const protocol = await makeProtocol({
       assets: defaultAssets({}, {
         WETH: { factory: await ethers.getContractFactory('FaucetWETH') as FaucetWETH__factory }
@@ -489,7 +489,7 @@ describe('bulker multiple actions', function () {
     const supplyAliceEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, alice.address, supplyAmount / 2n]);
     const supplyBobEthCalldata = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint'], [comet.address, bob.address, supplyAmount / 2n]);
     await bulker.connect(alice).invoke(
-      [await bulker.ACTION_SUPPLY_ETH(), await bulker.ACTION_SUPPLY_ETH()],
+      [await bulker.ACTION_SUPPLY_NATIVE_TOKEN(), await bulker.ACTION_SUPPLY_NATIVE_TOKEN()],
       [supplyAliceEthCalldata, supplyBobEthCalldata],
       { value: supplyAmount }
     );

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -4,8 +4,8 @@ import { expect } from 'chai';
 import { Block } from '@ethersproject/abstract-provider';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import {
-  Bulker,
-  Bulker__factory,
+  BaseBulker,
+  BaseBulker__factory,
   CometExt,
   CometExt__factory,
   CometHarness__factory,
@@ -130,7 +130,7 @@ export type BulkerOpts = {
 
 export type BulkerInfo = {
   opts: BulkerOpts;
-  bulker: Bulker;
+  bulker: BaseBulker;
 };
 
 export function dfn<T>(x: T | undefined | null, dflt: T): T {
@@ -493,7 +493,7 @@ export async function makeBulker(opts: BulkerOpts): Promise<BulkerInfo> {
   const admin = opts.admin || signers[0];
   const weth = opts.weth;
 
-  const BulkerFactory = (await ethers.getContractFactory('Bulker')) as Bulker__factory;
+  const BulkerFactory = (await ethers.getContractFactory('BaseBulker')) as BaseBulker__factory;
   const bulker = await BulkerFactory.deploy(admin.address, weth);
   await bulker.deployed();
 


### PR DESCRIPTION
Creating a new Bulker that is able to wrap/unwrap `stETH`.

Includes the following changes:

- moves the Bulker into a `bulkers/` subdirectory, renaming it to `BaseBulker`
- creates a new `MainnetBulker` that inherits from `BaseBulker` and adds `supplyStEthTo` and `withdrawStEthTo` functions
- converts the bulker action constants to strings/bytes32 to decrease the likelihood that bulkers will create actions with conflicting values
- adds a `handleAction` function that contracts inheriting from `BaseBulker` can implement; by default it just reverts
- scenarios for wrapping and unwrapping via the `MainnetBulker`

TODO:
- [x] fix unit tests
- [x] add scenario for BaseBulker that checks the UnhandledAction() error