### PR TITLE
Add Flashbots support to the liquidation bot

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "author": "Compound Finance",
   "license": "UNLICENSED",
   "dependencies": {
+    "@flashbots/ethers-provider-bundle": "^0.5.0",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "jest-diff": "^27.4.2"

--- a/scripts/liquidation_bot/index.ts
+++ b/scripts/liquidation_bot/index.ts
@@ -10,13 +10,15 @@ import {
   getAssets,
   Asset
 } from './liquidateUnderwaterBorrowers';
+import { FlashbotsBundleProvider } from "@flashbots/ethers-provider-bundle";
+import { providers, Wallet } from 'ethers';
 
 const loopDelay = 5000;
 const loopsUntilUpdateAssets = 1000;
 let assets: Asset[] = [];
 
 async function main() {
-  let { DEPLOYMENT: deployment, LIQUIDATOR_ADDRESS: liquidatorAddress } = process.env;
+  let { DEPLOYMENT: deployment, LIQUIDATOR_ADDRESS: liquidatorAddress, USE_FLASHBOTS: useFlashbots } = process.env;
   if (!liquidatorAddress) {
     throw new Error('missing required env variable: LIQUIDATOR_ADDRESS');
   }
@@ -40,6 +42,34 @@ async function main() {
   const signer = await dm.getSigner();
   const contracts = await dm.contracts();
   const comet = contracts.get('comet') as CometInterface;
+
+  // Flashbots provider requires passing in a standard provider
+  let flashbotsProvider: FlashbotsBundleProvider;
+  if (useFlashbots === 'true') {
+    // XXX use a designated auth signer
+    // `authSigner` is an Ethereum private key that does NOT store funds and is NOT your bot's primary key.
+    // This is an identifying key for signing payloads to establish reputation and whitelisting
+    // In production, this should be used across multiple bundles to build relationship. In this example, we generate a new wallet each time
+    const authSigner = Wallet.createRandom();
+
+    if (network === 'mainnet') {
+      flashbotsProvider = await FlashbotsBundleProvider.create(
+        signer.provider! as providers.BaseProvider, // a normal ethers.js provider, to perform gas estimations and nonce lookups
+        authSigner, // ethers.js signer wallet, only for signing request payloads, not transactions
+      );
+    } else if (network === 'goerli') {
+      flashbotsProvider = await FlashbotsBundleProvider.create(
+        signer.provider! as providers.BaseProvider, // a normal ethers.js provider, to perform gas estimations and nonce lookups
+        authSigner, // ethers.js signer wallet, only for signing request payloads, not transactions
+        'https://relay-goerli.flashbots.net',
+        'goerli'
+      );
+    } else {
+      throw new Error(`Unsupported network: ${network}`);
+    }
+  }
+
+  const signerWithFlashbots = { signer, flashbotsProvider };
 
   if (!comet) {
     throw new Error(`no deployed Comet found for ${network}/${deployment}`);
@@ -69,14 +99,14 @@ async function main() {
       const liquidationAttempted = await liquidateUnderwaterBorrowers(
         comet,
         liquidator,
-        signer
+        signerWithFlashbots
       );
       if (!liquidationAttempted) {
         await arbitragePurchaseableCollateral(
           comet,
           liquidator,
-          signer,
-          assets
+          assets,
+          signerWithFlashbots
         );
       }
     } else {

--- a/scripts/liquidation_bot/index.ts
+++ b/scripts/liquidation_bot/index.ts
@@ -10,7 +10,7 @@ import {
   getAssets,
   Asset
 } from './liquidateUnderwaterBorrowers';
-import { FlashbotsBundleProvider } from "@flashbots/ethers-provider-bundle";
+import { FlashbotsBundleProvider } from '@flashbots/ethers-provider-bundle';
 import { providers, Wallet } from 'ethers';
 
 const loopDelay = 5000;

--- a/scripts/liquidation_bot/index.ts
+++ b/scripts/liquidation_bot/index.ts
@@ -45,7 +45,7 @@ async function main() {
 
   // Flashbots provider requires passing in a standard provider
   let flashbotsProvider: FlashbotsBundleProvider;
-  if (useFlashbots === 'true') {
+  if (useFlashbots.toLowerCase() === 'true') {
     // XXX use a designated auth signer
     // `authSigner` is an Ethereum private key that does NOT store funds and is NOT your bot's primary key.
     // This is an identifying key for signing payloads to establish reputation and whitelisting

--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -4,7 +4,7 @@ import {
   Liquidator
 } from '../../build/types';
 import { exp } from '../../test/helpers';
-import { FlashbotsBundleProvider } from "@flashbots/ethers-provider-bundle";
+import { FlashbotsBundleProvider } from '@flashbots/ethers-provider-bundle';
 import { PopulatedTransaction } from 'ethers';
 
 export interface SignerWithFlashbots {
@@ -30,7 +30,7 @@ async function sendFlashbotsPrivateTransaction(
   const privateTx = {
     transaction: txn,
     signer: flashbotsProvider.getSigner(),
-  }
+  };
   await flashbotsProvider.sendPrivateTransaction(privateTx);
 }
 

--- a/test/liquidation/liquidation-bot-script.ts
+++ b/test/liquidation/liquidation-bot-script.ts
@@ -30,7 +30,7 @@ describe('Liquidation Bot', function () {
       await liquidateUnderwaterBorrowers(
         comet,
         liquidator,
-        signer
+        {signer}
       );
 
       expect(await comet.isLiquidatable(underwater.address)).to.be.false;
@@ -61,8 +61,8 @@ describe('Liquidation Bot', function () {
       await arbitragePurchaseableCollateral(
         comet,
         liquidator,
-        signer,
-        assetAddresses
+        assetAddresses,
+        {signer}
       );
 
       // There will be some dust to purchase, but we expect it to be less than $1 of worth
@@ -92,8 +92,8 @@ describe('Liquidation Bot', function () {
       await arbitragePurchaseableCollateral(
         comet,
         liquidator,
-        signer,
-        assetAddresses
+        assetAddresses,
+        {signer}
       );
 
       // There will be some dust to purchase, but we expect it to be less than $1 of worth

--- a/yarn.lock
+++ b/yarn.lock
@@ -412,6 +412,14 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@flashbots/ethers-provider-bundle@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@flashbots/ethers-provider-bundle/-/ethers-provider-bundle-0.5.0.tgz#068dd6a078066c50c36ac81b92d4726636768853"
+  integrity sha512-w7vc6aWDtgaHkDSgACjda0NoKYjOJ4mkr2av+u0NctvsoeNTg5dji65zeyU+98Fx3s6IbK0mfUTSGHAUtyt21A==
+  dependencies:
+    ts-node "^9.1.0"
+    typescript "^4.1.2"
+
 "@humanwhocodes/config-array@^0.10.5":
   version "0.10.7"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.7.tgz#6d53769fd0c222767e6452e8ebda825c22e9f0dc"
@@ -4696,6 +4704,18 @@ ts-node@^8.1.0:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
+ts-node@^9.1.0:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -4790,7 +4810,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.4.4:
+typescript@^4.1.2, typescript@^4.4.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==


### PR DESCRIPTION
Transactions can be sent to Flashbots by specifying `USE_FLASHBOTS=true` in env variables.