### PR TITLE
check for useFlashbots before down-casing

### DIFF
--- a/scripts/liquidation_bot/index.ts
+++ b/scripts/liquidation_bot/index.ts
@@ -45,7 +45,7 @@ async function main() {
 
   // Flashbots provider requires passing in a standard provider
   let flashbotsProvider: FlashbotsBundleProvider;
-  if (useFlashbots.toLowerCase() === 'true') {
+  if (useFlashbots && useFlashbots.toLowerCase() === 'true') {
     // XXX use a designated auth signer
     // `authSigner` is an Ethereum private key that does NOT store funds and is NOT your bot's primary key.
     // This is an identifying key for signing payloads to establish reputation and whitelisting


### PR DESCRIPTION
`useFlashbots` is undefined if you don't define a `USE_FLASHBOTS` environment variable; we should check for its existence before calling `.toLowerCase` on it (which will throw an error otherwise)