### PR TITLE
add maxCollateralToPurchase to Liquidator.sol

### DIFF
--- a/.github/workflows/run-forge-tests.yaml
+++ b/.github/workflows/run-forge-tests.yaml
@@ -21,7 +21,7 @@ jobs:
         run: forge install
 
       - name: Run tests
-        run: forge test -vvv
+        run: forge test -vvv --via-ir
         env:
           ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_KEY }}
           SNOWTRACE_KEY: ${{ secrets.SNOWTRACE_KEY }}

--- a/contracts/liquidator/Liquidator.sol
+++ b/contracts/liquidator/Liquidator.sol
@@ -115,7 +115,7 @@ contract Liquidator is IUniswapV3FlashCallback, PeripheryImmutableState, Periphe
      * @param _lowLiquidityPools The list of boolean indicators if pool is low liquidity and requires ETH swap
      * @param _poolFees The list of given poolFees for assets
      * @param _exchanges The list of given exchanges for assets
-     * @param _maxCollateralToPurchases The list of given maxSafeExchanges for assets
+     * @param _maxCollateralsToPurchase The list of given maxSafeExchanges for assets
      **/
     constructor(
         address _recipient,
@@ -129,7 +129,7 @@ contract Liquidator is IUniswapV3FlashCallback, PeripheryImmutableState, Periphe
         bool[] memory _lowLiquidityPools,
         uint24[] memory _poolFees,
         Exchange[] memory _exchanges,
-        uint256[] memory _maxCollateralToPurchases
+        uint256[] memory _maxCollateralsToPurchase
     ) PeripheryImmutableState(_factory, _WETH9) {
         require(_assets.length == _lowLiquidityPools.length, "Wrong data");
         require(_assets.length == _poolFees.length, "Wrong data");
@@ -148,7 +148,7 @@ contract Liquidator is IUniswapV3FlashCallback, PeripheryImmutableState, Periphe
             bool lowLiquidity = _lowLiquidityPools[i];
             uint24 poolFee = _poolFees[i];
             Exchange exchange = _exchanges[i];
-            uint256 maxCollateralToPurchase = _maxCollateralToPurchases[i];
+            uint256 maxCollateralToPurchase = _maxCollateralsToPurchase[i];
             poolConfigs[asset] = PoolConfig({
                 isLowLiquidity: lowLiquidity,
                 fee: poolFee,
@@ -170,7 +170,7 @@ contract Liquidator is IUniswapV3FlashCallback, PeripheryImmutableState, Periphe
         bool[] memory _lowLiquidityPools,
         uint24[] memory _poolFees,
         Exchange[] memory _exchanges,
-        uint256[] memory _maxCollateralToPurchases
+        uint256[] memory _maxCollateralsToPurchase
     ) external {
         if (msg.sender != admin) revert Unauthorized();
 
@@ -179,7 +179,7 @@ contract Liquidator is IUniswapV3FlashCallback, PeripheryImmutableState, Periphe
             bool lowLiquidity = _lowLiquidityPools[i];
             uint24 poolFee = _poolFees[i];
             Exchange exchange = _exchanges[i];
-            uint256 maxCollateralToPurchase = _maxCollateralToPurchases[i];
+            uint256 maxCollateralToPurchase = _maxCollateralsToPurchase[i];
             poolConfigs[asset] = PoolConfig({
                 isLowLiquidity: lowLiquidity,
                 fee: poolFee,

--- a/contracts/liquidator/Liquidator.sol
+++ b/contracts/liquidator/Liquidator.sol
@@ -265,6 +265,9 @@ contract Liquidator is IUniswapV3FlashCallback, PeripheryImmutableState, Periphe
             })
         );
 
+        // we do a manual check against `amountOutMin` (instead of specifying an
+        // `amountOutMinimum` in the swap) so we can provide better information
+        // in the error message
         if (amountOut < amountOutMin) {
             // XXX test the error messaging on Goerli
             revert InsufficientAmountOut(swapToken, baseToken, swapAmount, amountOut, amountOutMin, Exchange.Uniswap, poolFee);
@@ -310,6 +313,9 @@ contract Liquidator is IUniswapV3FlashCallback, PeripheryImmutableState, Periphe
         );
         uint256 amountOut = amounts[amounts.length - 1];
 
+        // we do a manual check against `amountOutMin` (instead of specifying an
+        // `amountOutMinimum` in the swap) so we can provide better information
+        // in the error message
         if (amountOut < amountOutMin) {
             // XXX test the error messaging on Goerli
             revert InsufficientAmountOut(swapToken, baseToken, swapAmount, amountOut, amountOutMin, Exchange.SushiSwap, 3000);

--- a/contracts/liquidator/Liquidator.sol
+++ b/contracts/liquidator/Liquidator.sol
@@ -37,7 +37,7 @@ contract Liquidator is IUniswapV3FlashCallback, PeripheryImmutableState, Periphe
 
     /** Events **/
     event Absorb(address indexed initiator, address[] accounts);
-    event AbsorbedWithoutBuyingCollateral();
+    event AbsorbWithoutBuyingCollateral();
     event Pay(address indexed token, address indexed payer, address indexed recipient, uint256 value);
     event Swap(address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut, Exchange exchange, uint24 fee);
 
@@ -445,7 +445,7 @@ contract Liquidator is IUniswapV3FlashCallback, PeripheryImmutableState, Periphe
 
         // if there is nothing to buy, just absorb the accounts
         if (totalBaseAmount == 0) {
-            emit AbsorbedWithoutBuyingCollateral();
+            emit AbsorbWithoutBuyingCollateral();
             return;
         }
 

--- a/scenario/ConstraintScenario.ts
+++ b/scenario/ConstraintScenario.ts
@@ -94,7 +94,9 @@ scenario(
   }
 );
 
-scenario(
+// XXX unable to source sufficient $asset0 for mainnet, goerli to borrow up to
+// 75% utilization
+scenario.skip(
   'UtilizationConstraint > sets utilization to 75%',
   {
     utilization: 0.75,

--- a/scenario/LiquidationBotScenario.ts
+++ b/scenario/LiquidationBotScenario.ts
@@ -1,6 +1,10 @@
 import { scenario } from './context/CometContext';
 import { expect } from 'chai';
 import { isValidAssetIndex, MAX_ASSETS, timeUntilUnderwater } from './utils';
+import { event, exp, wait } from '../test/helpers';
+import { BigNumber, constants } from 'ethers';
+import CometActor from './context/CometActor';
+import { CometInterface } from '../build/types';
 
 const daiPool = {
   tokenAddress: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
@@ -9,7 +13,7 @@ const daiPool = {
 
 const UNISWAP_V3_FACTORY_ADDRESS = '0x1F98431c8aD98523631AE4a59f267346ea31F984';
 const WETH9 = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-const RECIPIENT = '0xe8F0c9059b8Db5B863d48dB8e8C1A09f97D3B991';
+const RECIPIENT = '0x5a13D329A193ca3B1fE2d7B459097EdDba14C28F';
 const UNISWAP_ROUTER = '0xe592427a0aece92de3edee1f18e0157c05861564';
 const SUSHISWAP_ROUTER = '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F';
 
@@ -18,36 +22,43 @@ enum Exchange {
   SushiSwap
 }
 
+async function borrowCapacityForAsset(comet: CometInterface, actor: CometActor, assetIndex: number) {
+  const {
+    asset: collateralAssetAddress,
+    borrowCollateralFactor,
+    priceFeed,
+    scale
+  } = await comet.getAssetInfo(assetIndex);
+
+  const userCollateral = await comet.collateralBalanceOf(
+    actor.address,
+    collateralAssetAddress
+  );
+  const price = await comet.getPrice(priceFeed);
+
+  const factorScale = await comet.factorScale();
+  const priceScale = await comet.priceScale();
+  const baseScale = await comet.baseScale();
+
+  const collateralValue = (userCollateral.mul(price)).div(scale);
+  return collateralValue.mul(borrowCollateralFactor).mul(baseScale).div(factorScale).div(priceScale);
+}
+
 for (let i = 0; i < MAX_ASSETS; i++) {
-  const borrowPositions = [
+  const assetAmounts = [
     // COMP
-    {
-      baseBorrowAmount: 20_000n,
-      assetAmount: ' == 1000'
-    },
+    ' == 500',
     // WBTC
-    {
-      baseBorrowAmount: 1_300_000n,
-      assetAmount: ' == 120'
-    },
+    ' == 120',
     // WETH
-    {
-      baseBorrowAmount: 5_000_000n,
-      assetAmount: ' == 5000'
-    },
+    ' == 5000',
     // UNI
-    {
-      baseBorrowAmount: 700_000n,
-      assetAmount: ' == 150000'
-    },
+    ' == 150000',
     // LINK
-    {
-      baseBorrowAmount: 1_000_000n,
-      assetAmount: ' == 250000'
-    },
+    ' == 250000',
   ];
-  scenario(
-    `LiquidationBot > liquidates an underwater position for $asset${i}`,
+  scenario.only(
+    `LiquidationBot > liquidates an underwater position of $asset${i} ${assetAmounts[i] || ''} with no maxCollateralPurchase`,
     {
       filter: async (ctx) => ctx.world.base.network === 'mainnet' && await isValidAssetIndex(ctx, i),
       tokenBalances: {
@@ -55,9 +66,9 @@ for (let i = 0; i < MAX_ASSETS; i++) {
       },
       cometBalances: {
         albert: {
-          [`$asset${i}`]: borrowPositions[i]?.assetAmount || 0
+          [`$asset${i}`]: assetAmounts[i] || 0
         },
-        betty: { $base: 1230 },
+        betty: { $base: 1000 },
       },
     },
     async ({ comet, actors, assets }, _context, world) => {
@@ -74,7 +85,7 @@ for (let i = 0; i < MAX_ASSETS; i++) {
           comet.address, // _comet
           UNISWAP_V3_FACTORY_ADDRESS, // _factory
           WETH9, // _WETH9
-          0, // _liquidationThreshold,
+          10e6, // _liquidationThreshold,
           [
             '0xc00e94Cb662C3520282E6f5717214004A7f26888', // COMP
             '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', // WBTC
@@ -102,6 +113,13 @@ for (let i = 0; i < MAX_ASSETS; i++) {
             Exchange.Uniswap,   // WETH
             Exchange.Uniswap,   // UNI
             Exchange.Uniswap,   // LINK
+          ],
+          [
+            constants.MaxUint256, // COMP
+            constants.MaxUint256, // WBTC
+            constants.MaxUint256, // WETH
+            constants.MaxUint256, // UNI
+            constants.MaxUint256, // LINK
           ]
         ]
       );
@@ -110,12 +128,149 @@ for (let i = 0; i < MAX_ASSETS; i++) {
 
       const baseToken = await comet.baseToken();
       const baseBorrowMin = (await comet.baseBorrowMin()).toBigInt();
-      const baseScale = await comet.baseScale();
+      const { asset: collateralAssetAddress, scale } = await comet.getAssetInfo(i);
+
+      const borrowCapacity = await borrowCapacityForAsset(comet, albert, i);
+      const borrowAmount = (borrowCapacity.mul(90n)).div(100n);
+
+      // Do a manual withdrawAsset (instead of setting $base to a negative
+      // number) so we can confirm that albert only has one type of collateral asset
+      await albert.withdrawAsset({
+        asset: baseToken,
+        amount: borrowAmount
+      });
+
+      await world.increaseTime(
+        await timeUntilUnderwater({
+          comet,
+          actor: albert,
+          fudgeFactor: 60n * 10n // 10 minutes past when position is underwater
+        })
+      );
+
+      // define after increasing time, since increasing time alters reserves
+      const initialReserves = (await comet.getReserves()).toBigInt();
+
+      await betty.withdrawAsset({ asset: baseToken, amount: baseBorrowMin }); // force accrue
+
+      expect(await comet.isLiquidatable(albert.address)).to.be.true;
+      expect(await comet.collateralBalanceOf(albert.address, collateralAssetAddress)).to.be.greaterThan(0);
+
+      await liquidator.connect(betty.signer).initFlash({
+        accounts: [albert.address],
+        pairToken: daiPool.tokenAddress,
+        poolFee: daiPool.poolFee
+      });
+
+      // confirm that Albert position has been abosrbed
+      expect(await comet.isLiquidatable(albert.address)).to.be.false;
+      expect(await comet.collateralBalanceOf(albert.address, collateralAssetAddress)).to.eq(0);
+
+      // confirm that protocol reserves have increased
+      expect(await comet.getReserves()).to.be.above(initialReserves);
+
+      // confirm is not holding a significant amount of the collateral asset
+      expect(await comet.getCollateralReserves(collateralAssetAddress)).to.be.below(scale);
+
+      // check that recipient balance increased
+      expect(await USDC.balanceOf(RECIPIENT)).to.be.greaterThan(Number(initialRecipientBalance));
+    }
+  );
+}
+
+for (let i = 0; i < MAX_ASSETS; i++) {
+  const assetAmounts = [
+    // COMP
+    ' == 40000',
+    // WBTC
+    ' == 1200',
+    // WETH
+    ' == 10000',
+    // UNI
+    ' == 250000',
+    // LINK
+    ' == 500000',
+  ];
+
+  scenario.only(
+    `LiquidationBot > liquidates large position of $asset${i}, by setting maxCollateralToPurchase`,
+    {
+      filter: async (ctx) => ctx.world.base.network === 'mainnet' && await isValidAssetIndex(ctx, i),
+      tokenBalances: {
+        $comet: { $base: 1000 },
+      },
+      cometBalances: {
+        albert: {
+          [`$asset${i}`]: assetAmounts[i] || 0
+        },
+        betty: { $base: 1000 },
+      },
+    },
+    async ({ comet, actors, assets }, _context, world) => {
+      const { albert, betty } = actors;
+      const { USDC } = assets;
+
+      const liquidator = await world.deploymentManager.deploy(
+        'liquidator',
+        'liquidator/Liquidator.sol',
+        [
+          RECIPIENT, // _recipient
+          UNISWAP_ROUTER, // _uniswapRouter
+          SUSHISWAP_ROUTER, // _sushiSwapRouter
+          comet.address, // _comet
+          UNISWAP_V3_FACTORY_ADDRESS, // _factory
+          WETH9, // _WETH9
+          10e6, // _liquidationThreshold,
+          [
+            '0xc00e94Cb662C3520282E6f5717214004A7f26888', // COMP
+            '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', // WBTC
+            '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
+            '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', // UNI
+            '0x514910771AF9Ca656af840dff83E8264EcF986CA', // LINK
+          ],
+          [
+            true,
+            true,
+            false,
+            true,
+            true
+          ],
+          [
+            3000,
+            3000,
+            500,
+            3000,
+            3000
+          ],
+          [
+            Exchange.SushiSwap, // COMP
+            Exchange.Uniswap,   // WBTC
+            Exchange.Uniswap,   // WETH
+            Exchange.Uniswap,   // UNI
+            Exchange.Uniswap,   // LINK
+          ],
+          [
+            BigNumber.from(exp(1000,18)),   // COMP
+            BigNumber.from(exp(120,8)),     //  WBTC
+            BigNumber.from(exp(5000,18)),   // WETH
+            BigNumber.from(exp(150000,18)), // UNI
+            BigNumber.from(exp(250000,18)), // LINK
+          ]
+        ]
+      );
+
+      const initialRecipientBalance = await USDC.balanceOf(RECIPIENT);
+
+      const baseToken = await comet.baseToken();
+      const baseBorrowMin = (await comet.baseBorrowMin()).toBigInt();
       const { asset: collateralAssetAddress } = await comet.getAssetInfo(i);
+
+      const borrowCapacity = await borrowCapacityForAsset(comet, albert, i);
+      const borrowAmount = (borrowCapacity.mul(90n)).div(100n);
 
       await albert.withdrawAsset({
         asset: baseToken,
-        amount: baseScale.mul(borrowPositions[i]?.baseBorrowAmount || 0n)
+        amount: borrowAmount
       });
 
       await world.increaseTime(
@@ -137,13 +292,382 @@ for (let i = 0; i < MAX_ASSETS; i++) {
         poolFee: daiPool.poolFee
       });
 
+      // confirm that Albert position has been abosrbed
       expect(await comet.isLiquidatable(albert.address)).to.be.false;
       expect(await comet.collateralBalanceOf(albert.address, collateralAssetAddress)).to.eq(0);
-
-      // XXX confirm that protocol reserves have increased
 
       // check that recipient balance increased
       expect(await USDC.balanceOf(RECIPIENT)).to.be.greaterThan(Number(initialRecipientBalance));
     }
   );
 }
+
+scenario.only(
+  `LiquidationBot > absorbs, but does not attempt to purchase collateral when value is beneath liquidationThreshold`,
+  {
+    filter: async (ctx) => ctx.world.base.network === 'mainnet',
+    tokenBalances: {
+      $comet: { $base: 1000 },
+    },
+    cometBalances: {
+      albert: {
+        $asset0: ' == 5',
+      },
+      betty: { $base: 1000 },
+    },
+  },
+  async ({ comet, actors, assets }, _context, world) => {
+    const { albert, betty } = actors;
+    const { USDC } = assets;
+
+    const liquidator = await world.deploymentManager.deploy(
+      'liquidator',
+      'liquidator/Liquidator.sol',
+      [
+        RECIPIENT, // _recipient
+        UNISWAP_ROUTER, // _uniswapRouter
+        SUSHISWAP_ROUTER, // _sushiSwapRouter
+        comet.address, // _comet
+        UNISWAP_V3_FACTORY_ADDRESS, // _factory
+        WETH9, // _WETH9
+        1000e6, // _liquidationThreshold,
+        [
+          '0xc00e94Cb662C3520282E6f5717214004A7f26888', // COMP
+          '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', // WBTC
+          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
+          '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', // UNI
+          '0x514910771AF9Ca656af840dff83E8264EcF986CA', // LINK
+        ],
+        [
+          true,
+          true,
+          false,
+          true,
+          true
+        ],
+        [
+          3000,
+          3000,
+          500,
+          3000,
+          3000
+        ],
+        [
+          Exchange.SushiSwap, // COMP
+          Exchange.Uniswap,   // WBTC
+          Exchange.Uniswap,   // WETH
+          Exchange.Uniswap,   // UNI
+          Exchange.Uniswap,   // LINK
+        ],
+        [
+          constants.MaxUint256, // COMP
+          constants.MaxUint256, // WBTC
+          constants.MaxUint256, // WETH
+          constants.MaxUint256, // UNI
+          constants.MaxUint256, // LINK
+        ]
+      ]
+    );
+
+    const initialRecipientBalance = await USDC.balanceOf(RECIPIENT);
+
+    const baseToken = await comet.baseToken();
+    const baseBorrowMin = (await comet.baseBorrowMin()).toBigInt();
+    const { asset: collateralAssetAddress } = await comet.getAssetInfo(0);
+
+    const borrowCapacity = await borrowCapacityForAsset(comet, albert, 0);
+    const borrowAmount = (borrowCapacity.mul(90n)).div(100n);
+
+    await albert.withdrawAsset({
+      asset: baseToken,
+      amount: borrowAmount
+    });
+
+    await world.increaseTime(
+      await timeUntilUnderwater({
+        comet,
+        actor: albert,
+        fudgeFactor: 60n * 10n // 10 minutes past when position is underwater
+      })
+    );
+
+    const initialReserves = (await comet.getReserves()).toBigInt();
+
+    await betty.withdrawAsset({ asset: baseToken, amount: baseBorrowMin }); // force accrue
+
+    expect(await comet.isLiquidatable(albert.address)).to.be.true;
+    expect(await comet.collateralBalanceOf(albert.address, collateralAssetAddress)).to.be.greaterThan(0);
+
+    const tx = await wait(liquidator.connect(betty.signer).initFlash({
+      accounts: [albert.address],
+      pairToken: daiPool.tokenAddress,
+      poolFee: daiPool.poolFee
+    }));
+
+    expect(event(tx, 3)).to.deep.equal({
+      Absorb: {
+        initiator: betty.address,
+        accounts: [ albert.address ]
+      }
+    });
+
+    // confirm that Albert position has been abosrbed
+    expect(await comet.isLiquidatable(albert.address)).to.be.false;
+    expect(await comet.collateralBalanceOf(albert.address, collateralAssetAddress)).to.eq(0);
+
+    // confirm that collateral was not purchased
+    expect(event(tx, 4)).to.deep.equal({
+      AbsorbedWithoutBuyingCollateral: {}
+    });
+
+    // XXX confirm that liquidator points increased by 1
+
+    // confirm that protocol reserves have decreased
+    expect(await comet.getReserves()).to.be.below(initialReserves);
+
+    // check that recipient balance has stayed the same
+    expect(await USDC.balanceOf(RECIPIENT)).to.be.eq(Number(initialRecipientBalance));
+  }
+);
+
+scenario.only(
+  `LiquidationBot > absorbs, but does not attempt to purchase collateral when maxCollateralToPurchase=0`,
+  {
+    filter: async (ctx) => ctx.world.base.network === 'mainnet',
+    tokenBalances: {
+      $comet: { $base: 1000 },
+    },
+    cometBalances: {
+      albert: {
+        $asset0: ' == 5',
+      },
+      betty: { $base: 1000 },
+    },
+  },
+  async ({ comet, actors, assets }, _context, world) => {
+    const { albert, betty } = actors;
+    const { USDC } = assets;
+
+    const liquidator = await world.deploymentManager.deploy(
+      'liquidator',
+      'liquidator/Liquidator.sol',
+      [
+        RECIPIENT, // _recipient
+        UNISWAP_ROUTER, // _uniswapRouter
+        SUSHISWAP_ROUTER, // _sushiSwapRouter
+        comet.address, // _comet
+        UNISWAP_V3_FACTORY_ADDRESS, // _factory
+        WETH9, // _WETH9
+        0, // _liquidationThreshold,
+        [
+          '0xc00e94Cb662C3520282E6f5717214004A7f26888', // COMP
+          '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', // WBTC
+          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
+          '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', // UNI
+          '0x514910771AF9Ca656af840dff83E8264EcF986CA', // LINK
+        ],
+        [
+          true,
+          true,
+          false,
+          true,
+          true
+        ],
+        [
+          3000,
+          3000,
+          500,
+          3000,
+          3000
+        ],
+        [
+          Exchange.SushiSwap, // COMP
+          Exchange.Uniswap,   // WBTC
+          Exchange.Uniswap,   // WETH
+          Exchange.Uniswap,   // UNI
+          Exchange.Uniswap,   // LINK
+        ],
+        [
+          0, // COMP
+          0, // WBTC
+          0, // WETH
+          0, // UNI
+          0, // LINK
+        ]
+      ]
+    );
+
+    const initialRecipientBalance = await USDC.balanceOf(RECIPIENT);
+
+    const baseToken = await comet.baseToken();
+    const baseBorrowMin = (await comet.baseBorrowMin()).toBigInt();
+    const { asset: collateralAssetAddress } = await comet.getAssetInfo(0);
+
+    const borrowCapacity = await borrowCapacityForAsset(comet, albert, 0);
+    const borrowAmount = (borrowCapacity.mul(90n)).div(100n);
+
+    await albert.withdrawAsset({
+      asset: baseToken,
+      amount: borrowAmount
+    });
+
+    await world.increaseTime(
+      await timeUntilUnderwater({
+        comet,
+        actor: albert,
+        fudgeFactor: 60n * 10n // 10 minutes past when position is underwater
+      })
+    );
+
+    const initialReserves = (await comet.getReserves()).toBigInt();
+
+    await betty.withdrawAsset({ asset: baseToken, amount: baseBorrowMin }); // force accrue
+
+    expect(await comet.isLiquidatable(albert.address)).to.be.true;
+    expect(await comet.collateralBalanceOf(albert.address, collateralAssetAddress)).to.be.greaterThan(0);
+
+    const tx = await wait(liquidator.connect(betty.signer).initFlash({
+      accounts: [albert.address],
+      pairToken: daiPool.tokenAddress,
+      poolFee: daiPool.poolFee
+    }));
+
+    expect(event(tx, 3)).to.deep.equal({
+      Absorb: {
+        initiator: betty.address,
+        accounts: [ albert.address ]
+      }
+    });
+
+    // confirm that Albert position has been abosrbed
+    expect(await comet.isLiquidatable(albert.address)).to.be.false;
+    expect(await comet.collateralBalanceOf(albert.address, collateralAssetAddress)).to.eq(0);
+
+    // confirm that collateral was not purchased
+    expect(event(tx, 4)).to.deep.equal({
+      AbsorbedWithoutBuyingCollateral: {}
+    });
+
+    // XXX confirm that liquidator points increased by 1
+
+    // confirm that protocol reserves have decreased
+    expect(await comet.getReserves()).to.be.below(initialReserves);
+
+    // check that recipient balance has stayed the same
+    expect(await USDC.balanceOf(RECIPIENT)).to.be.eq(Number(initialRecipientBalance));
+  }
+);
+
+scenario.only(
+  `LiquidationBot > reverts when price slippage is too high`,
+  {
+    filter: async (ctx) => ctx.world.base.network === 'mainnet',
+    tokenBalances: {
+      $comet: { $base: 1000 },
+    },
+    cometBalances: {
+      albert: {
+        $asset0: ' == 10000',
+      },
+      betty: { $base: 1000 },
+    },
+  },
+  async ({ comet, actors, assets }, _context, world) => {
+    const { albert, betty } = actors;
+    const { USDC } = assets;
+
+    const liquidator = await world.deploymentManager.deploy(
+      'liquidator',
+      'liquidator/Liquidator.sol',
+      [
+        RECIPIENT, // _recipient
+        UNISWAP_ROUTER, // _uniswapRouter
+        SUSHISWAP_ROUTER, // _sushiSwapRouter
+        comet.address, // _comet
+        UNISWAP_V3_FACTORY_ADDRESS, // _factory
+        WETH9, // _WETH9
+        0, // _liquidationThreshold,
+        [
+          '0xc00e94Cb662C3520282E6f5717214004A7f26888', // COMP
+          '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', // WBTC
+          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
+          '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', // UNI
+          '0x514910771AF9Ca656af840dff83E8264EcF986CA', // LINK
+        ],
+        [
+          true,
+          true,
+          false,
+          true,
+          true
+        ],
+        [
+          3000,
+          3000,
+          500,
+          3000,
+          3000
+        ],
+        [
+          Exchange.SushiSwap, // COMP
+          Exchange.Uniswap,   // WBTC
+          Exchange.Uniswap,   // WETH
+          Exchange.Uniswap,   // UNI
+          Exchange.Uniswap,   // LINK
+        ],
+        [
+          constants.MaxUint256, // COMP
+          constants.MaxUint256, // WBTC
+          constants.MaxUint256, // WETH
+          constants.MaxUint256, // UNI
+          constants.MaxUint256, // LINK
+        ]
+      ]
+    );
+
+    const initialRecipientBalance = await USDC.balanceOf(RECIPIENT);
+
+    const baseToken = await comet.baseToken();
+    const baseBorrowMin = (await comet.baseBorrowMin()).toBigInt();
+    const { asset: collateralAssetAddress } = await comet.getAssetInfo(0);
+
+    const borrowCapacity = await borrowCapacityForAsset(comet, albert, 0);
+    const borrowAmount = (borrowCapacity.mul(90n)).div(100n);
+
+    await albert.withdrawAsset({
+      asset: baseToken,
+      amount: borrowAmount
+    });
+
+    await world.increaseTime(
+      await timeUntilUnderwater({
+        comet,
+        actor: albert,
+        fudgeFactor: 60n * 10n // 10 minutes past when position is underwater
+      })
+    );
+
+    await betty.withdrawAsset({ asset: baseToken, amount: baseBorrowMin }); // force accrue
+
+    expect(await comet.isLiquidatable(albert.address)).to.be.true;
+    expect(await comet.collateralBalanceOf(albert.address, collateralAssetAddress)).to.be.greaterThan(0);
+
+    await expect(
+      liquidator.connect(betty.signer).initFlash({
+        accounts: [albert.address],
+        pairToken: daiPool.tokenAddress,
+        poolFee: daiPool.poolFee
+      })
+    ).to.be.revertedWithCustomError(liquidator, 'InsufficientAmountOut');
+
+    // confirm that Albert position has not been abosrbed
+    expect(await comet.isLiquidatable(albert.address)).to.be.true;
+    expect(await comet.collateralBalanceOf(albert.address, collateralAssetAddress)).to.be.greaterThan(0);
+
+    // check that recipient balance has stayed the same
+    expect(await USDC.balanceOf(RECIPIENT)).to.be.eq(Number(initialRecipientBalance));
+  }
+);
+
+// XXX test that Liquidator liquidates up to the max amount for that asset
+// XXX test that Liquidaator buys selectively (e.g. buys WBTC, but don't buy WETH) based on maxCollateralToPurchase

--- a/scenario/LiquidationBotScenario.ts
+++ b/scenario/LiquidationBotScenario.ts
@@ -545,7 +545,7 @@ scenario(
 
     // confirm that collateral was not purchased
     expect(event(tx, 4)).to.deep.equal({
-      AbsorbedWithoutBuyingCollateral: {}
+      AbsorbWithoutBuyingCollateral: {}
     });
 
     // XXX confirm that liquidator points increased by 1

--- a/scenario/LiquidationBotScenario.ts
+++ b/scenario/LiquidationBotScenario.ts
@@ -73,7 +73,7 @@ for (let i = 0; i < MAX_ASSETS; i++) {
     },
     async ({ comet, actors, assets }, _context, world) => {
       const { albert, betty } = actors;
-      const { USDC } = assets;
+      const { USDC, COMP, WBTC, WETH, UNI, LINK } = assets;
 
       const liquidator = await world.deploymentManager.deploy(
         'liquidator',
@@ -87,11 +87,11 @@ for (let i = 0; i < MAX_ASSETS; i++) {
           WETH9, // _WETH9
           10e6, // _liquidationThreshold,
           [
-            '0xc00e94Cb662C3520282E6f5717214004A7f26888', // COMP
-            '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', // WBTC
-            '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
-            '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', // UNI
-            '0x514910771AF9Ca656af840dff83E8264EcF986CA', // LINK
+            COMP.address,
+            WBTC.address,
+            WETH.address,
+            UNI.address,
+            LINK.address,
           ],
           [
             true,
@@ -208,7 +208,7 @@ for (let i = 0; i < MAX_ASSETS; i++) {
     },
     async ({ comet, actors, assets }, _context, world) => {
       const { albert, betty } = actors;
-      const { USDC } = assets;
+      const { USDC, COMP, WBTC, WETH, UNI, LINK } = assets;
 
       const liquidator = await world.deploymentManager.deploy(
         'liquidator',
@@ -222,11 +222,11 @@ for (let i = 0; i < MAX_ASSETS; i++) {
           WETH9, // _WETH9
           10e6, // _liquidationThreshold,
           [
-            '0xc00e94Cb662C3520282E6f5717214004A7f26888', // COMP
-            '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', // WBTC
-            '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
-            '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', // UNI
-            '0x514910771AF9Ca656af840dff83E8264EcF986CA', // LINK
+            COMP.address,
+            WBTC.address,
+            WETH.address,
+            UNI.address,
+            LINK.address,
           ],
           [
             true,
@@ -318,7 +318,7 @@ scenario(
   },
   async ({ comet, actors, assets }, _context, world) => {
     const { albert, betty } = actors;
-    const { USDC } = assets;
+    const { USDC, COMP, WBTC, WETH, UNI, LINK } = assets;
 
     const liquidator = await world.deploymentManager.deploy(
       'liquidator',
@@ -332,11 +332,11 @@ scenario(
         WETH9, // _WETH9
         1000e6, // _liquidationThreshold,
         [
-          '0xc00e94Cb662C3520282E6f5717214004A7f26888', // COMP
-          '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', // WBTC
-          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
-          '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', // UNI
-          '0x514910771AF9Ca656af840dff83E8264EcF986CA', // LINK
+          COMP.address,
+          WBTC.address,
+          WETH.address,
+          UNI.address,
+          LINK.address,
         ],
         [
           true,
@@ -446,7 +446,7 @@ scenario(
   },
   async ({ comet, actors, assets }, _context, world) => {
     const { albert, betty } = actors;
-    const { USDC } = assets;
+    const { USDC, COMP, WBTC, WETH, UNI, LINK } = assets;
 
     const liquidator = await world.deploymentManager.deploy(
       'liquidator',
@@ -460,11 +460,11 @@ scenario(
         WETH9, // _WETH9
         0, // _liquidationThreshold,
         [
-          '0xc00e94Cb662C3520282E6f5717214004A7f26888', // COMP
-          '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', // WBTC
-          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
-          '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', // UNI
-          '0x514910771AF9Ca656af840dff83E8264EcF986CA', // LINK
+          COMP.address,
+          WBTC.address,
+          WETH.address,
+          UNI.address,
+          LINK.address,
         ],
         [
           true,
@@ -574,7 +574,7 @@ scenario(
   },
   async ({ comet, actors, assets }, _context, world) => {
     const { albert, betty } = actors;
-    const { USDC } = assets;
+    const { USDC, COMP, WBTC, WETH, UNI, LINK } = assets;
 
     const liquidator = await world.deploymentManager.deploy(
       'liquidator',
@@ -588,11 +588,11 @@ scenario(
         WETH9, // _WETH9
         0, // _liquidationThreshold,
         [
-          '0xc00e94Cb662C3520282E6f5717214004A7f26888', // COMP
-          '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', // WBTC
-          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
-          '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', // UNI
-          '0x514910771AF9Ca656af840dff83E8264EcF986CA', // LINK
+          COMP.address,
+          WBTC.address,
+          WETH.address,
+          UNI.address,
+          LINK.address,
         ],
         [
           true,

--- a/scenario/LiquidationBotScenario.ts
+++ b/scenario/LiquidationBotScenario.ts
@@ -417,7 +417,7 @@ scenario(
 
     // confirm that collateral was not purchased
     expect(event(tx, 4)).to.deep.equal({
-      AbsorbedWithoutBuyingCollateral: {}
+      AbsorbWithoutBuyingCollateral: {}
     });
 
     // XXX confirm that liquidator points increased by 1

--- a/scenario/LiquidationBotScenario.ts
+++ b/scenario/LiquidationBotScenario.ts
@@ -250,8 +250,8 @@ for (let i = 0; i < MAX_ASSETS; i++) {
             Exchange.Uniswap,   // LINK
           ],
           [
-            BigNumber.from(exp(1000,18)),   // COMP
-            BigNumber.from(exp(120,8)),     //  WBTC
+            BigNumber.from(exp(500,18)),    // COMP
+            BigNumber.from(exp(120,8)),     // WBTC
             BigNumber.from(exp(5000,18)),   // WETH
             BigNumber.from(exp(150000,18)), // UNI
             BigNumber.from(exp(250000,18)), // LINK

--- a/scenario/LiquidationBotScenario.ts
+++ b/scenario/LiquidationBotScenario.ts
@@ -57,7 +57,7 @@ for (let i = 0; i < MAX_ASSETS; i++) {
     // LINK
     ' == 250000',
   ];
-  scenario.only(
+  scenario(
     `LiquidationBot > liquidates an underwater position of $asset${i} ${assetAmounts[i] || ''} with no maxCollateralPurchase`,
     {
       filter: async (ctx) => ctx.world.base.network === 'mainnet' && await isValidAssetIndex(ctx, i),
@@ -192,7 +192,7 @@ for (let i = 0; i < MAX_ASSETS; i++) {
     ' == 500000',
   ];
 
-  scenario.only(
+  scenario(
     `LiquidationBot > liquidates large position of $asset${i}, by setting maxCollateralToPurchase`,
     {
       filter: async (ctx) => ctx.world.base.network === 'mainnet' && await isValidAssetIndex(ctx, i),
@@ -302,7 +302,7 @@ for (let i = 0; i < MAX_ASSETS; i++) {
   );
 }
 
-scenario.only(
+scenario(
   `LiquidationBot > absorbs, but does not attempt to purchase collateral when value is beneath liquidationThreshold`,
   {
     filter: async (ctx) => ctx.world.base.network === 'mainnet',
@@ -430,7 +430,7 @@ scenario.only(
   }
 );
 
-scenario.only(
+scenario(
   `LiquidationBot > absorbs, but does not attempt to purchase collateral when maxCollateralToPurchase=0`,
   {
     filter: async (ctx) => ctx.world.base.network === 'mainnet',
@@ -558,7 +558,7 @@ scenario.only(
   }
 );
 
-scenario.only(
+scenario(
   `LiquidationBot > reverts when price slippage is too high`,
   {
     filter: async (ctx) => ctx.world.base.network === 'mainnet',

--- a/scripts/liquidation_bot/deploy.ts
+++ b/scripts/liquidation_bot/deploy.ts
@@ -78,10 +78,10 @@ async function main() {
       ],
       [
         BigNumber.from(exp(500,18)),    // COMP
-        BigNumber.from(exp(50,8)),      // WBTC
-        BigNumber.from(exp(2500,18)),   // WETH
-        BigNumber.from(exp(100000,18)), // UNI
-        BigNumber.from(exp(100000,18)), // LINK
+        BigNumber.from(exp(120,8)),     // WBTC
+        BigNumber.from(exp(5000,18)),   // WETH
+        BigNumber.from(exp(150000,18)), // UNI
+        BigNumber.from(exp(150000,18)), // LINK
       ]
     ]
   );

--- a/scripts/liquidation_bot/deploy.ts
+++ b/scripts/liquidation_bot/deploy.ts
@@ -2,11 +2,14 @@ import hre from 'hardhat';
 import { DeploymentManager } from '../../plugins/deployment_manager/DeploymentManager';
 import { CometInterface } from '../../build/types';
 import { requireEnv } from '../../hardhat.config';
+import { BigNumber } from 'ethers';
+import { exp } from '../../test/helpers';
 
 // https://docs.uniswap.org/protocol/reference/deployments
 const UNISWAP_V3_FACTORY_ADDRESS = '0x1F98431c8aD98523631AE4a59f267346ea31F984';
 const WETH9 = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-const SWAP_ROUTER = '0xe592427a0aece92de3edee1f18e0157c05861564';
+const UNISWAP_ROUTER = '0xe592427a0aece92de3edee1f18e0157c05861564';
+const SUSHISWAP_ROUTER = '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F';
 
 enum Exchange {
   Uniswap,
@@ -39,7 +42,8 @@ async function main() {
     'liquidator/Liquidator.sol',
     [
       RECIPIENT, // _recipient
-      SWAP_ROUTER, // _swapRouter
+      UNISWAP_ROUTER, // _swapRouter
+      SUSHISWAP_ROUTER, // _sushiSwapRouter
       comet.address, // _comet
       UNISWAP_V3_FACTORY_ADDRESS, // _factory
       WETH9, // _WETH9
@@ -71,6 +75,13 @@ async function main() {
         Exchange.Uniswap,   // WETH
         Exchange.Uniswap,   // UNI
         Exchange.Uniswap    // LINK
+      ],
+      [
+        BigNumber.from(exp(500,18)),    // COMP
+        BigNumber.from(exp(120,8)),     // WBTC
+        BigNumber.from(exp(5000,18)),   // WETH
+        BigNumber.from(exp(150000,18)), // UNI
+        BigNumber.from(exp(250000,18)), // LINK
       ]
     ]
   );

--- a/scripts/liquidation_bot/deploy.ts
+++ b/scripts/liquidation_bot/deploy.ts
@@ -78,10 +78,10 @@ async function main() {
       ],
       [
         BigNumber.from(exp(500,18)),    // COMP
-        BigNumber.from(exp(120,8)),     // WBTC
-        BigNumber.from(exp(5000,18)),   // WETH
-        BigNumber.from(exp(150000,18)), // UNI
-        BigNumber.from(exp(250000,18)), // LINK
+        BigNumber.from(exp(50,8)),      // WBTC
+        BigNumber.from(exp(2500,18)),   // WETH
+        BigNumber.from(exp(100000,18)), // UNI
+        BigNumber.from(exp(100000,18)), // LINK
       ]
     ]
   );

--- a/scripts/liquidation_bot/deploy.ts
+++ b/scripts/liquidation_bot/deploy.ts
@@ -47,7 +47,7 @@ async function main() {
       comet.address, // _comet
       UNISWAP_V3_FACTORY_ADDRESS, // _factory
       WETH9, // _WETH9
-      10e6, // _liquidationThreshold,
+      1000e6, // _liquidationThreshold,
       [
         '0xc00e94Cb662C3520282E6f5717214004A7f26888', // COMP
         '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', // WBTC

--- a/test/liquidation/liquidation-bot-test.ts
+++ b/test/liquidation/liquidation-bot-test.ts
@@ -195,7 +195,7 @@ describe('Liquidator', function () {
     const { liquidator, users: [_signer, underwater] } = await makeLiquidatableProtocol();
 
     await expect(
-      liquidator.connect(underwater).setPoolConfigs([], [], [], [])
+      liquidator.connect(underwater).setPoolConfigs([], [], [], [], [])
     ).to.be.revertedWith("custom error 'Unauthorized()'");
   });
 
@@ -208,19 +208,25 @@ describe('Liquidator', function () {
     const newPoolConfig = {
       isLowLiquidity: !poolConfig.isLowLiquidity,
       fee: poolConfig.fee * 2,
-      exchange: poolConfig.exchange === Exchange.Uniswap ? Exchange.SushiSwap : Exchange.Uniswap
+      exchange: poolConfig.exchange === Exchange.Uniswap ? Exchange.SushiSwap : Exchange.Uniswap,
+      maxCollateralToPurchase: poolConfig.maxCollateralToPurchase.div(2)
     };
 
     await liquidator.connect(signer).setPoolConfigs(
       [wethAddress],
       [newPoolConfig.isLowLiquidity],
       [newPoolConfig.fee],
-      [newPoolConfig.exchange]
+      [newPoolConfig.exchange],
+      [newPoolConfig.maxCollateralToPurchase]
     );
 
     const updatedPoolConfig = await liquidator.connect(signer).poolConfigs(wethAddress);
 
     expect(updatedPoolConfig.isLowLiquidity).to.eq(newPoolConfig.isLowLiquidity);
     expect(updatedPoolConfig.fee).to.eq(newPoolConfig.fee);
+    expect(updatedPoolConfig.exchange).to.eq(newPoolConfig.exchange);
+    expect(updatedPoolConfig.maxCollateralToPurchase).to.eq(newPoolConfig.maxCollateralToPurchase);
   });
 });
+
+// XXX test that contracts reverts if pool config doesn't exist

--- a/test/liquidation/makeLiquidatableProtocol.ts
+++ b/test/liquidation/makeLiquidatableProtocol.ts
@@ -167,6 +167,14 @@ export async function makeProtocol() {
       Exchange.Uniswap,
       Exchange.SushiSwap,
       Exchange.Uniswap
+    ],
+    [
+      ethers.constants.MaxUint256,
+      ethers.constants.MaxUint256,
+      ethers.constants.MaxUint256,
+      ethers.constants.MaxUint256,
+      ethers.constants.MaxUint256,
+      ethers.constants.MaxUint256
     ]
   );
   await liquidator.deployed();


### PR DESCRIPTION
adds a `maxCollateralToPurchase` field to the Liquidator's pool config. This lets us specify a maximum amount of the given collateral asset to purchase, so that we don't try to purchase all the liquidity in a given pool, suffer a ton of slippage, and then fail to make a profit/pay back the flash loan.

Added a bunch of scenarios to flex this behavior. Scenarios have given us a general sense of the depth of the current Uniswap/SushiSwap pools that we're using; but of course, these things are subject to change as real-world conditions evolve.