### PR TITLE
Look for BuyCollateral opportunities even if no accounts are absorbable

### DIFF
--- a/scripts/liquidation_bot/index.ts
+++ b/scripts/liquidation_bot/index.ts
@@ -12,7 +12,7 @@ import {
 } from './liquidateUnderwaterBorrowers';
 
 const loopDelay = 5000;
-const updateAssetsDelay = 86_400_000; // 1 day
+const loopsUntilUpdateAssets = 1000;
 let assets: Asset[] = [];
 
 async function main() {
@@ -52,13 +52,12 @@ async function main() {
   ) as Liquidator;
 
   let lastBlockNumber: number;
-  let loopsUntilUpdateAssets = updateAssetsDelay / loopDelay;
+  let loops = 0;
   while (true) {
-    loopsUntilUpdateAssets -= 1;
-    if (loopsUntilUpdateAssets <= 0) {
+    if (loops >= loopsUntilUpdateAssets) {
       console.log('Updating assets');
       assets = await getAssets(comet);
-      loopsUntilUpdateAssets = updateAssetsDelay / loopDelay;
+      loops = 0;
     }
 
     const currentBlockNumber = await hre.ethers.provider.getBlockNumber();
@@ -84,6 +83,8 @@ async function main() {
       console.log(`block already checked; waiting ${loopDelay}ms`);
       await new Promise(resolve => setTimeout(resolve, loopDelay));
     }
+
+    loops += 1;
   }
 }
 

--- a/scripts/liquidation_bot/index.ts
+++ b/scripts/liquidation_bot/index.ts
@@ -7,12 +7,13 @@ import {
 import {
   arbitragePurchaseableCollateral,
   liquidateUnderwaterBorrowers,
-  getAssetAddresses
+  getAssets,
+  Asset
 } from './liquidateUnderwaterBorrowers';
 
 const loopDelay = 5000;
 const updateAssetsDelay = 86_400_000; // 1 day
-let assetAddresses: string[] = [];
+let assets: Asset[] = [];
 
 async function main() {
   let { DEPLOYMENT: deployment, LIQUIDATOR_ADDRESS: liquidatorAddress } = process.env;
@@ -56,7 +57,7 @@ async function main() {
     loopsUntilUpdateAssets -= 1;
     if (loopsUntilUpdateAssets <= 0) {
       console.log('Updating asset addresses');
-      assetAddresses = await getAssetAddresses(comet);
+      assets = await getAssets(comet);
       loopsUntilUpdateAssets = updateAssetsDelay / loopDelay;
     }
 
@@ -76,7 +77,7 @@ async function main() {
           comet,
           liquidator,
           signer,
-          assetAddresses
+          assets
         );
       }
     } else {

--- a/scripts/liquidation_bot/index.ts
+++ b/scripts/liquidation_bot/index.ts
@@ -4,7 +4,10 @@ import {
   CometInterface,
   Liquidator
 } from '../../build/types';
-import liquidateUnderwaterBorrowers from './liquidateUnderwaterBorrowers';
+import {
+  arbitragePurchaseableCollateral,
+  liquidateUnderwaterBorrowers
+} from './liquidateUnderwaterBorrowers';
 
 const loopDelay = 5000;
 
@@ -53,11 +56,18 @@ async function main() {
 
     if (currentBlockNumber !== lastBlockNumber) {
       lastBlockNumber = currentBlockNumber;
-      await liquidateUnderwaterBorrowers(
+      const liquidationAttempted = await liquidateUnderwaterBorrowers(
         comet,
         liquidator,
         signer
       );
+      if (!liquidationAttempted) {
+        await arbitragePurchaseableCollateral(
+          comet,
+          liquidator,
+          signer
+        );
+      }
     } else {
       console.log(`block already checked; waiting ${loopDelay}ms`);
       await new Promise(resolve => setTimeout(resolve, loopDelay));

--- a/scripts/liquidation_bot/index.ts
+++ b/scripts/liquidation_bot/index.ts
@@ -56,7 +56,7 @@ async function main() {
   while (true) {
     loopsUntilUpdateAssets -= 1;
     if (loopsUntilUpdateAssets <= 0) {
-      console.log('Updating asset addresses');
+      console.log('Updating assets');
       assets = await getAssets(comet);
       loopsUntilUpdateAssets = updateAssetsDelay / loopDelay;
     }

--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -103,7 +103,7 @@ export async function getAssets(comet: CometInterface): Promise<Asset[]> {
   let assets = [
     ...await Promise.all(Array(numAssets).fill(0).map(async (_, i) => {
       const asset = await comet.getAssetInfo(i);
-      return { address: asset.asset, priceFeed: asset.priceFeed, scale: asset.scale.toBigInt() }
+      return { address: asset.asset, priceFeed: asset.priceFeed, scale: asset.scale.toBigInt() };
     })),
   ];
   return assets;

--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -3,6 +3,13 @@ import {
   CometInterface,
   Liquidator
 } from '../../build/types';
+import {exp} from '../../test/helpers';
+
+export interface Asset {
+  address: string;
+  priceFeed: string;
+  scale: bigint;
+}
 
 const daiPool = {
   tokenAddress: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
@@ -32,11 +39,14 @@ async function getUniqueAddresses(comet: CometInterface): Promise<Set<string>> {
   return new Set(withdrawEvents.map(event => event.args.src));
 }
 
-async function hasPurchaseableCollateral(comet: CometInterface, assetAddresses: string[]): Promise<boolean> {
-  // XXX filter out small amounts
-  // XXX refresh cache every day
-  for (let asset in assetAddresses) {
-    if ((await comet.getCollateralReserves(asset)).gt(0)) {
+export async function hasPurchaseableCollateral(comet: CometInterface, assets: Asset[], minUsdValue: number = 100): Promise<boolean> {
+  let totalValue = 0n;
+  const minValue = exp(minUsdValue, 8);
+  for (const asset of assets) {
+    const collateralReserves = await comet.getCollateralReserves(asset.address);
+    const price = await comet.getPrice(asset.priceFeed);
+    totalValue += collateralReserves.toBigInt() * price.toBigInt() / asset.scale;
+    if (totalValue >= minValue) {
       return true;
     }
   }
@@ -74,11 +84,11 @@ export async function arbitragePurchaseableCollateral(
   comet: CometInterface,
   liquidator: Liquidator,
   signer: SignerWithAddress,
-  assetAddresses: string[]
+  assets: Asset[]
 ) {
   console.log(`Checking for purchaseable collateral`);
 
-  if (await hasPurchaseableCollateral(comet, assetAddresses)) {
+  if (await hasPurchaseableCollateral(comet, assets)) {
     console.log(`There is purchaseable collateral`);
     await attemptLiquidation(
       liquidator,
@@ -88,11 +98,12 @@ export async function arbitragePurchaseableCollateral(
   }
 }
 
-export async function getAssetAddresses(comet: CometInterface): Promise<string[]> {
+export async function getAssets(comet: CometInterface): Promise<Asset[]> {
   let numAssets = await comet.numAssets();
   let assets = [
     ...await Promise.all(Array(numAssets).fill(0).map(async (_, i) => {
-      return (await comet.getAssetInfo(i)).asset;
+      const asset = await comet.getAssetInfo(i);
+      return { address: asset.asset, priceFeed: asset.priceFeed, scale: asset.scale.toBigInt() }
     })),
   ];
   return assets;

--- a/test/liquidation/liquidation-bot-script.ts
+++ b/test/liquidation/liquidation-bot-script.ts
@@ -1,8 +1,8 @@
 import { expect, exp } from '../helpers';
-import liquidateUnderwaterBorrowers from '../../scripts/liquidation_bot/liquidateUnderwaterBorrowers';
-import makeLiquidatableProtocol, { forkMainnet, resetHardhatNetwork } from './makeLiquidatableProtocol';
+import { arbitragePurchaseableCollateral, getAssets, hasPurchaseableCollateral, liquidateUnderwaterBorrowers } from '../../scripts/liquidation_bot/liquidateUnderwaterBorrowers';
+import { forkMainnet, makeProtocol, makeLiquidatableProtocol, resetHardhatNetwork } from './makeLiquidatableProtocol';
 
-describe('Liquidation Bot', function () {
+describe.only('Liquidation Bot', function () {
   before(forkMainnet);
   after(resetHardhatNetwork);
 
@@ -12,7 +12,7 @@ describe('Liquidation Bot', function () {
         comet,
         liquidator,
         users: [signer, underwater],
-        assets: { dai, usdc  },
+        assets: { dai, usdc },
         whales: { usdcWhale }
       } = await makeLiquidatableProtocol();
 
@@ -34,6 +34,89 @@ describe('Liquidation Bot', function () {
       );
 
       expect(await comet.isLiquidatable(underwater.address)).to.be.false;
+
+      const assetAddresses = await getAssets(comet);
+      expect(await hasPurchaseableCollateral(comet, assetAddresses, 1)).to.be.false;
+    });
+  });
+
+  describe('arbitragePurchaseableCollateral', function () {
+    it('buys collateral when available', async function () {
+      const {
+        comet,
+        liquidator,
+        users: [signer],
+        assets: { weth },
+        whales: { wethWhale }
+      } = await makeProtocol();
+      const assetAddresses = await getAssets(comet);
+
+      expect(await hasPurchaseableCollateral(comet, assetAddresses)).to.be.false;
+
+      // Transfer WETH to comet, so it has purchaseable collateral
+      await weth.connect(wethWhale).transfer(comet.address, 100000000000000000000n); // 100e18
+
+      expect(await hasPurchaseableCollateral(comet, assetAddresses, 0)).to.be.true;
+
+      await arbitragePurchaseableCollateral(
+        comet,
+        liquidator,
+        signer,
+        assetAddresses
+      );
+
+      // There will be some dust to purchase, but we expect it to be less than $1 of worth
+      expect(await hasPurchaseableCollateral(comet, assetAddresses, 1)).to.be.false;
+    });
+
+    it('buys all collateral when available', async function () {
+      const {
+        comet,
+        liquidator,
+        users: [signer],
+        assets: { weth, wbtc, comp, uni, link },
+        whales: { wethWhale, wbtcWhale, compWhale, uniWhale, linkWhale }
+      } = await makeProtocol();
+      const assetAddresses = await getAssets(comet);
+
+      expect(await hasPurchaseableCollateral(comet, assetAddresses)).to.be.false;
+
+      await weth.connect(wethWhale).transfer(comet.address, 100000000000000000000n); // 100e18
+      await wbtc.connect(wbtcWhale).transfer(comet.address, 100000000n); // 1e8
+      await comp.connect(compWhale).transfer(comet.address, 50000000000000000000n); // 50e18
+      await uni.connect(uniWhale).transfer(comet.address, 1000000000000000000000n); // 1000e18
+      await link.connect(linkWhale).transfer(comet.address, 5000000000000000000n); // 5e18
+
+      expect(await hasPurchaseableCollateral(comet, assetAddresses, 0)).to.be.true;
+
+      await arbitragePurchaseableCollateral(
+        comet,
+        liquidator,
+        signer,
+        assetAddresses
+      );
+
+      // There will be some dust to purchase, but we expect it to be less than $1 of worth
+      expect(await hasPurchaseableCollateral(comet, assetAddresses, 1)).to.be.false;
+    });
+
+    it('hasPurchaseableCollateral ignores dust collateral', async function () {
+      const {
+        comet,
+        assets: { weth },
+        whales: { wethWhale }
+      } = await makeProtocol();
+      const assetAddresses = await getAssets(comet);
+
+      expect(await hasPurchaseableCollateral(comet, assetAddresses)).to.be.false;
+
+      // Transfer dust amount of WETH to comet, so it has purchaseable collateral
+      await weth.connect(wethWhale).transfer(comet.address, 1000n);
+
+      // Expect non-zero collateral
+      expect(await hasPurchaseableCollateral(comet, assetAddresses, 0)).to.be.true;
+      // There will be some dust to purchase, but we expect it to be less than $1 of worth
+      expect(await hasPurchaseableCollateral(comet, assetAddresses, 1)).to.be.false;
     });
   });
 });

--- a/test/liquidation/liquidation-bot-script.ts
+++ b/test/liquidation/liquidation-bot-script.ts
@@ -2,7 +2,7 @@ import { expect, exp } from '../helpers';
 import { arbitragePurchaseableCollateral, getAssets, hasPurchaseableCollateral, liquidateUnderwaterBorrowers } from '../../scripts/liquidation_bot/liquidateUnderwaterBorrowers';
 import { forkMainnet, makeProtocol, makeLiquidatableProtocol, resetHardhatNetwork } from './makeLiquidatableProtocol';
 
-describe.only('Liquidation Bot', function () {
+describe('Liquidation Bot', function () {
   before(forkMainnet);
   after(resetHardhatNetwork);
 

--- a/test/liquidation/liquidation-bot-test.ts
+++ b/test/liquidation/liquidation-bot-test.ts
@@ -1,6 +1,6 @@
 import { event, expect, exp, wait } from '../helpers';
 import { ethers } from 'hardhat';
-import makeLiquidatableProtocol, { forkMainnet, resetHardhatNetwork } from './makeLiquidatableProtocol';
+import { forkMainnet, makeLiquidatableProtocol, resetHardhatNetwork } from './makeLiquidatableProtocol';
 import { DAI } from './addresses';
 import { SWAP_ROUTER } from './addresses';
 

--- a/test/liquidation/makeLiquidatableProtocol.ts
+++ b/test/liquidation/makeLiquidatableProtocol.ts
@@ -132,7 +132,7 @@ export async function makeProtocol() {
   await comet.deployed();
   const cometHarnessInterface = await ethers.getContractAt('CometHarnessInterface', comet.address) as CometHarnessInterface;
 
-  const [signer, underwaterUser_, recipient] = await ethers.getSigners();
+  const [signer,, recipient] = await ethers.getSigners();
 
   // build Liquidator
   const Liquidator = await ethers.getContractFactory('Liquidator') as Liquidator__factory;
@@ -228,7 +228,7 @@ export async function makeProtocol() {
       compWhale: compWhaleSigner,
       linkWhale: linkWhaleSigner,
     }
-  }
+  };
 }
 
 export async function makeLiquidatableProtocol() {


### PR DESCRIPTION
Currently, the bot will only `BuyCollateral` if there are accounts to be absorbed. This change will make it so the bot will also look for `BuyCollateral` opportunities separately.