### PR TITLE
Move priceFeedDecimals to Comet constructor

### DIFF
--- a/contracts/CometConfiguration.sol
+++ b/contracts/CometConfiguration.sol
@@ -35,6 +35,8 @@ contract CometConfiguration {
         uint104 targetReserves;
 
         AssetConfig[] assetConfigs;
+
+        uint8 priceFeedDecimals;
     }
 
     struct AssetConfig {

--- a/contracts/CometCore.sol
+++ b/contracts/CometCore.sol
@@ -39,9 +39,6 @@ abstract contract CometCore is CometConfiguration, CometStorage, CometMath {
     uint8 internal constant PAUSE_ABSORB_OFFSET = 3;
     uint8 internal constant PAUSE_BUY_OFFSET = 4;
 
-    /// @dev The decimals required for a price feed
-    uint8 internal constant PRICE_FEED_DECIMALS = 8;
-
     /// @dev 365 days * 24 hours * 60 minutes * 60 seconds
     uint64 internal constant SECONDS_PER_YEAR = 31_536_000;
 
@@ -50,9 +47,6 @@ abstract contract CometCore is CometConfiguration, CometStorage, CometMath {
 
     /// @dev The scale for base index (depends on time/rate scales, not base token)
     uint64 internal constant BASE_INDEX_SCALE = 1e15;
-
-    /// @dev The scale for prices (in USD)
-    uint64 internal constant PRICE_SCALE = uint64(10 ** PRICE_FEED_DECIMALS);
 
     /// @dev The scale for factors
     uint64 internal constant FACTOR_SCALE = 1e18;

--- a/contracts/CometExt.sol
+++ b/contracts/CometExt.sol
@@ -43,7 +43,6 @@ contract CometExt is CometExtInterface {
     function baseAccrualScale() override external pure returns (uint64) { return BASE_ACCRUAL_SCALE; }
     function baseIndexScale() override external pure returns (uint64) { return BASE_INDEX_SCALE; }
     function factorScale() override external pure returns (uint64) { return FACTOR_SCALE; }
-    function priceScale() override external pure returns (uint64) { return PRICE_SCALE; }
     function maxAssets() override external pure returns (uint8) { return MAX_ASSETS; }
 
     /**

--- a/contracts/CometExtInterface.sol
+++ b/contracts/CometExtInterface.sol
@@ -25,7 +25,6 @@ abstract contract CometExtInterface is CometCore {
     function baseAccrualScale() virtual external view returns (uint64);
     function baseIndexScale() virtual external view returns (uint64);
     function factorScale() virtual external view returns (uint64);
-    function priceScale() virtual external view returns (uint64);
 
     function maxAssets() virtual external view returns (uint8);
 

--- a/contracts/CometMainInterface.sol
+++ b/contracts/CometMainInterface.sol
@@ -146,6 +146,8 @@ abstract contract CometMainInterface is CometCore {
 
     function numAssets() virtual external view returns (uint8);
     function decimals() virtual external view returns (uint8);
+    function priceFeedDecimals() virtual external view returns (uint8);
+    function priceScale() virtual external view returns (uint64);
 
     function initializeStorage() virtual external;
 }

--- a/contracts/Configurator.sol
+++ b/contracts/Configurator.sol
@@ -32,6 +32,7 @@ contract Configurator is ConfiguratorStorage {
     event SetBaseMinForRewards(address indexed cometProxy, uint104 oldBaseMinForRewards, uint104 newBaseMinForRewards);
     event SetBaseBorrowMin(address indexed cometProxy, uint104 oldBaseBorrowMin, uint104 newBaseBorrowMin);
     event SetTargetReserves(address indexed cometProxy, uint104 oldTargetReserves, uint104 newTargetReserves);
+    event SetPriceFeedDecimals(address indexed cometProxy, uint8 oldPriceFeedDecimals, uint8 newPriceFeedDecimals);
     event UpdateAsset(address indexed cometProxy, AssetConfig oldAssetConfig, AssetConfig newAssetConfig);
     event UpdateAssetPriceFeed(address indexed cometProxy, address indexed asset, address oldPriceFeed, address newPriceFeed);
     event UpdateAssetBorrowCollateralFactor(address indexed cometProxy, address indexed asset, uint64 oldBorrowCF, uint64 newBorrowCF);
@@ -239,6 +240,14 @@ contract Configurator is ConfiguratorStorage {
         uint104 oldTargetReserves = configuratorParams[cometProxy].targetReserves;
         configuratorParams[cometProxy].targetReserves = newTargetReserves;
         emit SetTargetReserves(cometProxy, oldTargetReserves, newTargetReserves);
+    }
+
+    function setPriceFeedDecimals(address cometProxy, uint8 newPriceFeedDecimals) external {
+        if (msg.sender != governor) revert Unauthorized();
+
+        uint8 oldPriceFeedDecimals = configuratorParams[cometProxy].priceFeedDecimals;
+        configuratorParams[cometProxy].priceFeedDecimals = newPriceFeedDecimals;
+        emit SetPriceFeedDecimals(cometProxy, oldPriceFeedDecimals, newPriceFeedDecimals);
     }
 
     function addAsset(address cometProxy, AssetConfig calldata assetConfig) external {

--- a/contracts/ConstantPriceFeed.sol
+++ b/contracts/ConstantPriceFeed.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.15;
+
+import "./vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+contract ConstantPriceFeed is AggregatorV3Interface {
+    /** Custom errors **/
+    error InvalidInt256();
+    error NotImplemented();
+
+    /// @notice Version of the price feed
+    uint public constant override version = 1;
+
+    /// @notice Description of the price feed
+    string public constant description = "Constant price feed";
+
+    /// @notice Number of decimals for returned prices
+    uint8 public immutable override decimals;
+
+    /// @notice The constant price
+    int private immutable CONSTANT_PRICE;
+
+    /**
+     * @notice Construct a new scaling price feed
+     * @param decimals_ The number of decimals for the returned prices
+     **/
+    constructor(uint8 decimals_) {
+        decimals = decimals_;
+        CONSTANT_PRICE = signed256(10 ** decimals_);
+    }
+
+    /**
+     * @notice Unimplemented function required to fulfill AggregatorV3Interface; always reverts
+     **/
+    function getRoundData(uint80 _roundId) override external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        revert NotImplemented();
+    }
+
+    /**
+     * @notice Price for the latest round
+     * @return roundId Round id from the underlying price feed
+     * @return answer Latest price for the asset (will always be a constant price)
+     * @return startedAt Timestamp when the round was started; passed on from underlying price feed
+     * @return updatedAt Timestamp when the round was last updated; passed on from underlying price feed
+     * @return answeredInRound Round id in which the answer was computed; passed on from underlying price feed
+     **/
+    function latestRoundData() external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        return (0, CONSTANT_PRICE, block.timestamp, block.timestamp, 0);
+    }
+
+    function signed256(uint256 n) internal pure returns (int256) {
+        if (n > uint256(type(int256).max)) revert InvalidInt256();
+        return int256(n);
+    }
+}

--- a/deployments/fuji/usdc/configuration.json
+++ b/deployments/fuji/usdc/configuration.json
@@ -6,6 +6,7 @@
   "borrowMin": "1000e6",
   "storeFrontPriceFactor": 0.5,
   "targetReserves": "5000000e6",
+  "priceFeedDecimals": 8,
   "rates": {
     "supplyKink": 0.8,
     "supplySlopeLow": 0.0325,

--- a/deployments/goerli/usdc/configuration.json
+++ b/deployments/goerli/usdc/configuration.json
@@ -6,6 +6,7 @@
   "borrowMin": "1000e6",
   "storeFrontPriceFactor": 0.5,
   "targetReserves": "5000000e6",
+  "priceFeedDecimals": 8,
   "rates": {
     "supplyKink": 0.8,
     "supplySlopeLow": 0.0325,

--- a/deployments/hardhat/dai/configuration.json
+++ b/deployments/hardhat/dai/configuration.json
@@ -5,6 +5,7 @@
   "borrowMin": "1000e6",
   "storeFrontPriceFactor": 0.5,
   "targetReserves": "5000000e6",
+  "priceFeedDecimals": 8,
   "rates": {
     "supplyKink": 0.8,
     "supplySlopeLow": 0.0325,

--- a/deployments/kovan/usdc/configuration.json
+++ b/deployments/kovan/usdc/configuration.json
@@ -6,6 +6,7 @@
   "borrowMin": "1000e6",
   "storeFrontPriceFactor": 0.5,
   "targetReserves": "5000000e6",
+  "priceFeedDecimals": 8,
   "rates": {
     "supplyKink": 0.8,
     "supplySlopeLow": 0.0325,

--- a/deployments/mainnet/usdc/configuration.json
+++ b/deployments/mainnet/usdc/configuration.json
@@ -9,6 +9,7 @@
   "pauseGuardian": "0xbbf3f1421d886e9b2c5d716b5192ac998af2012c",
   "storeFrontPriceFactor": 0.5,
   "targetReserves": "5000000e6",
+  "priceFeedDecimals": 8,
   "rates": {
     "supplyKink": 0.8,
     "supplySlopeLow": 0.0325,

--- a/deployments/mainnet/weth/configuration.json
+++ b/deployments/mainnet/weth/configuration.json
@@ -3,12 +3,12 @@
   "symbol": "cWETHv3",
   "baseToken": "WETH",
   "baseTokenAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-  "baseTokenPriceFeed": "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
   "borrowMin": "100e6",
   "governor": "0x6d903f6003cca6255d85cca4d3b5e5146dc33925",
   "pauseGuardian": "0xbbf3f1421d886e9b2c5d716b5192ac998af2012c",
   "storeFrontPriceFactor": 0.5,
   "targetReserves": "5000000e6",
+  "priceFeedDecimals": 18,
   "rates": {
     "supplyKink": 0.8,
     "supplySlopeLow": 0.0325,
@@ -28,7 +28,7 @@
   "assets": {
     "cbETH": {
       "address": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
-      "priceFeed": "0x67eF3CAF8BeB93149F48e8d20920BEC9b4320510",
+      "priceFeed": "0x86392dC19c0b719886221c78AB11eb8Cf5c52812",
       "decimals": "18",
       "borrowCF": 0.80,
       "liquidateCF": 0.85,

--- a/deployments/mainnet/weth/deploy.ts
+++ b/deployments/mainnet/weth/deploy.ts
@@ -10,8 +10,17 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
     'wstETH:priceFeed',
     'WstETHPriceFeed.sol',
     [
-      '0xcfe54b5cd566ab89272946f602d76ea879cab4a8', // stETHtoUSDPriceFeed
+      '0x86392dC19c0b719886221c78AB11eb8Cf5c52812', // stETHtoETHPriceFeed
       wstETH.address                                // wstETH
+    ]
+  );
+
+  // Deploy constant price feed for WETH
+  const wethConstantPriceFeed = await deploymentManager.deploy(
+    'WETH:priceFeed',
+    'ConstantPriceFeed.sol',
+    [
+      18                                             // decimals
     ]
   );
 

--- a/deployments/mumbai/usdc/configuration.json
+++ b/deployments/mumbai/usdc/configuration.json
@@ -6,6 +6,7 @@
   "borrowMin": "100e6",
   "storeFrontPriceFactor": 0.5,
   "targetReserves": "5000000e6",
+  "priceFeedDecimals": 8,
   "rates": {
     "supplyKink": 0.8,
     "supplySlopeLow": 0.0325,

--- a/forge/test/Comet.t.sol
+++ b/forge/test/Comet.t.sol
@@ -35,6 +35,7 @@ contract CometTest is Test {
                           0,
                           0,
                           0,
+                          0,
                           assets);
         comet = new Comet(config);
     }

--- a/forge/test/Comet.t.sol
+++ b/forge/test/Comet.t.sol
@@ -35,8 +35,8 @@ contract CometTest is Test {
                           0,
                           0,
                           0,
-                          0,
-                          assets);
+                          assets,
+                          0);
         comet = new Comet(config);
     }
 }

--- a/scenario/GovernanceScenario.ts
+++ b/scenario/GovernanceScenario.ts
@@ -173,7 +173,7 @@ scenario('add new asset (mainnet-weth)',
     const dogecoinPricefeed = await dm.deploy(
       'DOGE:priceFeed',
       'test/SimplePriceFeed.sol',
-      [exp(1_000, 8).toString(), 8],
+      [exp(1_000, 18).toString(), 18],
       true
     );
 

--- a/scenario/GovernanceScenario.ts
+++ b/scenario/GovernanceScenario.ts
@@ -24,7 +24,7 @@ scenario('upgrade Comet implementation and initialize', {filter: async (ctx) => 
   // 4. Deploy and upgrade to the new implementation of Comet
   // 5. Call initialize(address) on the new version of Comet
   const upgradeConfiguratorImplCalldata = utils.defaultAbiCoder.encode(['address', 'address'], [configurator.address, upgradedConfigurator.address]);
-  const setPriceFeedDecimalsCalldata = utils.defaultAbiCoder.encode(['address', 'uint8'], [comet.address, 8]);
+  const setPriceFeedDecimalsCalldata = utils.defaultAbiCoder.encode(['address', 'uint8'], [comet.address, await comet.priceFeedDecimals()]);
   const setFactoryCalldata = utils.defaultAbiCoder.encode(['address', 'address'], [comet.address, cometModifiedFactory.address]);
   const deployAndUpgradeToCalldata = utils.defaultAbiCoder.encode(['address', 'address'], [configurator.address, comet.address]);
   const initializeCalldata = utils.defaultAbiCoder.encode(['address'], [constants.AddressZero]);
@@ -59,7 +59,7 @@ scenario('upgrade Comet implementation and initialize using deployUpgradeToAndCa
   // 3. Set the new factory address in Configurator
   // 4. DeployUpgradeToAndCall the new implementation of Comet
   const upgradeConfiguratorImplCalldata = utils.defaultAbiCoder.encode(['address', 'address'], [configurator.address, upgradedConfigurator.address]);
-  const setPriceFeedDecimalsCalldata = utils.defaultAbiCoder.encode(['address', 'uint8'], [comet.address, 8]);
+  const setPriceFeedDecimalsCalldata = utils.defaultAbiCoder.encode(['address', 'uint8'], [comet.address, await comet.priceFeedDecimals()]);
   const setFactoryCalldata = utils.defaultAbiCoder.encode(['address', 'address'], [comet.address, cometModifiedFactory.address]);
   const modifiedComet = (await dm.hre.ethers.getContractFactory('CometModified')).attach(comet.address);
   const initializeCalldata = (await modifiedComet.populateTransaction.initialize(constants.AddressZero)).data;
@@ -86,7 +86,7 @@ scenario('upgrade Comet implementation and call new function', {filter: async (c
 
   // Upgrade Comet implementation
   const upgradeConfiguratorImplCalldata = utils.defaultAbiCoder.encode(['address', 'address'], [configurator.address, upgradedConfigurator.address]);
-  const setPriceFeedDecimalsCalldata = utils.defaultAbiCoder.encode(['address', 'uint8'], [comet.address, 8]);
+  const setPriceFeedDecimalsCalldata = utils.defaultAbiCoder.encode(['address', 'uint8'], [comet.address, await comet.priceFeedDecimals()]);
   const setFactoryCalldata = utils.defaultAbiCoder.encode(['address', 'address'], [comet.address, cometModifiedFactory.address]);
   const deployAndUpgradeToCalldata = utils.defaultAbiCoder.encode(['address', 'address'], [configurator.address, comet.address]);
   await context.fastGovernanceExecute(

--- a/src/deploy/Network.ts
+++ b/src/deploy/Network.ts
@@ -115,6 +115,7 @@ export async function deployNetworkComet(
     baseMinForRewards,
     baseBorrowMin,
     targetReserves,
+    priceFeedDecimals,
     assetConfigs,
     rewardTokenAddress
   } = await getConfiguration(deploymentManager, configOverrides);
@@ -175,6 +176,7 @@ export async function deployNetworkComet(
     baseBorrowMin,
     targetReserves,
     assetConfigs,
+    priceFeedDecimals
   };
 
   const configuratorImpl = await deploymentManager.deploy(

--- a/src/deploy/NetworkConfiguration.ts
+++ b/src/deploy/NetworkConfiguration.ts
@@ -69,6 +69,7 @@ export interface NetworkConfiguration {
   borrowMin: number;
   storeFrontPriceFactor: number;
   targetReserves: number;
+  priceFeedDecimals: number;
   rates: NetworkRateConfiguration;
   tracking: NetworkTrackingConfiguration;
   assets: { [name: string]: NetworkAssetConfiguration };
@@ -135,6 +136,7 @@ function getOverridesOrConfig(
     baseBorrowMin: _ => number(config.borrowMin), // TODO: in token units (?)
     storeFrontPriceFactor: _ => percentage(config.storeFrontPriceFactor),
     targetReserves: _ => number(config.targetReserves),
+    priceFeedDecimals: _ => number(config.priceFeedDecimals),
     ...interestRateInfoMapping(config.rates),
     ...trackingInfoMapping(config.tracking),
     assetConfigs: _ => getAssetConfigs(config.assets, contracts),

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -27,6 +27,7 @@ export interface ProtocolConfiguration {
   baseMinForRewards?: BigNumberish;
   baseBorrowMin?: BigNumberish;
   targetReserves?: BigNumberish;
+  priceFeedDecimals?: BigNumberish;
   assetConfigs?: AssetConfigStruct[];
   rewardTokenAddress?: string;
 }

--- a/test/comet-ext-test.ts
+++ b/test/comet-ext-test.ts
@@ -26,11 +26,6 @@ describe('CometExt', function () {
     expect(factorScale).to.eq(exp(1, 18));
   });
 
-  it('returns price scale', async () => {
-    const priceScale = await comet.priceScale();
-    expect(priceScale).to.eq(exp(1, 8));
-  });
-
   it('returns collateralBalance (in units of the collateral asset)', async () => {
     const { WETH } = tokens;
 

--- a/test/constant-price-feed-test.ts
+++ b/test/constant-price-feed-test.ts
@@ -38,7 +38,7 @@ describe('constant price feed', function () {
         updatedAt,
         answeredInRound
       } = await constantPriceFeed.latestRoundData();
-      const currentTimestamp = (await getBlock()).timestamp
+      const currentTimestamp = (await getBlock()).timestamp;
 
       expect(roundId).to.eq(0);
       expect(startedAt).to.eq(currentTimestamp);

--- a/test/constant-price-feed-test.ts
+++ b/test/constant-price-feed-test.ts
@@ -1,0 +1,57 @@
+import { ethers, exp, expect, getBlock } from './helpers';
+import {
+  ConstantPriceFeed__factory
+} from '../build/types';
+
+export async function makeConstantPriceFeed({ decimals }) {
+  const constantPriceFeedFactory = (await ethers.getContractFactory('ConstantPriceFeed')) as ConstantPriceFeed__factory;
+  const constantPriceFeed = await constantPriceFeedFactory.deploy(decimals);
+  await constantPriceFeed.deployed();
+
+  return constantPriceFeed;
+}
+
+describe('constant price feed', function () {
+  describe('latestRoundData', function () {
+    it('returns constant price for 8 decimals', async () => {
+      const constantPriceFeed = await makeConstantPriceFeed({ decimals: 8 });
+      const latestRoundData = await constantPriceFeed.latestRoundData();
+      const price = latestRoundData.answer.toBigInt();
+
+      expect(price).to.eq(exp(1, 8));
+    });
+
+    it('returns constant price for 18 decimals', async () => {
+      const constantPriceFeed = await makeConstantPriceFeed({ decimals: 18 });
+      const latestRoundData = await constantPriceFeed.latestRoundData();
+      const price = latestRoundData.answer.toBigInt();
+
+      expect(price).to.eq(exp(1, 18));
+    });
+
+    it('returns expected roundId, startedAt, updatedAt and answeredInRound values', async () => {
+      const constantPriceFeed = await makeConstantPriceFeed({ decimals: 18 });
+
+      const {
+        roundId,
+        startedAt,
+        updatedAt,
+        answeredInRound
+      } = await constantPriceFeed.latestRoundData();
+      const currentTimestamp = (await getBlock()).timestamp
+
+      expect(roundId).to.eq(0);
+      expect(startedAt).to.eq(currentTimestamp);
+      expect(updatedAt).to.eq(currentTimestamp);
+      expect(answeredInRound).to.eq(0);
+    });
+  });
+
+  it(`getRoundData > always reverts`, async () => {
+    const constantPriceFeed = await makeConstantPriceFeed({ decimals: 8 });
+
+    await expect(
+      constantPriceFeed.getRoundData(1)
+    ).to.be.revertedWith("custom error 'NotImplemented()'");
+  });
+});

--- a/test/constructor-test.ts
+++ b/test/constructor-test.ts
@@ -14,6 +14,42 @@ describe('constructor', function () {
     expect(await comet.baseBorrowMin()).to.eq(exp(100, 6));
   });
 
+  it('sets price scale', async () => {
+    const { comet: comet8 } = await makeProtocol({ priceFeedDecimals: 8 });
+    const priceScale8 = await comet8.priceScale();
+    const { comet: comet18 } = await makeProtocol({
+      priceFeedDecimals: 18,
+      assets: {
+        USDC: { priceFeedDecimals: 18 },
+        COMP: { priceFeedDecimals: 18 },
+        WETH: { priceFeedDecimals: 18 },
+        WBTC: { priceFeedDecimals: 18 },
+      },
+    });
+    const priceScale18 = await comet18.priceScale();
+
+    expect(priceScale8).to.eq(exp(1, 8));
+    expect(priceScale18).to.eq(exp(1, 18));
+  });
+
+  it('sets price feed decimals', async () => {
+    const { comet: comet8 } = await makeProtocol({ priceFeedDecimals: 8 });
+    const priceFeedDecimals8 = await comet8.priceFeedDecimals();
+    const { comet: comet18 } = await makeProtocol({
+      priceFeedDecimals: 18,
+      assets: {
+        USDC: { priceFeedDecimals: 18 },
+        COMP: { priceFeedDecimals: 18 },
+        WETH: { priceFeedDecimals: 18 },
+        WBTC: { priceFeedDecimals: 18 },
+      },
+    });
+    const priceFeedDecimals18 = await comet18.priceFeedDecimals();
+
+    expect(priceFeedDecimals8).to.eq(8);
+    expect(priceFeedDecimals18).to.eq(18);
+  });
+
   it('verifies asset scales', async function () {
     const [governor, pauseGuardian] = await ethers.getSigners();
 
@@ -73,6 +109,7 @@ describe('constructor', function () {
       baseMinForRewards: exp(1, 6),
       baseBorrowMin: exp(1, 6),
       targetReserves: 0,
+      priceFeedDecimals: 8,
       assetConfigs: [{
         asset: tokens['EVIL'].address,
         priceFeed: priceFeeds['EVIL'].address,
@@ -85,6 +122,7 @@ describe('constructor', function () {
     })).to.be.revertedWith("custom error 'BadDecimals()'");
   });
 
+  // XXX change these tests to only revert if price feeds mismatch against Comet's price feed decimals
   it('reverts if baseTokenPriceFeed does not have 8 decimals', async () => {
     await expect(
       makeProtocol({

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -83,6 +83,7 @@ export type ProtocolOpts = {
   baseMinForRewards?: Numeric;
   baseBorrowMin?: Numeric;
   targetReserves?: Numeric;
+  priceFeedDecimals?: Numeric;
   baseTokenBalance?: Numeric;
 };
 
@@ -251,6 +252,7 @@ export async function makeProtocol(opts: ProtocolOpts = {}): Promise<Protocol> {
   const baseMinForRewards = dfn(opts.baseMinForRewards, exp(1, assets[base].decimals));
   const baseBorrowMin = dfn(opts.baseBorrowMin, exp(1, assets[base].decimals));
   const targetReserves = dfn(opts.targetReserves, 0);
+  const priceFeedDecimals = dfn(opts.priceFeedDecimals, 8);
 
   const FaucetFactory = (await ethers.getContractFactory('FaucetToken')) as FaucetToken__factory;
   const tokens = {};
@@ -296,6 +298,7 @@ export async function makeProtocol(opts: ProtocolOpts = {}): Promise<Protocol> {
     baseMinForRewards,
     baseBorrowMin,
     targetReserves,
+    priceFeedDecimals,
     assetConfigs: Object.entries(assets).reduce((acc, [symbol, config], _i) => {
       if (symbol != base) {
         acc.push({
@@ -384,6 +387,7 @@ export async function makeConfigurator(opts: ProtocolOpts = {}): Promise<Configu
   const baseMinForRewards = await comet.baseMinForRewards();
   const baseBorrowMin = await comet.baseBorrowMin();
   const targetReserves = await comet.targetReserves();
+  const priceFeedDecimals = await comet.priceFeedDecimals();
 
   // Deploy CometFactory
   const CometFactoryFactory = (await ethers.getContractFactory('CometFactory')) as CometFactory__factory;
@@ -415,6 +419,7 @@ export async function makeConfigurator(opts: ProtocolOpts = {}): Promise<Configu
     baseMinForRewards,
     baseBorrowMin,
     targetReserves,
+    priceFeedDecimals,
     assetConfigs: Object.entries(assets).reduce((acc, [symbol, config], _i) => {
       if (symbol != base) {
         acc.push({

--- a/test/liquidation/makeLiquidatableProtocol.ts
+++ b/test/liquidation/makeLiquidatableProtocol.ts
@@ -70,6 +70,7 @@ export default async function makeLiquidatableProtocol() {
     baseMinForRewards: exp(1, 6),
     baseBorrowMin: exp(1, 6),
     targetReserves: exp(1, 18),
+    priceFeedDecimals: 8,
     assetConfigs: [
       {
         asset: DAI,

--- a/test/wsteth-price-feed.ts
+++ b/test/wsteth-price-feed.ts
@@ -7,7 +7,7 @@ import {
 
 export async function makeWstETH({ stEthPrice, tokensPerStEth }) {
   const SimplePriceFeedFactory = (await ethers.getContractFactory('SimplePriceFeed')) as SimplePriceFeed__factory;
-  const stETHPriceFeed = await SimplePriceFeedFactory.deploy(stEthPrice, 8);
+  const stETHPriceFeed = await SimplePriceFeedFactory.deploy(stEthPrice, 18);
 
   const SimpleWstETHFactory = (await ethers.getContractFactory('SimpleWstETH')) as SimpleWstETH__factory;
   const simpleWstETH = await SimpleWstETHFactory.deploy(tokensPerStEth);
@@ -28,38 +28,78 @@ export async function makeWstETH({ stEthPrice, tokensPerStEth }) {
 
 const testCases = [
   {
-    stEthPrice: exp(1300, 8),
+    stEthPrice: exp(1300, 18),
     tokensPerStEth: exp(.9, 18),
-    result: 144444444444n
+    result: 1444444444444444444444n
   },
   {
-    stEthPrice: exp(1000, 8),
+    stEthPrice: exp(1000, 18),
     tokensPerStEth: exp(.9, 18),
-    result: 111111111111n
+    result: 1111111111111111111111n
   },
   {
-    stEthPrice: exp(1000, 8),
+    stEthPrice: exp(1000, 18),
     tokensPerStEth: exp(.2, 18),
-    result: exp(5000, 8)
+    result: exp(5000, 18)
   },
   {
-    stEthPrice: exp(1000, 8),
+    stEthPrice: exp(1000, 18),
     tokensPerStEth: exp(.5, 18),
-    result: exp(2000, 8)
+    result: exp(2000, 18)
   },
   {
-    stEthPrice: exp(1000, 8),
+    stEthPrice: exp(1000, 18),
     tokensPerStEth: exp(.8, 18),
-    result: exp(1250, 8)
+    result: exp(1250, 18)
   },
   {
-    stEthPrice: exp(-1000, 8),
+    stEthPrice: exp(-1000, 18),
     tokensPerStEth: exp(.8, 18),
-    result: exp(-1250, 8)
+    result: exp(-1250, 18)
   },
 ];
 
 describe('wstETH price feed', function () {
+  describe('getRoundData', function () {
+    for (const { stEthPrice, tokensPerStEth, result } of testCases) {
+      it(`stEthPrice (${stEthPrice}), tokensPerStEth (${tokensPerStEth}) -> ${result}`, async () => {
+        const { wstETHPriceFeed } = await makeWstETH({ stEthPrice, tokensPerStEth });
+        const roundId = 999;
+        const latestRoundData = await wstETHPriceFeed.getRoundData(roundId);
+        const price = latestRoundData.answer.toBigInt();
+
+        expect(price).to.eq(result);
+      });
+    }
+
+    it('passes along roundId, startedAt, updatedAt and answeredInRound values from stETH price feed', async () => {
+      const { stETHPriceFeed, wstETHPriceFeed } = await makeWstETH({
+        stEthPrice: exp(1000, 18),
+        tokensPerStEth: exp(.8, 18),
+      });
+
+      await stETHPriceFeed.setRoundData(
+        exp(15, 18), // roundId_,
+        1,           // answer_,
+        exp(16, 8),  // startedAt_,
+        exp(17, 8),  // updatedAt_,
+        exp(18, 18)  // answeredInRound_
+      );
+
+      const {
+        roundId,
+        startedAt,
+        updatedAt,
+        answeredInRound
+      } = await wstETHPriceFeed.getRoundData(exp(15, 18));
+
+      expect(roundId.toBigInt()).to.eq(exp(15, 18));
+      expect(startedAt.toBigInt()).to.eq(exp(16, 8));
+      expect(updatedAt.toBigInt()).to.eq(exp(17, 8));
+      expect(answeredInRound.toBigInt()).to.eq(exp(18, 18));
+    });
+  });
+
   describe('latestRoundData', function () {
     for (const { stEthPrice, tokensPerStEth, result } of testCases) {
       it(`stEthPrice (${stEthPrice}), tokensPerStEth (${tokensPerStEth}) -> ${result}`, async () => {
@@ -73,7 +113,7 @@ describe('wstETH price feed', function () {
 
     it('passes along roundId, startedAt, updatedAt and answeredInRound values from stETH price feed', async () => {
       const { stETHPriceFeed, wstETHPriceFeed } = await makeWstETH({
-        stEthPrice: exp(1000, 8),
+        stEthPrice: exp(1000, 18),
         tokensPerStEth: exp(.8, 18),
       });
 
@@ -97,16 +137,5 @@ describe('wstETH price feed', function () {
       expect(updatedAt.toBigInt()).to.eq(exp(17, 8));
       expect(answeredInRound.toBigInt()).to.eq(exp(18, 18));
     });
-  });
-
-  it(`getRoundData > always reverts`, async () => {
-    const { wstETHPriceFeed } = await makeWstETH({
-      stEthPrice: exp(1000, 8),
-      tokensPerStEth: exp(.2, 18)
-    });
-
-    await expect(
-      wstETHPriceFeed.getRoundData(1)
-    ).to.be.revertedWith("custom error 'NotImplemented()'");
   });
 });


### PR DESCRIPTION
This PR modifies the `Comet` and `CometExt` contracts to allow `priceFeedDecimals` to be set in the constructor. This is to support Comet deployments where the price feeds may have other decimals amounts, such as 18 for X/ETH price feeds.

The contract changes are as follows:
- Add `priceFeedDecimals` as a new field in `Configuration`, which is passed to the `Comet` constructor and is also stored in the `Configurator`
- Remove any `priceScale` dependencies in the `CometExt` (by removing it from `CometCore`) since `priceScale` is now directly dependent on what's passed to the `Comet` constructor
- Add method and event for setting `priceFeedDecimals` in the `Configurator`

I also moved some of the price feed changes over from #625 (e.g. constant price feed, modified wstETH price feed) to get the full deployment and scenarios working.