### PR TITLE
sync hasPurchasableCollateral definitions

### DIFF
--- a/contracts/liquidator/Liquidator.sol
+++ b/contracts/liquidator/Liquidator.sol
@@ -408,6 +408,10 @@ contract Liquidator is IUniswapV3FlashCallback, PeripheryImmutableState, Periphe
         return a <= b ? a : b;
     }
 
+    /**
+     * @notice Returns whether the protocol is selling an amount of any asset
+     * greater than the liquidation threshold
+     */
     function hasPurchasableCollateral() external view returns (bool) {
         uint8 numAssets = comet.numAssets();
         for (uint8 i = 0; i < numAssets; i++) {
@@ -421,6 +425,10 @@ contract Liquidator is IUniswapV3FlashCallback, PeripheryImmutableState, Periphe
         return false;
     }
 
+    /**
+     * @dev Calculates the amount of the base asset required to purchase the max
+     * allowed amount of a given collateral asset
+     */
     function baseAmountForCollateral(address asset) internal view returns (uint256) {
         PoolConfig memory poolConfig = getPoolConfigForAsset(asset);
         uint256 collateralBalance = min(comet.getCollateralReserves(asset), poolConfig.maxCollateralToPurchase);

--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -3,7 +3,6 @@ import {
   CometInterface,
   Liquidator
 } from '../../build/types';
-import { exp } from '../../test/helpers';
 import { FlashbotsBundleProvider } from '@flashbots/ethers-provider-bundle';
 import { Signer } from 'ethers';
 import googleCloudLog, { LogSeverity } from './googleCloudLog';

--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -72,20 +72,6 @@ async function getUniqueAddresses(comet: CometInterface): Promise<Set<string>> {
   return new Set(withdrawEvents.map(event => event.args.src));
 }
 
-export async function hasPurchaseableCollateral(comet: CometInterface, assets: Asset[], minUsdValue: number = 100): Promise<boolean> {
-  let totalValue = 0n;
-  const minValue = exp(minUsdValue, 8);
-  for (const asset of assets) {
-    const collateralReserves = await comet.getCollateralReserves(asset.address);
-    const price = await comet.getPrice(asset.priceFeed);
-    totalValue += collateralReserves.toBigInt() * price.toBigInt() / asset.scale;
-    if (totalValue >= minValue) {
-      return true;
-    }
-  }
-  return false;
-}
-
 export async function liquidateUnderwaterBorrowers(
   comet: CometInterface,
   liquidator: Liquidator,
@@ -124,7 +110,7 @@ export async function arbitragePurchaseableCollateral(
 ) {
   googleCloudLog(LogSeverity.INFO, `Checking for purchaseable collateral`);
 
-  if (await hasPurchaseableCollateral(comet, assets)) {
+  if (await liquidator.hasPurchasableCollateral()) {
     googleCloudLog(LogSeverity.INFO, `There is purchaseable collateral`);
     await attemptLiquidation(
       liquidator,

--- a/test/liquidation/liquidation-bot-script.ts
+++ b/test/liquidation/liquidation-bot-script.ts
@@ -36,7 +36,6 @@ describe('Liquidation Bot', function () {
 
       expect(await comet.isLiquidatable(underwater.address)).to.be.false;
 
-      const assetAddresses = await getAssets(comet);
       expect(await liquidator.hasPurchasableCollateral()).to.be.false;
     });
   });

--- a/test/liquidation/liquidation-bot-script.ts
+++ b/test/liquidation/liquidation-bot-script.ts
@@ -2,7 +2,7 @@ import { expect, exp } from '../helpers';
 import { arbitragePurchaseableCollateral, getAssets, liquidateUnderwaterBorrowers } from '../../scripts/liquidation_bot/liquidateUnderwaterBorrowers';
 import { forkMainnet, makeProtocol, makeLiquidatableProtocol, resetHardhatNetwork } from './makeLiquidatableProtocol';
 
-describe.only('Liquidation Bot', function () {
+describe('Liquidation Bot', function () {
   before(forkMainnet);
   after(resetHardhatNetwork);
 

--- a/test/liquidation/liquidation-bot-test.ts
+++ b/test/liquidation/liquidation-bot-test.ts
@@ -3,7 +3,7 @@ import { ethers } from 'hardhat';
 import { Exchange, forkMainnet, makeProtocol, makeLiquidatableProtocol, resetHardhatNetwork } from './makeLiquidatableProtocol';
 import { DAI, SUSHISWAP_ROUTER, UNISWAP_ROUTER } from './addresses';
 
-describe.only('Liquidator', function () {
+describe('Liquidator', function () {
   beforeEach(forkMainnet);
   afterEach(resetHardhatNetwork);
 

--- a/test/liquidation/liquidation-bot-test.ts
+++ b/test/liquidation/liquidation-bot-test.ts
@@ -230,7 +230,7 @@ describe('Liquidator', function () {
 
   describe('hasPurchasableCollateral', async () => {
     it('is false when there are no assets for sale', async () => {
-      const { comet, liquidator } = await makeLiquidatableProtocol();
+      const { liquidator } = await makeLiquidatableProtocol();
 
       expect(await liquidator.hasPurchasableCollateral()).to.be.false;
     });

--- a/test/liquidation/liquidation-bot-test.ts
+++ b/test/liquidation/liquidation-bot-test.ts
@@ -235,7 +235,7 @@ describe('Liquidator', function () {
       expect(await liquidator.hasPurchasableCollateral()).to.be.false;
     });
 
-    it('is true when are collateral is available for purchase', async () => {
+    it('is true when collateral is available for purchase', async () => {
       const {
         comet,
         liquidator,
@@ -250,7 +250,6 @@ describe('Liquidator', function () {
       expect(await liquidator.hasPurchasableCollateral()).to.be.true;
     });
 
-    // uses the liquidation threshold
     it('uses liquidation threshold to determine if there is a sufficient amount of collateral to purchase', async () => {
       const {
         comet,


### PR DESCRIPTION
This is a fix for a potential issue with the way that the TypeScript code and the Liquidator.sol code determine whether Comet has a sufficient amount of collateral for sale.

Approximately once per block, the TypeScript code calls `hasPurchaseableCollateral` to see if there is any collateral for sale. It returns true if there is any asset whose collateral reserve value (in USDC) is greater than $100. If that's true, then we fire off a transaction to the Liquidator contract (with an empty list of addresses to absorb).

The liquidator contract then tries to calculate how much of each asset it should buy from the protocol. If the value is less than `liquidationThreshold`, the contract will decide to buy 0. The transaction goes through but it does nothing and costs some amount of gas.

So if there is $500 worth of an asset for sale, `hasPurchaseableCollateral` will return true. but if the `liquidationThreshold` is $1,000, then when you go to buy that collateral, the Liquidator will say to buy $0, and just continue.

That transaction will happen nearly every block, until you've drained all the ETH from the wallet that the Liquidation Bot is using. At which point, you'll start getting errors when you try to initiate a transaction.

This patch exposes a `hasPurchasableCollateral` function on the Liquidator.sol contract. This means that both the TypeScript code and the Solidity code will have the same definition of whether there is collateral worth purchasing (and they will stay in sync even when `liquidationThreshold` is altered in the future).