### PR TITLE
Price feeds for WETH deployment + Bulker changes for OZ audit

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 import "./CometMainInterface.sol";
 import "./ERC20.sol";
-import "./vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import "./IPriceFeed.sol";
 
 /**
  * @title Compound's Comet Contract
@@ -144,7 +144,7 @@ contract Comet is CometMainInterface {
         if (config.storeFrontPriceFactor > FACTOR_SCALE) revert BadDiscount();
         if (config.assetConfigs.length > MAX_ASSETS) revert TooManyAssets();
         if (config.baseMinForRewards == 0) revert BadMinimum();
-        if (AggregatorV3Interface(config.baseTokenPriceFeed).decimals() != PRICE_FEED_DECIMALS) revert BadDecimals();
+        if (IPriceFeed(config.baseTokenPriceFeed).decimals() != PRICE_FEED_DECIMALS) revert BadDecimals();
 
         // Copy configuration
         unchecked {
@@ -240,7 +240,7 @@ contract Comet is CometMainInterface {
         }
 
         // Sanity check price feed and asset decimals
-        if (AggregatorV3Interface(priceFeed).decimals() != PRICE_FEED_DECIMALS) revert BadDecimals();
+        if (IPriceFeed(priceFeed).decimals() != PRICE_FEED_DECIMALS) revert BadDecimals();
         if (ERC20(asset).decimals() != decimals_) revert BadDecimals();
 
         // Ensure collateral factors are within range
@@ -471,7 +471,7 @@ contract Comet is CometMainInterface {
      * @return The price, scaled by `PRICE_SCALE`
      */
     function getPrice(address priceFeed) override public view returns (uint256) {
-        (, int price, , , ) = AggregatorV3Interface(priceFeed).latestRoundData();
+        (, int price, , , ) = IPriceFeed(priceFeed).latestRoundData();
         if (price <= 0) revert BadPrice();
         return uint256(price);
     }

--- a/contracts/CometCore.sol
+++ b/contracts/CometCore.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.15;
 import "./CometConfiguration.sol";
 import "./CometStorage.sol";
 import "./CometMath.sol";
-import "./vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 
 abstract contract CometCore is CometConfiguration, CometStorage, CometMath {
     struct AssetInfo {

--- a/contracts/ConstantPriceFeed.sol
+++ b/contracts/ConstantPriceFeed.sol
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.15;
 
-import "./vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import "./IPriceFeed.sol";
 
-contract ConstantPriceFeed is AggregatorV3Interface {
-    /** Custom errors **/
-    error NotImplemented();
-
+contract ConstantPriceFeed is IPriceFeed {
     /// @notice Version of the price feed
     uint public constant override version = 1;
 
@@ -26,13 +23,6 @@ contract ConstantPriceFeed is AggregatorV3Interface {
     constructor(uint8 decimals_, int256 constantPrice_) {
         decimals = decimals_;
         constantPrice = constantPrice_;
-    }
-
-    /**
-     * @notice Unimplemented function required to fulfill AggregatorV3Interface; always reverts
-     **/
-    function getRoundData(uint80 _roundId) override external pure returns (uint80, int256, uint256, uint256, uint80) {
-        revert NotImplemented();
     }
 
     /**

--- a/contracts/ConstantPriceFeed.sol
+++ b/contracts/ConstantPriceFeed.sol
@@ -32,13 +32,7 @@ contract ConstantPriceFeed is AggregatorV3Interface {
     /**
      * @notice Unimplemented function required to fulfill AggregatorV3Interface; always reverts
      **/
-    function getRoundData(uint80 _roundId) override external view returns (
-        uint80 roundId,
-        int256 answer,
-        uint256 startedAt,
-        uint256 updatedAt,
-        uint80 answeredInRound
-    ) {
+    function getRoundData(uint80 _roundId) override external pure returns (uint80, int256, uint256, uint256, uint80) {
         revert NotImplemented();
     }
 

--- a/contracts/ConstantPriceFeed.sol
+++ b/contracts/ConstantPriceFeed.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.15;
+
+import "./vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+contract ConstantPriceFeed is AggregatorV3Interface {
+    /** Custom errors **/
+    error InvalidInt256();
+    error NotImplemented();
+
+    /// @notice Version of the price feed
+    uint public constant override version = 1;
+
+    /// @notice Description of the price feed
+    string public constant description = "Constant price feed";
+
+    /// @notice Number of decimals for returned prices
+    uint8 public immutable override decimals;
+
+    /// @notice The constant price
+    int private immutable CONSTANT_PRICE;
+
+    /**
+     * @notice Construct a new scaling price feed
+     * @param decimals_ The number of decimals for the returned prices
+     **/
+    constructor(uint8 decimals_) {
+        decimals = decimals_;
+        CONSTANT_PRICE = signed256(10 ** decimals_);
+    }
+
+    /**
+     * @notice Unimplemented function required to fulfill AggregatorV3Interface; always reverts
+     **/
+    function getRoundData(uint80 _roundId) override external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        revert NotImplemented();
+    }
+
+    /**
+     * @notice Price for the latest round
+     * @return roundId Round id from the underlying price feed
+     * @return answer Latest price for the asset (will always be a constant price)
+     * @return startedAt Timestamp when the round was started; passed on from underlying price feed
+     * @return updatedAt Timestamp when the round was last updated; passed on from underlying price feed
+     * @return answeredInRound Round id in which the answer was computed; passed on from underlying price feed
+     **/
+    function latestRoundData() external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        return (0, CONSTANT_PRICE, block.timestamp, block.timestamp, 0);
+    }
+
+    function signed256(uint256 n) internal pure returns (int256) {
+        if (n > uint256(type(int256).max)) revert InvalidInt256();
+        return int256(n);
+    }
+}

--- a/contracts/ConstantPriceFeed.sol
+++ b/contracts/ConstantPriceFeed.sol
@@ -5,7 +5,6 @@ import "./vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.
 
 contract ConstantPriceFeed is AggregatorV3Interface {
     /** Custom errors **/
-    error InvalidInt256();
     error NotImplemented();
 
     /// @notice Version of the price feed
@@ -18,15 +17,15 @@ contract ConstantPriceFeed is AggregatorV3Interface {
     uint8 public immutable override decimals;
 
     /// @notice The constant price
-    int private immutable CONSTANT_PRICE;
+    int public immutable constantPrice;
 
     /**
      * @notice Construct a new scaling price feed
      * @param decimals_ The number of decimals for the returned prices
      **/
-    constructor(uint8 decimals_) {
+    constructor(uint8 decimals_, int256 constantPrice_) {
         decimals = decimals_;
-        CONSTANT_PRICE = signed256(10 ** decimals_);
+        constantPrice = constantPrice_;
     }
 
     /**
@@ -51,11 +50,6 @@ contract ConstantPriceFeed is AggregatorV3Interface {
         uint256 updatedAt,
         uint80 answeredInRound
     ) {
-        return (0, CONSTANT_PRICE, block.timestamp, block.timestamp, 0);
-    }
-
-    function signed256(uint256 n) internal pure returns (int256) {
-        if (n > uint256(type(int256).max)) revert InvalidInt256();
-        return int256(n);
+        return (0, constantPrice, block.timestamp, block.timestamp, 0);
     }
 }

--- a/contracts/IERC20NonStandard.sol
+++ b/contracts/IERC20NonStandard.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.15;
+
+/**
+ * @title IERC20NonStandard
+ * @dev Version of ERC20 with no return values for `transfer` and `transferFrom`
+ *  See https://medium.com/coinmonks/missing-return-value-bug-at-least-130-tokens-affected-d67bf08521ca
+ */
+interface IERC20NonStandard {
+    function approve(address spender, uint256 amount) external;
+    function transfer(address to, uint256 value) external;
+    function transferFrom(address from, address to, uint256 value) external;
+    function balanceOf(address account) external view returns (uint256);
+}

--- a/contracts/IPriceFeed.sol
+++ b/contracts/IPriceFeed.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.15;
+
+/**
+ * @dev Interface for price feeds used by Comet
+ * Note This is Chainlink's AggregatorV3Interface, but without the `getRoundData` function.
+ */
+interface IPriceFeed {
+  function decimals() external view returns (uint8);
+
+  function description() external view returns (string memory);
+
+  function version() external view returns (uint256);
+
+  function latestRoundData()
+    external
+    view
+    returns (
+      uint80 roundId,
+      int256 answer,
+      uint256 startedAt,
+      uint256 updatedAt,
+      uint80 answeredInRound
+    );
+}

--- a/contracts/ScalingPriceFeed.sol
+++ b/contracts/ScalingPriceFeed.sol
@@ -46,22 +46,22 @@ contract ScalingPriceFeed is AggregatorV3Interface {
 
     /**
      * @notice Price for a specific round
-     * @param roundId_ The round id to fetch the price for
+     * @param _roundId The round id to fetch the price for
      * @return roundId Round id from the underlying price feed
      * @return answer Latest price for the asset in terms of ETH
      * @return startedAt Timestamp when the round was started; passed on from underlying price feed
      * @return updatedAt Timestamp when the round was last updated; passed on from underlying price feed
      * @return answeredInRound Round id in which the answer was computed; passed on from underlying price feed
      **/
-    function getRoundData(uint80 roundId_) external view returns (
+    function getRoundData(uint80 _roundId) external view returns (
         uint80 roundId,
         int256 answer,
         uint256 startedAt,
         uint256 updatedAt,
         uint80 answeredInRound
     ) {
-        (uint80 roundId, int256 price, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = AggregatorV3Interface(underlyingPriceFeed).getRoundData(roundId_);
-        return (roundId, scalePrice(price), startedAt, updatedAt, answeredInRound);
+        (uint80 roundId_, int256 price, uint256 startedAt_, uint256 updatedAt_, uint80 answeredInRound_) = AggregatorV3Interface(underlyingPriceFeed).getRoundData(_roundId);
+        return (roundId_, scalePrice(price), startedAt_, updatedAt_, answeredInRound_);
     }
 
     /**
@@ -79,8 +79,8 @@ contract ScalingPriceFeed is AggregatorV3Interface {
         uint256 updatedAt,
         uint80 answeredInRound
     ) {
-        (uint80 roundId, int256 price, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = AggregatorV3Interface(underlyingPriceFeed).latestRoundData();
-        return (roundId, scalePrice(price), startedAt, updatedAt, answeredInRound);
+        (uint80 roundId_, int256 price, uint256 startedAt_, uint256 updatedAt_, uint80 answeredInRound_) = AggregatorV3Interface(underlyingPriceFeed).latestRoundData();
+        return (roundId_, scalePrice(price), startedAt_, updatedAt_, answeredInRound_);
     }
 
     function signed256(uint256 n) internal pure returns (int256) {

--- a/contracts/ScalingPriceFeed.sol
+++ b/contracts/ScalingPriceFeed.sol
@@ -14,7 +14,7 @@ contract ScalingPriceFeed is AggregatorV3Interface {
     uint8 public immutable override decimals;
 
     /// @notice Underlying Chainlink price feed where prices are fetched from
-    address public immutable priceFeed;
+    address public immutable underlyingPriceFeed;
 
     /// @notice Description of the price feed
     string public description;
@@ -27,15 +27,15 @@ contract ScalingPriceFeed is AggregatorV3Interface {
 
     /**
      * @notice Construct a new scaling price feed
-     * @param priceFeed_ The address of the underlying price feed to fetch prices from
+     * @param underlyingPriceFeed_ The address of the underlying price feed to fetch prices from
      * @param decimals_ The number of decimals for the returned prices
      **/
-    constructor(address priceFeed_, uint8 decimals_) {
-        priceFeed = priceFeed_;
+    constructor(address underlyingPriceFeed_, uint8 decimals_) {
+        underlyingPriceFeed = underlyingPriceFeed_;
         decimals = decimals_;
-        description = AggregatorV3Interface(priceFeed_).description();
+        description = AggregatorV3Interface(underlyingPriceFeed_).description();
 
-        uint8 chainlinkPriceFeedDecimals = AggregatorV3Interface(priceFeed_).decimals();
+        uint8 chainlinkPriceFeedDecimals = AggregatorV3Interface(underlyingPriceFeed_).decimals();
         // Note: Solidity does not allow setting immutables in if/else statements
         shouldUpscale = chainlinkPriceFeedDecimals < decimals_ ? true : false;
         rescaleFactor = (shouldUpscale
@@ -47,11 +47,11 @@ contract ScalingPriceFeed is AggregatorV3Interface {
     /**
      * @notice Price for a specific round
      * @param roundId_ The round id to fetch the price for
-     * @return roundId Round id from the stETH price feed
-     * @return answer Latest price for wstETH / USD
-     * @return startedAt Timestamp when the round was started; passed on from stETH price feed
-     * @return updatedAt Timestamp when the round was last updated; passed on from stETH price feed
-     * @return answeredInRound Round id in which the answer was computed; passed on from stETH price feed
+     * @return roundId Round id from the underlying price feed
+     * @return answer Latest price for the asset in terms of ETH
+     * @return startedAt Timestamp when the round was started; passed on from underlying price feed
+     * @return updatedAt Timestamp when the round was last updated; passed on from underlying price feed
+     * @return answeredInRound Round id in which the answer was computed; passed on from underlying price feed
      **/
     function getRoundData(uint80 roundId_) external view returns (
         uint80 roundId,
@@ -60,17 +60,17 @@ contract ScalingPriceFeed is AggregatorV3Interface {
         uint256 updatedAt,
         uint80 answeredInRound
     ) {
-        (uint80 roundId, int256 price, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = AggregatorV3Interface(priceFeed).getRoundData(roundId_);
+        (uint80 roundId, int256 price, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = AggregatorV3Interface(underlyingPriceFeed).getRoundData(roundId_);
         return (roundId, scalePrice(price), startedAt, updatedAt, answeredInRound);
     }
 
     /**
      * @notice Price for the latest round
-     * @return roundId Round id from the stETH price feed
-     * @return answer Latest price for wstETH / USD
-     * @return startedAt Timestamp when the round was started; passed on from stETH price feed
-     * @return updatedAt Timestamp when the round was last updated; passed on from stETH price feed
-     * @return answeredInRound Round id in which the answer was computed; passed on from stETH price feed
+     * @return roundId Round id from the underlying price feed
+     * @return answer Latest price for the asset in terms of ETH
+     * @return startedAt Timestamp when the round was started; passed on from underlying price feed
+     * @return updatedAt Timestamp when the round was last updated; passed on from underlying price feed
+     * @return answeredInRound Round id in which the answer was computed; passed on from underlying price feed
      **/
     function latestRoundData() external view returns (
         uint80 roundId,
@@ -79,7 +79,7 @@ contract ScalingPriceFeed is AggregatorV3Interface {
         uint256 updatedAt,
         uint80 answeredInRound
     ) {
-        (uint80 roundId, int256 price, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = AggregatorV3Interface(priceFeed).latestRoundData();
+        (uint80 roundId, int256 price, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = AggregatorV3Interface(underlyingPriceFeed).latestRoundData();
         return (roundId, scalePrice(price), startedAt, updatedAt, answeredInRound);
     }
 

--- a/contracts/ScalingPriceFeed.sol
+++ b/contracts/ScalingPriceFeed.sol
@@ -10,14 +10,14 @@ contract ScalingPriceFeed is AggregatorV3Interface {
     /// @notice Version of the price feed
     uint public constant override version = 1;
 
+    /// @notice Description of the price feed
+    string public description;
+
     /// @notice Number of decimals for returned prices
     uint8 public immutable override decimals;
 
     /// @notice Underlying Chainlink price feed where prices are fetched from
     address public immutable underlyingPriceFeed;
-
-    /// @notice Description of the price feed
-    string public description;
 
     /// @notice Whether or not the price should be upscaled
     bool internal immutable shouldUpscale;

--- a/contracts/ScalingPriceFeed.sol
+++ b/contracts/ScalingPriceFeed.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.15;
+
+import "./vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+contract ScalingPriceFeed is AggregatorV3Interface {
+    /** Custom errors **/
+    error InvalidInt256();
+
+    /// @notice Version of the price feed
+    uint public constant override version = 1;
+
+    /// @notice Number of decimals for returned prices
+    uint8 public immutable override decimals;
+
+    /// @notice Underlying Chainlink price feed where prices are fetched from
+    address public immutable priceFeed;
+
+    /// @notice Description of the price feed
+    string public description;
+
+    /// @notice Whether or not the price should be upscaled
+    bool internal immutable shouldUpscale;
+
+    /// @notice The amount to upscale or downscale the price by
+    int256 internal immutable rescaleFactor;
+
+    /**
+     * @notice Construct a new scaling price feed
+     * @param priceFeed_ The address of the underlying price feed to fetch prices from
+     * @param decimals_ The number of decimals for the returned prices
+     **/
+    constructor(address priceFeed_, uint8 decimals_) {
+        priceFeed = priceFeed_;
+        decimals = decimals_;
+        description = AggregatorV3Interface(priceFeed_).description();
+
+        uint8 chainlinkPriceFeedDecimals = AggregatorV3Interface(priceFeed_).decimals();
+        // Note: Solidity does not allow setting immutables in if/else statements
+        shouldUpscale = chainlinkPriceFeedDecimals < decimals_ ? true : false;
+        rescaleFactor = (shouldUpscale
+            ? signed256(10 ** (decimals_ - chainlinkPriceFeedDecimals))
+            : signed256(10 ** (chainlinkPriceFeedDecimals - decimals_))
+        );
+    }
+
+    /**
+     * @notice Price for a specific round
+     * @param roundId_ The round id to fetch the price for
+     * @return roundId Round id from the stETH price feed
+     * @return answer Latest price for wstETH / USD
+     * @return startedAt Timestamp when the round was started; passed on from stETH price feed
+     * @return updatedAt Timestamp when the round was last updated; passed on from stETH price feed
+     * @return answeredInRound Round id in which the answer was computed; passed on from stETH price feed
+     **/
+    function getRoundData(uint80 roundId_) external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        (uint80 roundId, int256 price, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = AggregatorV3Interface(priceFeed).getRoundData(roundId_);
+        return (roundId, scalePrice(price), startedAt, updatedAt, answeredInRound);
+    }
+
+    /**
+     * @notice Price for the latest round
+     * @return roundId Round id from the stETH price feed
+     * @return answer Latest price for wstETH / USD
+     * @return startedAt Timestamp when the round was started; passed on from stETH price feed
+     * @return updatedAt Timestamp when the round was last updated; passed on from stETH price feed
+     * @return answeredInRound Round id in which the answer was computed; passed on from stETH price feed
+     **/
+    function latestRoundData() external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        (uint80 roundId, int256 price, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = AggregatorV3Interface(priceFeed).latestRoundData();
+        return (roundId, scalePrice(price), startedAt, updatedAt, answeredInRound);
+    }
+
+    function signed256(uint256 n) internal pure returns (int256) {
+        if (n > uint256(type(int256).max)) revert InvalidInt256();
+        return int256(n);
+    }
+
+    function scalePrice(int256 price) internal view returns (int256) {
+        int256 scaledPrice;
+        if (shouldUpscale) {
+            scaledPrice = price * rescaleFactor;
+        } else {
+            scaledPrice = price / rescaleFactor;
+        }
+        return scaledPrice;
+    }
+}

--- a/contracts/ScalingPriceFeed.sol
+++ b/contracts/ScalingPriceFeed.sol
@@ -2,8 +2,9 @@
 pragma solidity 0.8.15;
 
 import "./vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import "./IPriceFeed.sol";
 
-contract ScalingPriceFeed is AggregatorV3Interface {
+contract ScalingPriceFeed is IPriceFeed {
     /** Custom errors **/
     error InvalidInt256();
 
@@ -45,26 +46,6 @@ contract ScalingPriceFeed is AggregatorV3Interface {
     }
 
     /**
-     * @notice Price for a specific round
-     * @param _roundId The round id to fetch the price for
-     * @return roundId Round id from the underlying price feed
-     * @return answer Latest price for the asset in terms of ETH
-     * @return startedAt Timestamp when the round was started; passed on from underlying price feed
-     * @return updatedAt Timestamp when the round was last updated; passed on from underlying price feed
-     * @return answeredInRound Round id in which the answer was computed; passed on from underlying price feed
-     **/
-    function getRoundData(uint80 _roundId) external view returns (
-        uint80 roundId,
-        int256 answer,
-        uint256 startedAt,
-        uint256 updatedAt,
-        uint80 answeredInRound
-    ) {
-        (uint80 roundId_, int256 price, uint256 startedAt_, uint256 updatedAt_, uint80 answeredInRound_) = AggregatorV3Interface(underlyingPriceFeed).getRoundData(_roundId);
-        return (roundId_, scalePrice(price), startedAt_, updatedAt_, answeredInRound_);
-    }
-
-    /**
      * @notice Price for the latest round
      * @return roundId Round id from the underlying price feed
      * @return answer Latest price for the asset in terms of ETH
@@ -72,7 +53,7 @@ contract ScalingPriceFeed is AggregatorV3Interface {
      * @return updatedAt Timestamp when the round was last updated; passed on from underlying price feed
      * @return answeredInRound Round id in which the answer was computed; passed on from underlying price feed
      **/
-    function latestRoundData() external view returns (
+    function latestRoundData() override external view returns (
         uint80 roundId,
         int256 answer,
         uint256 startedAt,

--- a/contracts/WstETHPriceFeed.sol
+++ b/contracts/WstETHPriceFeed.sol
@@ -2,9 +2,10 @@
 pragma solidity 0.8.15;
 
 import "./vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import "./IPriceFeed.sol";
 import "./IWstETH.sol";
 
-contract WstETHPriceFeed is AggregatorV3Interface {
+contract WstETHPriceFeed is IPriceFeed {
     /** Custom errors **/
     error BadDecimals();
     error InvalidInt256();
@@ -44,30 +45,6 @@ contract WstETHPriceFeed is AggregatorV3Interface {
     function signed256(uint256 n) internal pure returns (int256) {
         if (n > uint256(type(int256).max)) revert InvalidInt256();
         return int256(n);
-    }
-
-    /**
-     * @notice WstETH price for a specific round
-     * @param _roundId The round id to fetch the price for
-     * @return roundId Round id from the stETH price feed
-     * @return answer Latest price for wstETH / USD
-     * @return startedAt Timestamp when the round was started; passed on from stETH price feed
-     * @return updatedAt Timestamp when the round was last updated; passed on from stETH price feed
-     * @return answeredInRound Round id in which the answer was computed; passed on from stETH price feed
-     **/
-    function getRoundData(uint80 _roundId) override external view returns (
-        uint80 roundId,
-        int256 answer,
-        uint256 startedAt,
-        uint256 updatedAt,
-        uint80 answeredInRound
-    ) {
-        (uint80 roundId_, int256 stETHPrice, uint256 startedAt_, uint256 updatedAt_, uint80 answeredInRound_) = AggregatorV3Interface(stETHtoETHPriceFeed).getRoundData(_roundId);
-        uint256 tokensPerStEth = IWstETH(wstETH).tokensPerStEth();
-        int256 price = stETHPrice * int256(wstETHScale) / signed256(tokensPerStEth);
-        // Note: Assumes the stETH price feed has an equal or larger amount of decimals than this price feed
-        int256 scaledPrice = price / int256(10 ** (stETHToETHPriceFeedDecimals - decimals));
-        return (roundId_, scaledPrice, startedAt_, updatedAt_, answeredInRound_);
     }
 
     /**

--- a/contracts/WstETHPriceFeed.sol
+++ b/contracts/WstETHPriceFeed.sol
@@ -45,26 +45,26 @@ contract WstETHPriceFeed is AggregatorV3Interface {
 
     /**
      * @notice WstETH price for a specific round
-     * @param roundId_ The round id to fetch the price for
+     * @param _roundId The round id to fetch the price for
      * @return roundId Round id from the stETH price feed
      * @return answer Latest price for wstETH / USD
      * @return startedAt Timestamp when the round was started; passed on from stETH price feed
      * @return updatedAt Timestamp when the round was last updated; passed on from stETH price feed
      * @return answeredInRound Round id in which the answer was computed; passed on from stETH price feed
      **/
-    function getRoundData(uint80 roundId_) override external view returns (
+    function getRoundData(uint80 _roundId) override external view returns (
         uint80 roundId,
         int256 answer,
         uint256 startedAt,
         uint256 updatedAt,
         uint80 answeredInRound
     ) {
-        (uint80 roundId, int256 stETHPrice, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = AggregatorV3Interface(stETHtoETHPriceFeed).getRoundData(roundId_);
+        (uint80 roundId_, int256 stETHPrice, uint256 startedAt_, uint256 updatedAt_, uint80 answeredInRound_) = AggregatorV3Interface(stETHtoETHPriceFeed).getRoundData(_roundId);
         uint256 tokensPerStEth = IWstETH(wstETH).tokensPerStEth();
         int256 price = stETHPrice * int256(wstETHScale) / signed256(tokensPerStEth);
         // Note: Assumes the stETH price feed has a greater or equal number of decimals than this price feed
         int256 scaledPrice = price / int256(10 ** (stETHPriceFeedDecimals - decimals));
-        return (roundId, scaledPrice, startedAt, updatedAt, answeredInRound);
+        return (roundId_, scaledPrice, startedAt_, updatedAt_, answeredInRound_);
     }
 
     /**
@@ -82,11 +82,11 @@ contract WstETHPriceFeed is AggregatorV3Interface {
         uint256 updatedAt,
         uint80 answeredInRound
     ) {
-        (uint80 roundId, int256 stETHPrice, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = AggregatorV3Interface(stETHtoETHPriceFeed).latestRoundData();
+        (uint80 roundId_, int256 stETHPrice, uint256 startedAt_, uint256 updatedAt_, uint80 answeredInRound_) = AggregatorV3Interface(stETHtoETHPriceFeed).latestRoundData();
         uint256 tokensPerStEth = IWstETH(wstETH).tokensPerStEth();
         int256 price = stETHPrice * int256(wstETHScale) / signed256(tokensPerStEth);
         // Note: Assumes the stETH price feed has a greater or equal number of decimals than this price feed
         int256 scaledPrice = price / int256(10 ** (stETHPriceFeedDecimals - decimals));
-        return (roundId, scaledPrice, startedAt, updatedAt, answeredInRound);
+        return (roundId_, scaledPrice, startedAt_, updatedAt_, answeredInRound_);
     }
 }

--- a/contracts/WstETHPriceFeed.sol
+++ b/contracts/WstETHPriceFeed.sol
@@ -8,18 +8,20 @@ contract WstETHPriceFeed is AggregatorV3Interface {
     /** Custom errors **/
     error InvalidInt256();
 
-    string public constant override description = "Custom price feed for wstETH / ETH";
-
+    /// @notice Version of the price feed
     uint public constant override version = 1;
+
+    /// @notice Description of the price feed
+    string public constant override description = "Custom price feed for wstETH / ETH";
 
     /// @notice Number of decimals for returned prices
     uint8 public override decimals = 8;
 
-    /// @notice Number of decimals for the stETH price feed
-    uint public immutable stETHPriceFeedDecimals;
-
     /// @notice Chainlink stETH / ETH price feed
     address public immutable stETHtoETHPriceFeed;
+
+    /// @notice Number of decimals for the stETH / ETH price feed
+    uint public immutable stETHToETHPriceFeedDecimals;
 
     /// @notice WstETH contract address
     address public immutable wstETH;
@@ -29,7 +31,7 @@ contract WstETHPriceFeed is AggregatorV3Interface {
 
     constructor(address stETHtoETHPriceFeed_, address wstETH_) {
         stETHtoETHPriceFeed = stETHtoETHPriceFeed_;
-        stETHPriceFeedDecimals = AggregatorV3Interface(stETHtoETHPriceFeed_).decimals();
+        stETHToETHPriceFeedDecimals = AggregatorV3Interface(stETHtoETHPriceFeed_).decimals();
         wstETH = wstETH_;
         wstETHScale = 10 ** IWstETH(wstETH).decimals();
     }
@@ -59,7 +61,7 @@ contract WstETHPriceFeed is AggregatorV3Interface {
         uint256 tokensPerStEth = IWstETH(wstETH).tokensPerStEth();
         int256 price = stETHPrice * int256(wstETHScale) / signed256(tokensPerStEth);
         // Note: Assumes the stETH price feed has a greater or equal number of decimals than this price feed
-        int256 scaledPrice = price / int256(10 ** (stETHPriceFeedDecimals - decimals));
+        int256 scaledPrice = price / int256(10 ** (stETHToETHPriceFeedDecimals - decimals));
         return (roundId_, scaledPrice, startedAt_, updatedAt_, answeredInRound_);
     }
 
@@ -82,7 +84,7 @@ contract WstETHPriceFeed is AggregatorV3Interface {
         uint256 tokensPerStEth = IWstETH(wstETH).tokensPerStEth();
         int256 price = stETHPrice * int256(wstETHScale) / signed256(tokensPerStEth);
         // Note: Assumes the stETH price feed has a greater or equal number of decimals than this price feed
-        int256 scaledPrice = price / int256(10 ** (stETHPriceFeedDecimals - decimals));
+        int256 scaledPrice = price / int256(10 ** (stETHToETHPriceFeedDecimals - decimals));
         return (roundId_, scaledPrice, startedAt_, updatedAt_, answeredInRound_);
     }
 }

--- a/contracts/WstETHPriceFeed.sol
+++ b/contracts/WstETHPriceFeed.sol
@@ -29,13 +29,14 @@ contract WstETHPriceFeed is IPriceFeed {
     address public immutable wstETH;
 
     /// @notice Scale for WstETH contract
-    uint public immutable wstETHScale;
+    int public immutable wstETHScale;
 
     constructor(address stETHtoETHPriceFeed_, address wstETH_, uint8 decimals_) {
         stETHtoETHPriceFeed = stETHtoETHPriceFeed_;
         stETHToETHPriceFeedDecimals = AggregatorV3Interface(stETHtoETHPriceFeed_).decimals();
         wstETH = wstETH_;
-        wstETHScale = 10 ** IWstETH(wstETH).decimals();
+        // Note: Safe to convert directly to an int256 because wstETH.decimals == 18
+        wstETHScale = int256(10 ** IWstETH(wstETH).decimals());
 
         // Note: stETH / ETH price feed has 18 decimals so `decimals_` should always be less than or equals to that
         if (decimals_ > stETHToETHPriceFeedDecimals) revert BadDecimals();
@@ -64,7 +65,7 @@ contract WstETHPriceFeed is IPriceFeed {
     ) {
         (uint80 roundId_, int256 stETHPrice, uint256 startedAt_, uint256 updatedAt_, uint80 answeredInRound_) = AggregatorV3Interface(stETHtoETHPriceFeed).latestRoundData();
         uint256 tokensPerStEth = IWstETH(wstETH).tokensPerStEth();
-        int256 price = stETHPrice * int256(wstETHScale) / signed256(tokensPerStEth);
+        int256 price = stETHPrice * wstETHScale / signed256(tokensPerStEth);
         // Note: Assumes the stETH price feed has an equal or larger amount of decimals than this price feed
         int256 scaledPrice = price / int256(10 ** (stETHToETHPriceFeedDecimals - decimals));
         return (roundId_, scaledPrice, startedAt_, updatedAt_, answeredInRound_);

--- a/contracts/WstETHPriceFeed.sol
+++ b/contracts/WstETHPriceFeed.sol
@@ -2,11 +2,7 @@
 pragma solidity 0.8.15;
 
 import "./vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
-
-interface IWstETH {
-    function decimals() external view returns (uint8);
-    function tokensPerStEth() external view returns (uint256);
-}
+import "./IWstETH.sol";
 
 contract WstETHPriceFeed is AggregatorV3Interface {
     /** Custom errors **/

--- a/contracts/WstETHPriceFeed.sol
+++ b/contracts/WstETHPriceFeed.sol
@@ -11,26 +11,29 @@ interface IWstETH {
 contract WstETHPriceFeed is AggregatorV3Interface {
     /** Custom errors **/
     error InvalidInt256();
-    error NotImplemented();
 
-    string public constant override description = "Custom price feed for wstETH / USD";
+    string public constant override description = "Custom price feed for wstETH / ETH";
 
     uint public constant override version = 1;
 
-    /// @notice Scale for returned prices
+    /// @notice Number of decimals for returned prices
     uint8 public override decimals = 8;
 
-    /// @notice Chainlink stETH / USD price feed
-    address public immutable stETHtoUSDPriceFeed;
+    /// @notice Number of decimals for the stETH price feed
+    uint public immutable stETHPriceFeedDecimals;
+
+    /// @notice Chainlink stETH / ETH price feed
+    address public immutable stETHtoETHPriceFeed;
 
     /// @notice WstETH contract address
     address public immutable wstETH;
 
-    /// @notice scale for WstETH contract
+    /// @notice Scale for WstETH contract
     uint public immutable wstETHScale;
 
-    constructor(address stETHtoUSDPriceFeed_, address wstETH_) {
-        stETHtoUSDPriceFeed = stETHtoUSDPriceFeed_;
+    constructor(address stETHtoETHPriceFeed_, address wstETH_) {
+        stETHtoETHPriceFeed = stETHtoETHPriceFeed_;
+        stETHPriceFeedDecimals = AggregatorV3Interface(stETHtoETHPriceFeed_).decimals();
         wstETH = wstETH_;
         wstETHScale = 10 ** IWstETH(wstETH).decimals();
     }
@@ -41,20 +44,31 @@ contract WstETHPriceFeed is AggregatorV3Interface {
     }
 
     /**
-     * @notice Unimplemented function required to fulfill AggregatorV3Interface; always reverts
+     * @notice WstETH price for a specific round
+     * @param roundId_ The round id to fetch the price for
+     * @return roundId Round id from the stETH price feed
+     * @return answer Latest price for wstETH / USD
+     * @return startedAt Timestamp when the round was started; passed on from stETH price feed
+     * @return updatedAt Timestamp when the round was last updated; passed on from stETH price feed
+     * @return answeredInRound Round id in which the answer was computed; passed on from stETH price feed
      **/
-    function getRoundData(uint80 _roundId) override external view returns (
+    function getRoundData(uint80 roundId_) override external view returns (
         uint80 roundId,
         int256 answer,
         uint256 startedAt,
         uint256 updatedAt,
         uint80 answeredInRound
     ) {
-        revert NotImplemented();
+        (uint80 roundId, int256 stETHPrice, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = AggregatorV3Interface(stETHtoETHPriceFeed).getRoundData(roundId_);
+        uint256 tokensPerStEth = IWstETH(wstETH).tokensPerStEth();
+        int256 price = stETHPrice * int256(wstETHScale) / signed256(tokensPerStEth);
+        // Note: Assumes the stETH price feed has a greater or equal number of decimals than this price feed
+        int256 scaledPrice = price / int256(10 ** (stETHPriceFeedDecimals - decimals));
+        return (roundId, scaledPrice, startedAt, updatedAt, answeredInRound);
     }
 
     /**
-     * @notice WstETH Price for the latest round
+     * @notice WstETH price for the latest round
      * @return roundId Round id from the stETH price feed
      * @return answer Latest price for wstETH / USD
      * @return startedAt Timestamp when the round was started; passed on from stETH price feed
@@ -68,9 +82,11 @@ contract WstETHPriceFeed is AggregatorV3Interface {
         uint256 updatedAt,
         uint80 answeredInRound
     ) {
-        (uint80 roundId, int256 stETHPrice, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = AggregatorV3Interface(stETHtoUSDPriceFeed).latestRoundData();
+        (uint80 roundId, int256 stETHPrice, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = AggregatorV3Interface(stETHtoETHPriceFeed).latestRoundData();
         uint256 tokensPerStEth = IWstETH(wstETH).tokensPerStEth();
         int256 price = stETHPrice * int256(wstETHScale) / signed256(tokensPerStEth);
-        return (roundId, price, startedAt, updatedAt, answeredInRound);
+        // Note: Assumes the stETH price feed has a greater or equal number of decimals than this price feed
+        int256 scaledPrice = price / int256(10 ** (stETHPriceFeedDecimals - decimals));
+        return (roundId, scaledPrice, startedAt, updatedAt, answeredInRound);
     }
 }

--- a/contracts/bulkers/MainnetBulker.sol
+++ b/contracts/bulkers/MainnetBulker.sol
@@ -4,13 +4,34 @@ pragma solidity 0.8.15;
 import "./BaseBulker.sol";
 import "../IWstETH.sol";
 
+/**
+ * @title Compound's Bulker contract for Ethereum mainnet
+ * @notice Executes multiple Comet-related actions in a single transaction
+ * @author Compound
+ */
 contract MainnetBulker is BaseBulker {
+    /** General configuration constants **/
+
+    /// @notice The address of Lido staked ETH
     address public immutable steth;
+
+    /// @notice The address of Lido wrapped staked ETH
     address public immutable wsteth;
 
+    /** Actions **/
+
+    /// @notice The action for supplying staked ETH to Comet
     bytes32 public constant ACTION_SUPPLY_STETH = "ACTION_SUPPLY_STETH";
+
+    /// @notice The action for withdrawing staked ETH from Comet
     bytes32 public constant ACTION_WITHDRAW_STETH = "ACTION_WITHDRAW_STETH";
 
+    /**
+     * @notice Construct a new MainnetBulker instance
+     * @param admin_ The admin of the Bulker contract
+     * @param weth_ The address of wrapped ETH
+     * @param wsteth_ The address of Lido wrapped staked ETH
+     **/
     constructor(
         address admin_,
         address payable weth_,
@@ -20,6 +41,9 @@ contract MainnetBulker is BaseBulker {
         steth = IWstETH(wsteth_).stETH();
     }
 
+    /**
+     * @notice Handles actions specific to the Ethereum mainnet version of Bulker, specifically supplying and withdrawing stETH
+     */
     function handleAction(bytes32 action, bytes calldata data) override internal {
         if (action == ACTION_SUPPLY_STETH) {
             (address comet, address to, uint stETHAmount) = abi.decode(data, (address, address, uint));
@@ -33,27 +57,24 @@ contract MainnetBulker is BaseBulker {
     }
 
     /**
-     * @notice Wraps stETH with wstETH and supplies to a user in Comet
+     * @notice Wraps stETH to wstETH and supplies to a user in Comet
+     * @dev Note: This contract must have permission to manage msg.sender's Comet account
      */
     function supplyStEthTo(address comet, address to, uint stETHAmount) internal {
-        // transfer in from stETH
-        ERC20(steth).transferFrom(msg.sender, address(this), stETHAmount);
-        // approve stETHAmount to the wstETH contract
+        doTransferIn(steth, msg.sender, stETHAmount);
         ERC20(steth).approve(wsteth, stETHAmount);
-        // wrap stETHAmount
         uint wstETHAmount = IWstETH(wsteth).wrap(stETHAmount);
-        // approve Comet for the wstETH amount
         ERC20(wsteth).approve(comet, wstETHAmount);
-        // supply
         CometInterface(comet).supplyFrom(address(this), to, wsteth, wstETHAmount);
     }
 
     /**
-     * @notice Withdraws wstETH from Comet to a user after unwrapping it to stETH
+     * @notice Withdraws wstETH from Comet, unwraps it to stETH, and transfers it to a user
+     * @dev Note: This contract must have permission to manage msg.sender's Comet account
      */
     function withdrawStEthTo(address comet, address to, uint wstETHAmount) internal {
         CometInterface(comet).withdrawFrom(msg.sender, address(this), wsteth, wstETHAmount);
         uint stETHAmount = IWstETH(wsteth).unwrap(wstETHAmount);
-        ERC20(steth).transfer(to, stETHAmount);
+        doTransferOut(steth, to, stETHAmount);
     }
 }

--- a/contracts/test/NonStandardFaucetToken.sol
+++ b/contracts/test/NonStandardFaucetToken.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.15;
+
+/**
+ * @title Non-standard ERC20 token
+ * @dev Implementation of the basic standard token.
+ *  See https://github.com/ethereum/EIPs/issues/20
+ * @dev Note: `transfer` and `transferFrom` do not return a boolean
+ */
+contract NonStandardToken {
+    string public name;
+    string public symbol;
+    uint8 public decimals;
+    uint256 public totalSupply;
+    mapping (address => mapping (address => uint256)) public allowance;
+    mapping(address => uint256) public balanceOf;
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    constructor(uint256 _initialAmount, string memory _tokenName, uint8 _decimalUnits, string memory _tokenSymbol) {
+        totalSupply = _initialAmount;
+        balanceOf[msg.sender] = _initialAmount;
+        name = _tokenName;
+        symbol = _tokenSymbol;
+        decimals = _decimalUnits;
+    }
+
+    function transfer(address dst, uint256 amount) external virtual {
+        require(amount <= balanceOf[msg.sender], "ERC20: transfer amount exceeds balance");
+        balanceOf[msg.sender] = balanceOf[msg.sender] - amount;
+        balanceOf[dst] = balanceOf[dst] + amount;
+        emit Transfer(msg.sender, dst, amount);
+    }
+
+    function transferFrom(address src, address dst, uint256 amount) external virtual {
+        require(amount <= allowance[src][msg.sender], "ERC20: transfer amount exceeds allowance");
+        require(amount <= balanceOf[src], "ERC20: transfer amount exceeds balance");
+        allowance[src][msg.sender] = allowance[src][msg.sender] - amount;
+        balanceOf[src] = balanceOf[src] - amount;
+        balanceOf[dst] = balanceOf[dst] + amount;
+        emit Transfer(src, dst, amount);
+    }
+
+    function approve(address _spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][_spender] = amount;
+        emit Approval(msg.sender, _spender, amount);
+        return true;
+    }
+}
+
+/**
+ * @title The Compound Faucet Test Token
+ * @author Compound
+ * @notice A simple test token that lets anyone get more of it.
+ */
+contract NonStandardFaucetToken is NonStandardToken {
+    constructor(uint256 _initialAmount, string memory _tokenName, uint8 _decimalUnits, string memory _tokenSymbol)
+        NonStandardToken(_initialAmount, _tokenName, _decimalUnits, _tokenSymbol) {
+    }
+
+    function allocateTo(address _owner, uint256 value) public {
+        balanceOf[_owner] += value;
+        totalSupply += value;
+        emit Transfer(address(this), _owner, value);
+    }
+}

--- a/deployments/mainnet/weth/configuration.json
+++ b/deployments/mainnet/weth/configuration.json
@@ -3,7 +3,6 @@
   "symbol": "cWETHv3",
   "baseToken": "WETH",
   "baseTokenAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-  "baseTokenPriceFeed": "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
   "borrowMin": "100e6",
   "governor": "0x6d903f6003cca6255d85cca4d3b5e5146dc33925",
   "pauseGuardian": "0xbbf3f1421d886e9b2c5d716b5192ac998af2012c",

--- a/deployments/mainnet/weth/configuration.json
+++ b/deployments/mainnet/weth/configuration.json
@@ -27,7 +27,6 @@
   "assets": {
     "cbETH": {
       "address": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
-      "priceFeed": "0x67eF3CAF8BeB93149F48e8d20920BEC9b4320510",
       "decimals": "18",
       "borrowCF": 0.80,
       "liquidateCF": 0.85,

--- a/deployments/mainnet/weth/deploy.ts
+++ b/deployments/mainnet/weth/deploy.ts
@@ -31,7 +31,7 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
     'cbETH:priceFeed',
     'ScalingPriceFeed.sol',
     [
-      '0x86392dC19c0b719886221c78AB11eb8Cf5c52812', // XXX using stETH / ETH price feed until cbETH / ETH is deployed
+      '0xF017fcB346A1885194689bA23Eff2fE6fA5C483b', // cbETH / ETH price feed
       8                                             // decimals
     ]
   );

--- a/deployments/mainnet/weth/deploy.ts
+++ b/deployments/mainnet/weth/deploy.ts
@@ -10,7 +10,7 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
     'wstETH:priceFeed',
     'WstETHPriceFeed.sol',
     [
-      '0xcfe54b5cd566ab89272946f602d76ea879cab4a8', // stETHtoUSDPriceFeed
+      '0x86392dC19c0b719886221c78AB11eb8Cf5c52812', // stETHtoETHPriceFeed
       wstETH.address                                // wstETH
     ]
   );

--- a/deployments/mainnet/weth/deploy.ts
+++ b/deployments/mainnet/weth/deploy.ts
@@ -11,7 +11,8 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
     'WstETHPriceFeed.sol',
     [
       '0x86392dC19c0b719886221c78AB11eb8Cf5c52812', // stETHtoETHPriceFeed
-      wstETH.address                                // wstETH
+      wstETH.address,                                // wstETH
+      8                                             // decimals
     ]
   );
 

--- a/deployments/mainnet/weth/deploy.ts
+++ b/deployments/mainnet/weth/deploy.ts
@@ -15,6 +15,15 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
     ]
   );
 
+  // Deploy constant price feed for WETH
+  const wethConstantPriceFeed = await deploymentManager.deploy(
+    'WETH:priceFeed',
+    'ConstantPriceFeed.sol',
+    [
+      8                                             // decimals
+    ]
+  );
+
   // Deploy all Comet-related contracts
   const deployed = await deployComet(deploymentManager, deploySpec);
   const { comet } = deployed;

--- a/deployments/mainnet/weth/deploy.ts
+++ b/deployments/mainnet/weth/deploy.ts
@@ -1,5 +1,5 @@
 import { Deployed, DeploymentManager } from '../../../plugins/deployment_manager';
-import { DeploySpec, deployComet } from '../../../src/deploy';
+import { DeploySpec, deployComet, exp } from '../../../src/deploy';
 
 export default async function deploy(deploymentManager: DeploymentManager, deploySpec: DeploySpec): Promise<Deployed> {
   const stETH = await deploymentManager.existing('stETH', '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84');
@@ -20,7 +20,8 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
     'WETH:priceFeed',
     'ConstantPriceFeed.sol',
     [
-      8                                             // decimals
+      8,                                             // decimals
+      exp(1, 8)                                      // constantPrice
     ]
   );
 

--- a/deployments/mainnet/weth/deploy.ts
+++ b/deployments/mainnet/weth/deploy.ts
@@ -24,6 +24,16 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
     ]
   );
 
+  // Deploy scaling price feed for cbETH
+  const cbETHScalingPriceFeed = await deploymentManager.deploy(
+    'cbETH:priceFeed',
+    'ScalingPriceFeed.sol',
+    [
+      '0x86392dC19c0b719886221c78AB11eb8Cf5c52812', // XXX using stETH / ETH price feed until cbETH / ETH is deployed
+      8                                             // decimals
+    ]
+  );
+
   // Deploy all Comet-related contracts
   const deployed = await deployComet(deploymentManager, deploySpec);
   const { comet } = deployed;

--- a/plugins/deployment_manager/Cache.ts
+++ b/plugins/deployment_manager/Cache.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs/promises';
 import * as nodepath from 'path';
 import { inspect } from 'util';
-import { fileExists, objectFromMap, objectToMap } from './Utils';
+import { fileExists, objectFromMap, objectToMap, stringifyJson } from './Utils';
 
 export type FileSpec = string | string[] | { rel: string | string[] } | { top: string | string[] };
 
@@ -27,17 +27,6 @@ function parseJson<K>(x: string | undefined): K {
   } else {
     return JSON.parse(x);
   }
-}
-
-function stringifyJson<K>(k: K): string {
-  return JSON.stringify(
-    k,
-    (_key, value) =>
-      typeof value === 'bigint'
-        ? value.toString()
-        : value,
-    4
-  );
 }
 
 type CacheMap = Map<string, any | CacheMap>;

--- a/plugins/deployment_manager/Deploy.ts
+++ b/plugins/deployment_manager/Deploy.ts
@@ -8,7 +8,7 @@ import { putVerifyArgs } from './VerifyArgs';
 import { Cache } from './Cache';
 import { storeBuildFile } from './ContractMap';
 import { BuildFile, TraceFn } from './Types';
-import { debug, getPrimaryContract } from './Utils';
+import { debug, getPrimaryContract, stringifyJson } from './Utils';
 import { VerifyArgs, verifyContract, VerificationStrategy } from './Verify';
 
 export interface DeployOpts {
@@ -29,7 +29,7 @@ async function doDeploy<C extends Contract>(
   src: string
 ): Promise<C> {
   const trace = opts.trace ?? debug;
-  trace(`Deploying ${name} with args ${JSON.stringify(args)} via ${src}`);
+  trace(`Deploying ${name} with args ${stringifyJson(args)} via ${src}`);
   const contract = await factory.deploy(...args);
   await contract.deployed();
   trace(contract.deployTransaction, `Deployed ${name} @ ${contract.address}`);

--- a/plugins/deployment_manager/Utils.ts
+++ b/plugins/deployment_manager/Utils.ts
@@ -26,6 +26,17 @@ export function debug(...args: any[]) {
   }
 }
 
+export function stringifyJson<K>(k: K): string {
+  return JSON.stringify(
+    k,
+    (_key, value) =>
+      typeof value === 'bigint'
+        ? value.toString()
+        : value,
+    4
+  );
+}
+
 export async function fileExists(path: string): Promise<boolean> {
   try {
     await fs.stat(path);

--- a/scenario/SupplyScenario.ts
+++ b/scenario/SupplyScenario.ts
@@ -204,7 +204,7 @@ scenario(
       albert: { $base: 1000 }
     },
     cometBalances: {
-      betty: { $base: -1000 } // in units of asset, not wei
+      betty: { $base: '<= -1000' } // in units of asset, not wei
     },
   },
   async ({ comet, actors }, context) => {
@@ -216,7 +216,7 @@ scenario(
     const borrowRate = (await comet.getBorrowRate(utilization)).toBigInt();
 
     expect(await baseAsset.balanceOf(albert.address)).to.be.equal(1000n * scale);
-    expectApproximately(await betty.getCometBaseBalance(), -1000n * scale, getInterest(1000n * scale, borrowRate, 1n) + 1n);
+    expectApproximately(await betty.getCometBaseBalance(), -1000n * scale, getInterest(1000n * scale, borrowRate, 5n) + 1n);
 
     await baseAsset.approve(albert, comet.address);
     await albert.allow(betty, true);

--- a/scenario/utils/index.ts
+++ b/scenario/utils/index.ts
@@ -206,11 +206,11 @@ export function parseAmount(amount): ComparativeAmount {
       return amount >= 0 ? { val: amount, op: ComparisonOp.GTE } : { val: amount, op: ComparisonOp.LTE };
     case 'string':
       return matchGroup(amount, {
-        'GTE': />=\s*(\d+)/,
-        'GT': />\s*(\d+)/,
-        'LTE': /<=\s*(\d+)/,
-        'LT': /<\s*(\d+)/,
-        'EQ': /==\s*(\d+)/,
+        'GTE': />=\s*(-?\d+)/,
+        'GT': />\s*(-?\d+)/,
+        'LTE': /<=\s*(-?\d+)/,
+        'LT': /<\s*(-?\d+)/,
+        'EQ': /==\s*(-?\d+)/,
       });
     case 'object':
       return amount;

--- a/test/bulker-test.ts
+++ b/test/bulker-test.ts
@@ -1,5 +1,5 @@
-import { baseBalanceOf, ethers, expect, exp, makeProtocol, wait, makeBulker, defaultAssets, getGasUsed, makeRewards, fastForward } from './helpers';
-import { FaucetWETH__factory } from '../build/types';
+import { baseBalanceOf, ethers, expect, exp, makeProtocol, wait, makeBulker, defaultAssets, getGasUsed, makeRewards, fastForward, event } from './helpers';
+import { FaucetWETH__factory, NonStandardFaucetToken__factory } from '../build/types';
 
 // XXX Improve the "no permission" tests that should expect a custom error when
 // when https://github.com/nomiclabs/hardhat/issues/1618 gets fixed.
@@ -364,7 +364,38 @@ describe('bulker', function () {
   });
 
   describe('admin functions', function () {
-    it('sweep ERC20 token', async () => {
+    it('transferAdmin', async () => {
+      const protocol = await makeProtocol({});
+      const { governor, tokens: { WETH }, users: [alice] } = protocol;
+      const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
+      const { bulker } = bulkerInfo;
+
+      expect(await bulker.admin()).to.be.equal(governor.address);
+
+      // Admin transferred
+      const txn = await wait(bulker.connect(governor).transferAdmin(alice.address));
+
+      expect(event(txn, 0)).to.be.deep.equal({
+        AdminTransferred: {
+          oldAdmin: governor.address,
+          newAdmin: alice.address
+        }
+      });
+      expect(await bulker.admin()).to.be.equal(alice.address);
+    });
+
+    it('revert is transferAdmin called by non-admin', async () => {
+      const protocol = await makeProtocol({});
+      const { governor, tokens: { WETH }, users: [alice] } = protocol;
+      const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
+      const { bulker } = bulkerInfo;
+
+      await expect(
+        bulker.connect(alice).transferAdmin(alice.address)
+      ).to.be.revertedWith("custom error 'Unauthorized()'");
+    });
+
+    it('sweep standard ERC20 token', async () => {
       const protocol = await makeProtocol({});
       const { governor, tokens: { USDC, WETH }, users: [alice] } = protocol;
       const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
@@ -383,6 +414,35 @@ describe('bulker', function () {
 
       const newBulkerBalance = await USDC.balanceOf(bulker.address);
       const newGovBalance = await USDC.balanceOf(governor.address);
+
+      expect(newBulkerBalance.sub(oldBulkerBalance)).to.be.equal(-transferAmount);
+      expect(newGovBalance.sub(oldGovBalance)).to.be.equal(transferAmount);
+    });
+
+    it('sweep non-standard ERC20 token', async () => {
+      const protocol = await makeProtocol({});
+      const { governor, tokens: { WETH }, users: [alice] } = protocol;
+      const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
+      const { bulker } = bulkerInfo;
+
+      // Deploy non-standard token
+      const factory = (await ethers.getContractFactory('NonStandardFaucetToken')) as NonStandardFaucetToken__factory;
+      const nonStandardToken = await factory.deploy(1000e6, 'Tether', 6, 'USDT');
+      await nonStandardToken.deployed();
+
+      // Alice "accidentally" sends 10 non-standard tokens to the Bulker
+      const transferAmount = exp(10, 6);
+      await nonStandardToken.allocateTo(alice.address, transferAmount);
+      await nonStandardToken.connect(alice).transfer(bulker.address, transferAmount);
+
+      const oldBulkerBalance = await nonStandardToken.balanceOf(bulker.address);
+      const oldGovBalance = await nonStandardToken.balanceOf(governor.address);
+
+      // Governor sweeps tokens
+      await bulker.connect(governor).sweepToken(governor.address, nonStandardToken.address);
+
+      const newBulkerBalance = await nonStandardToken.balanceOf(bulker.address);
+      const newGovBalance = await nonStandardToken.balanceOf(governor.address);
 
       expect(newBulkerBalance.sub(oldBulkerBalance)).to.be.equal(-transferAmount);
       expect(newGovBalance.sub(oldGovBalance)).to.be.equal(transferAmount);

--- a/test/constant-price-feed-test.ts
+++ b/test/constant-price-feed-test.ts
@@ -38,7 +38,7 @@ describe('constant price feed', function () {
         updatedAt,
         answeredInRound
       } = await constantPriceFeed.latestRoundData();
-      const currentTimestamp = (await getBlock()).timestamp
+      const currentTimestamp = (await getBlock()).timestamp;
 
       expect(roundId).to.eq(0);
       expect(startedAt).to.eq(currentTimestamp);

--- a/test/constant-price-feed-test.ts
+++ b/test/constant-price-feed-test.ts
@@ -1,0 +1,57 @@
+import { ethers, exp, expect, getBlock } from './helpers';
+import {
+  ConstantPriceFeed__factory
+} from '../build/types';
+
+export async function makeConstantPriceFeed({ decimals }) {
+  const constantPriceFeedFactory = (await ethers.getContractFactory('ConstantPriceFeed')) as ConstantPriceFeed__factory;
+  const constantPriceFeed = await constantPriceFeedFactory.deploy(decimals);
+  await constantPriceFeed.deployed();
+
+  return constantPriceFeed;
+}
+
+describe('constant price feed', function () {
+  describe('latestRoundData', function () {
+    it('returns constant price for 8 decimals', async () => {
+      const constantPriceFeed = await makeConstantPriceFeed({ decimals: 8 });
+      const latestRoundData = await constantPriceFeed.latestRoundData();
+      const price = latestRoundData.answer.toBigInt();
+
+      expect(price).to.eq(exp(1, 8));
+    });
+
+    it('returns constant price for 18 decimals', async () => {
+      const constantPriceFeed = await makeConstantPriceFeed({ decimals: 18 });
+      const latestRoundData = await constantPriceFeed.latestRoundData();
+      const price = latestRoundData.answer.toBigInt();
+
+      expect(price).to.eq(exp(1, 18));
+    });
+
+    it('returns expected roundId, startedAt, updatedAt and answeredInRound values', async () => {
+      const constantPriceFeed = await makeConstantPriceFeed({ decimals: 18 });
+
+      const {
+        roundId,
+        startedAt,
+        updatedAt,
+        answeredInRound
+      } = await constantPriceFeed.latestRoundData();
+      const currentTimestamp = (await getBlock()).timestamp
+
+      expect(roundId).to.eq(0);
+      expect(startedAt).to.eq(currentTimestamp);
+      expect(updatedAt).to.eq(currentTimestamp);
+      expect(answeredInRound).to.eq(0);
+    });
+  });
+
+  it(`getRoundData > always reverts`, async () => {
+    const constantPriceFeed = await makeConstantPriceFeed({ decimals: 8 });
+
+    await expect(
+      constantPriceFeed.getRoundData(1)
+    ).to.be.revertedWith("custom error 'NotImplemented()'");
+  });
+});

--- a/test/constant-price-feed-test.ts
+++ b/test/constant-price-feed-test.ts
@@ -46,12 +46,4 @@ describe('constant price feed', function () {
       expect(answeredInRound).to.eq(0);
     });
   });
-
-  it(`getRoundData > always reverts`, async () => {
-    const constantPriceFeed = await makeConstantPriceFeed({ decimals: 8, constantPrice: exp(1, 8) });
-
-    await expect(
-      constantPriceFeed.getRoundData(1)
-    ).to.be.revertedWith("custom error 'NotImplemented()'");
-  });
 });

--- a/test/constant-price-feed-test.ts
+++ b/test/constant-price-feed-test.ts
@@ -3,9 +3,9 @@ import {
   ConstantPriceFeed__factory
 } from '../build/types';
 
-export async function makeConstantPriceFeed({ decimals }) {
+export async function makeConstantPriceFeed({ decimals, constantPrice }) {
   const constantPriceFeedFactory = (await ethers.getContractFactory('ConstantPriceFeed')) as ConstantPriceFeed__factory;
-  const constantPriceFeed = await constantPriceFeedFactory.deploy(decimals);
+  const constantPriceFeed = await constantPriceFeedFactory.deploy(decimals, constantPrice);
   await constantPriceFeed.deployed();
 
   return constantPriceFeed;
@@ -14,7 +14,7 @@ export async function makeConstantPriceFeed({ decimals }) {
 describe('constant price feed', function () {
   describe('latestRoundData', function () {
     it('returns constant price for 8 decimals', async () => {
-      const constantPriceFeed = await makeConstantPriceFeed({ decimals: 8 });
+      const constantPriceFeed = await makeConstantPriceFeed({ decimals: 8, constantPrice: exp(1, 8) });
       const latestRoundData = await constantPriceFeed.latestRoundData();
       const price = latestRoundData.answer.toBigInt();
 
@@ -22,7 +22,7 @@ describe('constant price feed', function () {
     });
 
     it('returns constant price for 18 decimals', async () => {
-      const constantPriceFeed = await makeConstantPriceFeed({ decimals: 18 });
+      const constantPriceFeed = await makeConstantPriceFeed({ decimals: 18, constantPrice: exp(1, 18) });
       const latestRoundData = await constantPriceFeed.latestRoundData();
       const price = latestRoundData.answer.toBigInt();
 
@@ -30,7 +30,7 @@ describe('constant price feed', function () {
     });
 
     it('returns expected roundId, startedAt, updatedAt and answeredInRound values', async () => {
-      const constantPriceFeed = await makeConstantPriceFeed({ decimals: 18 });
+      const constantPriceFeed = await makeConstantPriceFeed({ decimals: 18, constantPrice: exp(1, 18) });
 
       const {
         roundId,
@@ -48,7 +48,7 @@ describe('constant price feed', function () {
   });
 
   it(`getRoundData > always reverts`, async () => {
-    const constantPriceFeed = await makeConstantPriceFeed({ decimals: 8 });
+    const constantPriceFeed = await makeConstantPriceFeed({ decimals: 8, constantPrice: exp(1, 8) });
 
     await expect(
       constantPriceFeed.getRoundData(1)

--- a/test/scaling-price-feed-test.ts
+++ b/test/scaling-price-feed-test.ts
@@ -77,43 +77,6 @@ describe('scaling price feed', function () {
     expect(await scalingPriceFeed.description()).to.eq(await simplePriceFeed.description());
   });
 
-  describe('getRoundData', function () {
-    for (const { price, priceFeedDecimals, result } of testCases) {
-      it(`price (${price}), priceFeedDecimals (${priceFeedDecimals}) -> ${result}`, async () => {
-        const { scalingPriceFeed } = await makeScalingPriceFeed({ price, priceFeedDecimals });
-        const roundId = 999;
-        const roundData = await scalingPriceFeed.getRoundData(roundId);
-        const res = roundData.answer.toBigInt();
-
-        expect(res).to.eq(result);
-      });
-    }
-
-    it('passes along roundId, startedAt, updatedAt and answeredInRound values from underlying price feed', async () => {
-      const { simplePriceFeed, scalingPriceFeed } = await makeScalingPriceFeed({ price: exp(10, 18), priceFeedDecimals: 18 });
-
-      await simplePriceFeed.setRoundData(
-        exp(15, 18), // roundId_,
-        1,           // answer_,
-        exp(16, 8),  // startedAt_,
-        exp(17, 8),  // updatedAt_,
-        exp(18, 18)  // answeredInRound_
-      );
-
-      const {
-        roundId,
-        startedAt,
-        updatedAt,
-        answeredInRound
-      } = await scalingPriceFeed.getRoundData(exp(15, 18));
-
-      expect(roundId.toBigInt()).to.eq(exp(15, 18));
-      expect(startedAt.toBigInt()).to.eq(exp(16, 8));
-      expect(updatedAt.toBigInt()).to.eq(exp(17, 8));
-      expect(answeredInRound.toBigInt()).to.eq(exp(18, 18));
-    });
-  });
-
   describe('latestRoundData', function () {
     for (const { price, priceFeedDecimals, result } of testCases) {
       it(`price (${price}), priceFeedDecimals (${priceFeedDecimals}) -> ${result}`, async () => {

--- a/test/scaling-price-feed-test.ts
+++ b/test/scaling-price-feed-test.ts
@@ -1,0 +1,152 @@
+import { ethers, exp, expect } from './helpers';
+import {
+  SimplePriceFeed__factory,
+  ScalingPriceFeed__factory
+} from '../build/types';
+
+export async function makeScalingPriceFeed({ price, priceFeedDecimals }) {
+  const SimplePriceFeedFactory = (await ethers.getContractFactory('SimplePriceFeed')) as SimplePriceFeed__factory;
+  const simplePriceFeed = await SimplePriceFeedFactory.deploy(price, priceFeedDecimals);
+  await simplePriceFeed.deployed();
+
+  const scalingPriceFeedFactory = (await ethers.getContractFactory('ScalingPriceFeed')) as ScalingPriceFeed__factory;
+  const scalingPriceFeed = await scalingPriceFeedFactory.deploy(simplePriceFeed.address, 8);
+  await scalingPriceFeed.deployed();
+
+  return {
+    simplePriceFeed,
+    scalingPriceFeed
+  };
+}
+
+const testCases = [
+  // Price feeds with same amount of decimals as scaling
+  {
+    price: exp(100, 8),
+    priceFeedDecimals: 8,
+    result: exp(100, 8)
+  },
+  {
+    price: exp(123456, 8),
+    priceFeedDecimals: 8,
+    result: exp(123456, 8)
+  },
+  {
+    price: exp(-1000, 8),
+    priceFeedDecimals: 8,
+    result: exp(-1000, 8)
+  },
+  // Price feeds with more decimals than scaling
+  {
+    price: exp(100, 18),
+    priceFeedDecimals: 18,
+    result: exp(100, 8)
+  },
+  {
+    price: exp(123456, 18),
+    priceFeedDecimals: 18,
+    result: exp(123456, 8)
+  },
+  {
+    price: exp(-1000, 18),
+    priceFeedDecimals: 18,
+    result: exp(-1000, 8)
+  },
+  // Price feeds with less decimals than scaling
+  {
+    price: exp(100, 6),
+    priceFeedDecimals: 6,
+    result: exp(100, 8)
+  },
+  {
+    price: exp(123456, 6),
+    priceFeedDecimals: 6,
+    result: exp(123456, 8)
+  },
+  {
+    price: exp(-1000, 6),
+    priceFeedDecimals: 6,
+    result: exp(-1000, 8)
+  },
+];
+
+describe('scaling price feed', function () {
+  it(`description is set properly`, async () => {
+    const { simplePriceFeed, scalingPriceFeed } = await makeScalingPriceFeed({ price: exp(10, 18), priceFeedDecimals: 18 });
+
+    expect(await scalingPriceFeed.description()).to.eq(await simplePriceFeed.description());
+  });
+
+  describe('getRoundData', function () {
+    for (const { price, priceFeedDecimals, result } of testCases) {
+      it(`price (${price}), priceFeedDecimals (${priceFeedDecimals}) -> ${result}`, async () => {
+        const { scalingPriceFeed } = await makeScalingPriceFeed({ price, priceFeedDecimals });
+        const roundId = 999;
+        const roundData = await scalingPriceFeed.getRoundData(roundId);
+        const res = roundData.answer.toBigInt();
+
+        expect(res).to.eq(result);
+      });
+    }
+
+    it('passes along roundId, startedAt, updatedAt and answeredInRound values from underlying price feed', async () => {
+      const { simplePriceFeed, scalingPriceFeed } = await makeScalingPriceFeed({ price: exp(10, 18), priceFeedDecimals: 18 });
+
+      await simplePriceFeed.setRoundData(
+        exp(15, 18), // roundId_,
+        1,           // answer_,
+        exp(16, 8),  // startedAt_,
+        exp(17, 8),  // updatedAt_,
+        exp(18, 18)  // answeredInRound_
+      );
+
+      const {
+        roundId,
+        startedAt,
+        updatedAt,
+        answeredInRound
+      } = await scalingPriceFeed.getRoundData(exp(15, 18));
+
+      expect(roundId.toBigInt()).to.eq(exp(15, 18));
+      expect(startedAt.toBigInt()).to.eq(exp(16, 8));
+      expect(updatedAt.toBigInt()).to.eq(exp(17, 8));
+      expect(answeredInRound.toBigInt()).to.eq(exp(18, 18));
+    });
+  });
+
+  describe('latestRoundData', function () {
+    for (const { price, priceFeedDecimals, result } of testCases) {
+      it(`price (${price}), priceFeedDecimals (${priceFeedDecimals}) -> ${result}`, async () => {
+        const { scalingPriceFeed } = await makeScalingPriceFeed({ price, priceFeedDecimals });
+        const latestRoundData = await scalingPriceFeed.latestRoundData();
+        const res = latestRoundData.answer.toBigInt();
+
+        expect(res).to.eq(result);
+      });
+    }
+
+    it('passes along roundId, startedAt, updatedAt and answeredInRound values from underlying price feed', async () => {
+      const { simplePriceFeed, scalingPriceFeed } = await makeScalingPriceFeed({ price: exp(10, 18), priceFeedDecimals: 18 });
+
+      await simplePriceFeed.setRoundData(
+        exp(15, 18), // roundId_,
+        1,           // answer_,
+        exp(16, 8),  // startedAt_,
+        exp(17, 8),  // updatedAt_,
+        exp(18, 18)  // answeredInRound_
+      );
+
+      const {
+        roundId,
+        startedAt,
+        updatedAt,
+        answeredInRound
+      } = await scalingPriceFeed.latestRoundData();
+
+      expect(roundId.toBigInt()).to.eq(exp(15, 18));
+      expect(startedAt.toBigInt()).to.eq(exp(16, 8));
+      expect(updatedAt.toBigInt()).to.eq(exp(17, 8));
+      expect(answeredInRound.toBigInt()).to.eq(exp(18, 18));
+    });
+  });
+});

--- a/test/wsteth-price-feed.ts
+++ b/test/wsteth-price-feed.ts
@@ -76,46 +76,6 @@ describe('wstETH price feed', function () {
     )).to.be.revertedWith("custom error 'BadDecimals()'");
   });
 
-  describe('getRoundData', function () {
-    for (const { stEthPrice, tokensPerStEth, result } of testCases) {
-      it(`stEthPrice (${stEthPrice}), tokensPerStEth (${tokensPerStEth}) -> ${result}`, async () => {
-        const { wstETHPriceFeed } = await makeWstETH({ stEthPrice, tokensPerStEth });
-        const roundId = 999;
-        const latestRoundData = await wstETHPriceFeed.getRoundData(roundId);
-        const price = latestRoundData.answer.toBigInt();
-
-        expect(price).to.eq(result);
-      });
-    }
-
-    it('passes along roundId, startedAt, updatedAt and answeredInRound values from stETH price feed', async () => {
-      const { stETHPriceFeed, wstETHPriceFeed } = await makeWstETH({
-        stEthPrice: exp(1000, 18),
-        tokensPerStEth: exp(.8, 18),
-      });
-
-      await stETHPriceFeed.setRoundData(
-        exp(15, 18), // roundId_,
-        1,           // answer_,
-        exp(16, 8),  // startedAt_,
-        exp(17, 8),  // updatedAt_,
-        exp(18, 18)  // answeredInRound_
-      );
-
-      const {
-        roundId,
-        startedAt,
-        updatedAt,
-        answeredInRound
-      } = await wstETHPriceFeed.getRoundData(exp(15, 18));
-
-      expect(roundId.toBigInt()).to.eq(exp(15, 18));
-      expect(startedAt.toBigInt()).to.eq(exp(16, 8));
-      expect(updatedAt.toBigInt()).to.eq(exp(17, 8));
-      expect(answeredInRound.toBigInt()).to.eq(exp(18, 18));
-    });
-  });
-
   describe('latestRoundData', function () {
     for (const { stEthPrice, tokensPerStEth, result } of testCases) {
       it(`stEthPrice (${stEthPrice}), tokensPerStEth (${tokensPerStEth}) -> ${result}`, async () => {

--- a/test/wsteth-price-feed.ts
+++ b/test/wsteth-price-feed.ts
@@ -7,7 +7,7 @@ import {
 
 export async function makeWstETH({ stEthPrice, tokensPerStEth }) {
   const SimplePriceFeedFactory = (await ethers.getContractFactory('SimplePriceFeed')) as SimplePriceFeed__factory;
-  const stETHPriceFeed = await SimplePriceFeedFactory.deploy(stEthPrice, 8);
+  const stETHPriceFeed = await SimplePriceFeedFactory.deploy(stEthPrice, 18);
 
   const SimpleWstETHFactory = (await ethers.getContractFactory('SimpleWstETH')) as SimpleWstETH__factory;
   const simpleWstETH = await SimpleWstETHFactory.deploy(tokensPerStEth);
@@ -28,38 +28,78 @@ export async function makeWstETH({ stEthPrice, tokensPerStEth }) {
 
 const testCases = [
   {
-    stEthPrice: exp(1300, 8),
+    stEthPrice: exp(1300, 18),
     tokensPerStEth: exp(.9, 18),
     result: 144444444444n
   },
   {
-    stEthPrice: exp(1000, 8),
+    stEthPrice: exp(1000, 18),
     tokensPerStEth: exp(.9, 18),
     result: 111111111111n
   },
   {
-    stEthPrice: exp(1000, 8),
+    stEthPrice: exp(1000, 18),
     tokensPerStEth: exp(.2, 18),
     result: exp(5000, 8)
   },
   {
-    stEthPrice: exp(1000, 8),
+    stEthPrice: exp(1000, 18),
     tokensPerStEth: exp(.5, 18),
     result: exp(2000, 8)
   },
   {
-    stEthPrice: exp(1000, 8),
+    stEthPrice: exp(1000, 18),
     tokensPerStEth: exp(.8, 18),
     result: exp(1250, 8)
   },
   {
-    stEthPrice: exp(-1000, 8),
+    stEthPrice: exp(-1000, 18),
     tokensPerStEth: exp(.8, 18),
     result: exp(-1250, 8)
   },
 ];
 
 describe('wstETH price feed', function () {
+  describe('getRoundData', function () {
+    for (const { stEthPrice, tokensPerStEth, result } of testCases) {
+      it(`stEthPrice (${stEthPrice}), tokensPerStEth (${tokensPerStEth}) -> ${result}`, async () => {
+        const { wstETHPriceFeed } = await makeWstETH({ stEthPrice, tokensPerStEth });
+        const roundId = 999;
+        const latestRoundData = await wstETHPriceFeed.getRoundData(roundId);
+        const price = latestRoundData.answer.toBigInt();
+
+        expect(price).to.eq(result);
+      });
+    }
+
+    it('passes along roundId, startedAt, updatedAt and answeredInRound values from stETH price feed', async () => {
+      const { stETHPriceFeed, wstETHPriceFeed } = await makeWstETH({
+        stEthPrice: exp(1000, 18),
+        tokensPerStEth: exp(.8, 18),
+      });
+
+      await stETHPriceFeed.setRoundData(
+        exp(15, 18), // roundId_,
+        1,           // answer_,
+        exp(16, 8),  // startedAt_,
+        exp(17, 8),  // updatedAt_,
+        exp(18, 18)  // answeredInRound_
+      );
+
+      const {
+        roundId,
+        startedAt,
+        updatedAt,
+        answeredInRound
+      } = await wstETHPriceFeed.getRoundData(exp(15, 18));
+
+      expect(roundId.toBigInt()).to.eq(exp(15, 18));
+      expect(startedAt.toBigInt()).to.eq(exp(16, 8));
+      expect(updatedAt.toBigInt()).to.eq(exp(17, 8));
+      expect(answeredInRound.toBigInt()).to.eq(exp(18, 18));
+    });
+  });
+
   describe('latestRoundData', function () {
     for (const { stEthPrice, tokensPerStEth, result } of testCases) {
       it(`stEthPrice (${stEthPrice}), tokensPerStEth (${tokensPerStEth}) -> ${result}`, async () => {
@@ -73,7 +113,7 @@ describe('wstETH price feed', function () {
 
     it('passes along roundId, startedAt, updatedAt and answeredInRound values from stETH price feed', async () => {
       const { stETHPriceFeed, wstETHPriceFeed } = await makeWstETH({
-        stEthPrice: exp(1000, 8),
+        stEthPrice: exp(1000, 18),
         tokensPerStEth: exp(.8, 18),
       });
 
@@ -97,16 +137,5 @@ describe('wstETH price feed', function () {
       expect(updatedAt.toBigInt()).to.eq(exp(17, 8));
       expect(answeredInRound.toBigInt()).to.eq(exp(18, 18));
     });
-  });
-
-  it(`getRoundData > always reverts`, async () => {
-    const { wstETHPriceFeed } = await makeWstETH({
-      stEthPrice: exp(1000, 8),
-      tokensPerStEth: exp(.2, 18)
-    });
-
-    await expect(
-      wstETHPriceFeed.getRoundData(1)
-    ).to.be.revertedWith("custom error 'NotImplemented()'");
   });
 });


### PR DESCRIPTION
This PR implements and modifies price feeds to support the upcoming WETH deployment. The favored plan so far is to use ETH-denominated price feeds as opposed to USD price feeds, but stick with using 8 decimals for prices to avoid having to change the `Comet` and `Configurator` implementations. 

This would require: 
- A new wrapper price feed (`ScalingPriceFeed.sol`) that scales prices up or down to 8 decimals
- A new `ConstantPriceFeed` that always returns 1e8 for the `WETH` base asset, since should always hold a 1:1 value with ETH
- Modifications to the `WstETHPriceFeed` to return prices in terms of ETH instead of USD

This is an alternative approach to #626, which is a more complex change but could be a better long-term solution.

*Note: This PR also now contains the changes from #634 and #635, which address some suggestions made by OZ for their audit of `WstETHPriceFeed` and `Bulker`.*