### PR TITLE
Liquidate via Flashbots bundles

### DIFF
--- a/scripts/liquidation_bot/index.ts
+++ b/scripts/liquidation_bot/index.ts
@@ -26,7 +26,7 @@ async function main() {
   if (!deployment) {
     throw new Error('missing required env variable: DEPLOYMENT');
   }
-  if (!ethPk) {
+  if (useFlashbots && !ethPk) {
     throw new Error('missing required env variable: ETH_PK');
   }
 

--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -58,18 +58,18 @@ async function sendFlashbotsBundle(
     const resolution = await bundleReceipt.wait();
     if (resolution === FlashbotsBundleResolution.BundleIncluded) {
       success = true;
-      console.log('Bundle included!');
+      googleCloudLog(LogSeverity.INFO, 'Bundle included!');
     } else if (resolution === FlashbotsBundleResolution.BlockPassedWithoutInclusion) {
       // XXX alert if too many attempts are not included in a block
       success = false;
-      console.log('Block passed without inclusion');
+      googleCloudLog(LogSeverity.INFO, 'Block passed without inclusion');
     } else if (resolution === FlashbotsBundleResolution.AccountNonceTooHigh) {
       success = false;
-      console.log('Account nonce too high');
+      googleCloudLog(LogSeverity.INFO, 'Account nonce too high');
     }
   } else {
     success = false;
-    console.log('Error while sending Flashbots bundle: ', bundleReceipt.error);
+    googleCloudLog(LogSeverity.ALERT, `Error while sending Flashbots bundle: ${bundleReceipt.error}`);
   }
 
   return success;

--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -4,8 +4,8 @@ import {
   Liquidator
 } from '../../build/types';
 import { exp } from '../../test/helpers';
-import { FlashbotsBundleProvider, FlashbotsBundleResolution, FlashbotsTransactionResponse, RelayResponseError } from '@flashbots/ethers-provider-bundle';
-import { PopulatedTransaction, Signer } from 'ethers';
+import { FlashbotsBundleProvider } from '@flashbots/ethers-provider-bundle';
+import { Signer } from 'ethers';
 import googleCloudLog, { LogSeverity } from './googleCloudLog';
 import {sendTxn} from './sendTransaction';
 
@@ -31,7 +31,7 @@ const flashLoanPools = {
     tokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
     poolFee: 3000
   }
-}
+};
 
 async function attemptLiquidation(
   liquidator: Liquidator,

--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -1,15 +1,15 @@
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import hre from 'hardhat';
 import {
   CometInterface,
   Liquidator
 } from '../../build/types';
 import { exp } from '../../test/helpers';
-import { FlashbotsBundleProvider } from '@flashbots/ethers-provider-bundle';
-import { PopulatedTransaction } from 'ethers';
+import { FlashbotsBundleProvider, FlashbotsBundleResolution, FlashbotsTransactionResponse, RelayResponseError } from '@flashbots/ethers-provider-bundle';
+import { PopulatedTransaction, Signer } from 'ethers';
 import googleCloudLog, { LogSeverity } from './googleCloudLog';
 
 export interface SignerWithFlashbots {
-  signer: SignerWithAddress;
+  signer: Signer;
   flashbotsProvider?: FlashbotsBundleProvider;
 }
 
@@ -19,49 +19,104 @@ export interface Asset {
   scale: bigint;
 }
 
-const daiPool = {
-  tokenAddress: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
-  poolFee: 100
-};
-
-async function sendFlashbotsPrivateTransaction(
-  txn: PopulatedTransaction,
-  flashbotsProvider: FlashbotsBundleProvider
-) {
-  const privateTx = {
-    transaction: txn,
-    signer: flashbotsProvider.getSigner(),
-  };
-  await flashbotsProvider.sendPrivateTransaction(privateTx);
+const flashLoanPools = {
+  'mainnet': {
+    // DAI pool
+    tokenAddress: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+    poolFee: 100
+  },
+  'goerli': {
+    // WETH pool
+    tokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
+    poolFee: 3000
+  }
 }
 
+function isFlashbotsTxnResponse(bundleReceipt: FlashbotsTransactionResponse | RelayResponseError): bundleReceipt is FlashbotsTransactionResponse {
+  return (bundleReceipt as FlashbotsTransactionResponse).bundleTransactions !== undefined;
+}
+
+async function sendFlashbotsBundle(
+  txn: PopulatedTransaction,
+  signerWithFlashbots: SignerWithFlashbots
+): Promise<boolean> {
+  const wallet = signerWithFlashbots.signer;
+  const flashbotsProvider = signerWithFlashbots.flashbotsProvider;
+  const signedBundle = await flashbotsProvider.signBundle(
+    [
+      {
+        signer: wallet, // ethers signer
+        transaction: txn // ethers populated transaction object
+      }
+    ])
+  const bundleReceipt = await flashbotsProvider.sendRawBundle(
+    signedBundle, // bundle we signed above
+    await hre.ethers.provider.getBlockNumber() + 1, // block number at which this bundle is valid
+  );
+  let success: boolean;
+  if (isFlashbotsTxnResponse(bundleReceipt)) {
+    const resolution = await bundleReceipt.wait();
+    if (resolution === FlashbotsBundleResolution.BundleIncluded) {
+      success = true;
+      console.log('Bundle included!');
+    } else if (resolution === FlashbotsBundleResolution.BlockPassedWithoutInclusion) {
+      // XXX alert if too many attempts are not included in a block
+      success = false;
+      console.log('Block passed without inclusion');
+    } else if (resolution === FlashbotsBundleResolution.AccountNonceTooHigh) {
+      success = false;
+      console.log('Account nonce too high');
+    }
+  } else {
+    success = false;
+    console.log('Error while sending Flashbots bundle: ', bundleReceipt.error);
+  }
+
+  return success;
+}
+
+// XXX Note: Blocking txn, so we probably want to run these methods in separate threads
 async function sendTxn(
   txn: PopulatedTransaction,
   signerWithFlashbots: SignerWithFlashbots
-) {
+): Promise<boolean> {
   if (signerWithFlashbots.flashbotsProvider) {
     googleCloudLog(LogSeverity.INFO, 'Sending a private txn');
-    await sendFlashbotsPrivateTransaction(txn, signerWithFlashbots.flashbotsProvider);
+    return await sendFlashbotsBundle(txn, signerWithFlashbots);
   } else {
     googleCloudLog(LogSeverity.INFO, 'Sending a public txn');
-    await signerWithFlashbots.signer.sendTransaction(txn);
+    // XXX confirm that txn.wait() throws if the txn reverts
+    await (await signerWithFlashbots.signer.sendTransaction(txn)).wait();
+    return true;
   }
 }
 
 async function attemptLiquidation(
   liquidator: Liquidator,
   targetAddresses: string[],
-  signerWithFlashbots: SignerWithFlashbots
+  signerWithFlashbots: SignerWithFlashbots,
+  network: string
 ) {
   try {
     googleCloudLog(LogSeverity.INFO, `Attempting to liquidate ${targetAddresses} via ${liquidator.address}`);
-    const txn = await liquidator.populateTransaction.initFlash({
+    const flashLoanPool = flashLoanPools[network];
+    const calldata = {
       accounts: targetAddresses,
-      pairToken: daiPool.tokenAddress,
-      poolFee: daiPool.poolFee
+      pairToken: flashLoanPool.tokenAddress,
+      poolFee: flashLoanPool.poolFee
+    };
+    // XXX set appropriate gas price...currently we are overestimating slightly to be safe
+    // XXX also factor in gas price to profitability
+    const txn = await liquidator.populateTransaction.initFlash(calldata, {
+      gasLimit: Math.ceil(1.1 * (await liquidator.estimateGas.initFlash(calldata)).toNumber()),
+      gasPrice: Math.ceil(1.1 * (await hre.ethers.provider.getGasPrice()).toNumber()),
     });
-    await sendTxn(txn, signerWithFlashbots);
-    googleCloudLog(LogSeverity.INFO, `Successfully liquidated ${targetAddresses} via ${liquidator.address}`);
+    const success = await sendTxn(txn, signerWithFlashbots);
+    if (success) {
+      googleCloudLog(LogSeverity.INFO, `Successfully liquidated ${targetAddresses} via ${liquidator.address}`);
+    } else {
+      googleCloudLog(LogSeverity.ALERT, `Failed to liquidate ${targetAddresses} via ${liquidator.address}`);
+    }
   } catch (e) {
     googleCloudLog(
       LogSeverity.ALERT,
@@ -92,7 +147,8 @@ export async function hasPurchaseableCollateral(comet: CometInterface, assets: A
 export async function liquidateUnderwaterBorrowers(
   comet: CometInterface,
   liquidator: Liquidator,
-  signerWithFlashbots: SignerWithFlashbots
+  signerWithFlashbots: SignerWithFlashbots,
+  network: string
 ): Promise<boolean> {
   const uniqueAddresses = await getUniqueAddresses(comet);
 
@@ -108,7 +164,8 @@ export async function liquidateUnderwaterBorrowers(
       await attemptLiquidation(
         liquidator,
         [address],
-        signerWithFlashbots
+        signerWithFlashbots,
+        network
       );
       liquidationAttempted = true;
     }
@@ -120,7 +177,8 @@ export async function arbitragePurchaseableCollateral(
   comet: CometInterface,
   liquidator: Liquidator,
   assets: Asset[],
-  signerWithFlashbots: SignerWithFlashbots
+  signerWithFlashbots: SignerWithFlashbots,
+  network: string
 ) {
   googleCloudLog(LogSeverity.INFO, `Checking for purchaseable collateral`);
 
@@ -129,7 +187,8 @@ export async function arbitragePurchaseableCollateral(
     await attemptLiquidation(
       liquidator,
       [], // empty list means we will only buy collateral and not absorb
-      signerWithFlashbots
+      signerWithFlashbots,
+      network
     );
   }
 }

--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -7,6 +7,7 @@ import { exp } from '../../test/helpers';
 import { FlashbotsBundleProvider, FlashbotsBundleResolution, FlashbotsTransactionResponse, RelayResponseError } from '@flashbots/ethers-provider-bundle';
 import { PopulatedTransaction, Signer } from 'ethers';
 import googleCloudLog, { LogSeverity } from './googleCloudLog';
+import {sendTxn} from './sendTransaction';
 
 export interface SignerWithFlashbots {
   signer: Signer;
@@ -29,65 +30,6 @@ const flashLoanPools = {
     // WETH pool
     tokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
     poolFee: 3000
-  }
-}
-
-function isFlashbotsTxnResponse(bundleReceipt: FlashbotsTransactionResponse | RelayResponseError): bundleReceipt is FlashbotsTransactionResponse {
-  return (bundleReceipt as FlashbotsTransactionResponse).bundleTransactions !== undefined;
-}
-
-async function sendFlashbotsBundle(
-  txn: PopulatedTransaction,
-  signerWithFlashbots: SignerWithFlashbots
-): Promise<boolean> {
-  const wallet = signerWithFlashbots.signer;
-  const flashbotsProvider = signerWithFlashbots.flashbotsProvider;
-  const signedBundle = await flashbotsProvider.signBundle(
-    [
-      {
-        signer: wallet, // ethers signer
-        transaction: txn // ethers populated transaction object
-      }
-    ])
-  const bundleReceipt = await flashbotsProvider.sendRawBundle(
-    signedBundle, // bundle we signed above
-    await hre.ethers.provider.getBlockNumber() + 1, // block number at which this bundle is valid
-  );
-  let success: boolean;
-  if (isFlashbotsTxnResponse(bundleReceipt)) {
-    const resolution = await bundleReceipt.wait();
-    if (resolution === FlashbotsBundleResolution.BundleIncluded) {
-      success = true;
-      googleCloudLog(LogSeverity.INFO, 'Bundle included!');
-    } else if (resolution === FlashbotsBundleResolution.BlockPassedWithoutInclusion) {
-      // XXX alert if too many attempts are not included in a block
-      success = false;
-      googleCloudLog(LogSeverity.INFO, 'Block passed without inclusion');
-    } else if (resolution === FlashbotsBundleResolution.AccountNonceTooHigh) {
-      success = false;
-      googleCloudLog(LogSeverity.INFO, 'Account nonce too high');
-    }
-  } else {
-    success = false;
-    googleCloudLog(LogSeverity.ALERT, `Error while sending Flashbots bundle: ${bundleReceipt.error}`);
-  }
-
-  return success;
-}
-
-// XXX Note: Blocking txn, so we probably want to run these methods in separate threads
-async function sendTxn(
-  txn: PopulatedTransaction,
-  signerWithFlashbots: SignerWithFlashbots
-): Promise<boolean> {
-  if (signerWithFlashbots.flashbotsProvider) {
-    googleCloudLog(LogSeverity.INFO, 'Sending a private txn');
-    return await sendFlashbotsBundle(txn, signerWithFlashbots);
-  } else {
-    googleCloudLog(LogSeverity.INFO, 'Sending a public txn');
-    // XXX confirm that txn.wait() throws if the txn reverts
-    await (await signerWithFlashbots.signer.sendTransaction(txn)).wait();
-    return true;
   }
 }
 

--- a/scripts/liquidation_bot/sendTransaction.ts
+++ b/scripts/liquidation_bot/sendTransaction.ts
@@ -20,7 +20,7 @@ async function sendFlashbotsBundle(
         signer: wallet, // ethers signer
         transaction: txn // ethers populated transaction object
       }
-    ])
+    ]);
   const bundleReceipt = await flashbotsProvider.sendRawBundle(
     signedBundle, // bundle we signed above
     await hre.ethers.provider.getBlockNumber() + 1, // block number at which this bundle is valid
@@ -53,7 +53,7 @@ export async function sendTxn(
   signerWithFlashbots: SignerWithFlashbots
 ): Promise<boolean> {
   if (signerWithFlashbots.flashbotsProvider) {
-    googleCloudLog(LogSeverity.INFO, 'Sending a private txn');
+    googleCloudLog(LogSeverity.INFO, 'Sending a private txn via Flashbots');
     return await sendFlashbotsBundle(txn, signerWithFlashbots);
   } else {
     googleCloudLog(LogSeverity.INFO, 'Sending a public txn');

--- a/scripts/liquidation_bot/sendTransaction.ts
+++ b/scripts/liquidation_bot/sendTransaction.ts
@@ -1,0 +1,64 @@
+import hre from 'hardhat';
+import { FlashbotsBundleResolution, FlashbotsTransactionResponse, RelayResponseError } from '@flashbots/ethers-provider-bundle';
+import { PopulatedTransaction } from 'ethers';
+import googleCloudLog, { LogSeverity } from './googleCloudLog';
+import {SignerWithFlashbots} from './liquidateUnderwaterBorrowers';
+
+function isFlashbotsTxnResponse(bundleReceipt: FlashbotsTransactionResponse | RelayResponseError): bundleReceipt is FlashbotsTransactionResponse {
+  return (bundleReceipt as FlashbotsTransactionResponse).bundleTransactions !== undefined;
+}
+
+async function sendFlashbotsBundle(
+  txn: PopulatedTransaction,
+  signerWithFlashbots: SignerWithFlashbots
+): Promise<boolean> {
+  const wallet = signerWithFlashbots.signer;
+  const flashbotsProvider = signerWithFlashbots.flashbotsProvider;
+  const signedBundle = await flashbotsProvider.signBundle(
+    [
+      {
+        signer: wallet, // ethers signer
+        transaction: txn // ethers populated transaction object
+      }
+    ])
+  const bundleReceipt = await flashbotsProvider.sendRawBundle(
+    signedBundle, // bundle we signed above
+    await hre.ethers.provider.getBlockNumber() + 1, // block number at which this bundle is valid
+  );
+  let success: boolean;
+  if (isFlashbotsTxnResponse(bundleReceipt)) {
+    const resolution = await bundleReceipt.wait();
+    if (resolution === FlashbotsBundleResolution.BundleIncluded) {
+      success = true;
+      googleCloudLog(LogSeverity.INFO, 'Bundle included!');
+    } else if (resolution === FlashbotsBundleResolution.BlockPassedWithoutInclusion) {
+      // XXX alert if too many attempts are not included in a block
+      success = false;
+      googleCloudLog(LogSeverity.INFO, 'Block passed without inclusion');
+    } else if (resolution === FlashbotsBundleResolution.AccountNonceTooHigh) {
+      success = false;
+      googleCloudLog(LogSeverity.INFO, 'Account nonce too high');
+    }
+  } else {
+    success = false;
+    googleCloudLog(LogSeverity.ALERT, `Error while sending Flashbots bundle: ${bundleReceipt.error}`);
+  }
+
+  return success;
+}
+
+// XXX Note: Blocking txn, so we probably want to run these methods in separate threads
+export async function sendTxn(
+  txn: PopulatedTransaction,
+  signerWithFlashbots: SignerWithFlashbots
+): Promise<boolean> {
+  if (signerWithFlashbots.flashbotsProvider) {
+    googleCloudLog(LogSeverity.INFO, 'Sending a private txn');
+    return await sendFlashbotsBundle(txn, signerWithFlashbots);
+  } else {
+    googleCloudLog(LogSeverity.INFO, 'Sending a public txn');
+    // XXX confirm that txn.wait() throws if the txn reverts
+    await (await signerWithFlashbots.signer.sendTransaction(txn)).wait();
+    return true;
+  }
+}

--- a/scripts/liquidation_bot/sendTransaction.ts
+++ b/scripts/liquidation_bot/sendTransaction.ts
@@ -37,7 +37,7 @@ async function sendFlashbotsBundle(
       googleCloudLog(LogSeverity.INFO, 'Block passed without inclusion');
     } else if (resolution === FlashbotsBundleResolution.AccountNonceTooHigh) {
       success = false;
-      googleCloudLog(LogSeverity.INFO, 'Account nonce too high');
+      googleCloudLog(LogSeverity.ALERT, 'Account nonce too high');
     }
   } else {
     success = false;

--- a/test/liquidation/liquidation-bot-script.ts
+++ b/test/liquidation/liquidation-bot-script.ts
@@ -30,7 +30,8 @@ describe('Liquidation Bot', function () {
       await liquidateUnderwaterBorrowers(
         comet,
         liquidator,
-        {signer}
+        {signer},
+        'mainnet'
       );
 
       expect(await comet.isLiquidatable(underwater.address)).to.be.false;
@@ -62,7 +63,8 @@ describe('Liquidation Bot', function () {
         comet,
         liquidator,
         assetAddresses,
-        {signer}
+        {signer},
+        'mainnet'
       );
 
       // There will be some dust to purchase, but we expect it to be less than $1 of worth
@@ -93,7 +95,8 @@ describe('Liquidation Bot', function () {
         comet,
         liquidator,
         assetAddresses,
-        {signer}
+        {signer},
+        'mainnet'
       );
 
       // There will be some dust to purchase, but we expect it to be less than $1 of worth


### PR DESCRIPTION
This PR implements liquidating positions via the private mempool (to prevent front-running) by sending bundles to Flashbots. Both the Flashbots and non-Flashbots paths have been tested E2E on Goerli.
