### PR TITLE
alert on purchasable collateral

### DIFF
--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -122,10 +122,10 @@ export async function arbitragePurchaseableCollateral(
   signerWithFlashbots: SignerWithFlashbots,
   network: string
 ) {
-  googleCloudLog(LogSeverity.INFO, `Checking for purchaseable collateral`);
+  googleCloudLog(LogSeverity.INFO, `Checking for purchasable collateral`);
 
   if (await hasPurchaseableCollateral(comet, assets)) {
-    googleCloudLog(LogSeverity.INFO, `There is purchaseable collateral`);
+    googleCloudLog(LogSeverity.ALERT, `There is purchasable collateral`);
     await attemptLiquidation(
       liquidator,
       [], // empty list means we will only buy collateral and not absorb

--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -125,7 +125,7 @@ export async function arbitragePurchaseableCollateral(
   googleCloudLog(LogSeverity.INFO, `Checking for purchasable collateral`);
 
   if (await hasPurchaseableCollateral(comet, assets)) {
-    googleCloudLog(LogSeverity.ALERT, `There is purchasable collateral`);
+    googleCloudLog(LogSeverity.WARNING, `There is purchasable collateral`);
     await attemptLiquidation(
       liquidator,
       [], // empty list means we will only buy collateral and not absorb


### PR DESCRIPTION
- Fix spelling
- Increase severity of finding purchasable collateral to `ALERT`

Maybe `ALERT` is extreme; maybe `WARNING`?