### PR TITLE
Impersonate flag for migrate task

### DIFF
--- a/plugins/scenario/World.ts
+++ b/plugins/scenario/World.ts
@@ -84,11 +84,7 @@ export class World {
   }
 
   async impersonateAddress(address: string, value?: bigint): Promise<SignerWithAddress> {
-    if (value) {
-      const signer = await this.deploymentManager.getSigner();
-      await signer.sendTransaction({ to: address, value });
-    }
-    return await impersonateAddress(this.deploymentManager, address);
+    return impersonateAddress(this.deploymentManager, address, value);
   }
 
   async timestamp() {

--- a/plugins/scenario/utils/index.ts
+++ b/plugins/scenario/utils/index.ts
@@ -1,7 +1,11 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { DeploymentManager } from '../../../plugins/deployment_manager';
 
-export async function impersonateAddress(dm: DeploymentManager, address: string): Promise<SignerWithAddress> {
+export async function impersonateAddress(dm: DeploymentManager, address: string, value?: bigint): Promise<SignerWithAddress> {
+  if (value) {
+    const signer = await dm.getSigner();
+    await signer.sendTransaction({ to: address, value });
+  }
   await dm.hre.network.provider.request({
     method: 'hardhat_impersonateAccount',
     params: [address],

--- a/tasks/deployment_manager/task.ts
+++ b/tasks/deployment_manager/task.ts
@@ -207,7 +207,7 @@ task('migrate', 'Runs migration')
       if (impersonate && !simulate) {
         throw new Error('Cannot impersonate an address if not simulating a migration. Please specify --simulate to simulate.');
       } else if (impersonate && simulate) {
-        const signer = await impersonateAddress(governanceDm, impersonate);
+        const signer = await impersonateAddress(governanceDm, impersonate, 10n ** 18n);
         governanceDm._signers.unshift(signer);
       }
 

--- a/tasks/deployment_manager/task.ts
+++ b/tasks/deployment_manager/task.ts
@@ -208,7 +208,7 @@ task('migrate', 'Runs migration')
         throw new Error('Cannot impersonate an address if not simulating a migration. Please specify --simulate to simulate.');
       } else if (impersonate && simulate) {
         const signer = await impersonateAddress(governanceDm, impersonate);
-        governanceDm._signers[0] = signer;
+        governanceDm._signers.unshift(signer);
       }
 
       const migrationPath = `${__dirname}/../../deployments/${network}/${deployment}/migrations/${migrationName}.ts`;


### PR DESCRIPTION
Add an impersonate flag for migration simulations so developers can test their new migration script.