### PR TITLE
wstETHPriceFeed and BaseBulker stylistic changes

### DIFF
--- a/contracts/IERC20NonStandard.sol
+++ b/contracts/IERC20NonStandard.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.15;
+
+/**
+ * @title IERC20NonStandard
+ * @dev Version of ERC20 with no return values for `transfer` and `transferFrom`
+ *  See https://medium.com/coinmonks/missing-return-value-bug-at-least-130-tokens-affected-d67bf08521ca
+ */
+interface IERC20NonStandard {
+    function approve(address spender, uint256 amount) external;
+    function transfer(address to, uint256 value) external;
+    function transferFrom(address from, address to, uint256 value) external;
+    function balanceOf(address account) external view returns (uint256);
+}

--- a/contracts/WstETHPriceFeed.sol
+++ b/contracts/WstETHPriceFeed.sol
@@ -35,6 +35,7 @@ contract WstETHPriceFeed is IPriceFeed {
         stETHtoETHPriceFeed = stETHtoETHPriceFeed_;
         stETHToETHPriceFeedDecimals = AggregatorV3Interface(stETHtoETHPriceFeed_).decimals();
         wstETH = wstETH_;
+        // Note: Safe to convert directly to an int256 because wstETH.decimals == 18
         wstETHScale = int256(10 ** IWstETH(wstETH).decimals());
 
         // Note: stETH / ETH price feed has 18 decimals so `decimals_` should always be less than or equals to that

--- a/contracts/WstETHPriceFeed.sol
+++ b/contracts/WstETHPriceFeed.sol
@@ -29,13 +29,13 @@ contract WstETHPriceFeed is IPriceFeed {
     address public immutable wstETH;
 
     /// @notice Scale for WstETH contract
-    uint public immutable wstETHScale;
+    int public immutable wstETHScale;
 
     constructor(address stETHtoETHPriceFeed_, address wstETH_, uint8 decimals_) {
         stETHtoETHPriceFeed = stETHtoETHPriceFeed_;
         stETHToETHPriceFeedDecimals = AggregatorV3Interface(stETHtoETHPriceFeed_).decimals();
         wstETH = wstETH_;
-        wstETHScale = 10 ** IWstETH(wstETH).decimals();
+        wstETHScale = int256(10 ** IWstETH(wstETH).decimals());
 
         // Note: stETH / ETH price feed has 18 decimals so `decimals_` should always be less than or equals to that
         if (decimals_ > stETHToETHPriceFeedDecimals) revert BadDecimals();
@@ -64,7 +64,7 @@ contract WstETHPriceFeed is IPriceFeed {
     ) {
         (uint80 roundId_, int256 stETHPrice, uint256 startedAt_, uint256 updatedAt_, uint80 answeredInRound_) = AggregatorV3Interface(stETHtoETHPriceFeed).latestRoundData();
         uint256 tokensPerStEth = IWstETH(wstETH).tokensPerStEth();
-        int256 price = stETHPrice * int256(wstETHScale) / signed256(tokensPerStEth);
+        int256 price = stETHPrice * wstETHScale / signed256(tokensPerStEth);
         // Note: Assumes the stETH price feed has an equal or larger amount of decimals than this price feed
         int256 scaledPrice = price / int256(10 ** (stETHToETHPriceFeedDecimals - decimals));
         return (roundId_, scaledPrice, startedAt_, updatedAt_, answeredInRound_);

--- a/contracts/bulkers/BaseBulker.sol
+++ b/contracts/bulkers/BaseBulker.sol
@@ -42,6 +42,7 @@ contract BaseBulker {
 
     /**
      * @notice A public function to sweep accidental ERC-20 transfers to this contract. Tokens are sent to admin (Timelock)
+     * @dev Note: Make sure to check that the asset being swept out is not malicious.
      * @param recipient The address that will receive the swept funds
      * @param asset The address of the ERC-20 token to sweep
      */

--- a/contracts/bulkers/BaseBulker.sol
+++ b/contracts/bulkers/BaseBulker.sol
@@ -41,7 +41,7 @@ contract BaseBulker {
     receive() external payable {}
 
     /**
-     * @notice A public function to sweep accidental ERC-20 transfers to this contract. Tokens are sent to admin (Timelock)
+     * @notice A public function to sweep accidental ERC-20 transfers to this contract.
      * @dev Note: Make sure to check that the asset being swept out is not malicious.
      * @param recipient The address that will receive the swept funds
      * @param asset The address of the ERC-20 token to sweep
@@ -54,7 +54,7 @@ contract BaseBulker {
     }
 
     /**
-     * @notice A public function to sweep accidental native token transfers to this contract. Tokens are sent to admin (Timelock)
+     * @notice A public function to sweep accidental native token transfers to this contract.
      * @param recipient The address that will receive the swept funds
      */
     function sweepNativeToken(address recipient) external {
@@ -101,7 +101,7 @@ contract BaseBulker {
             unchecked { i++; }
         }
 
-        // Refund unused ETH back to msg.sender
+        // Refund unused native token back to msg.sender
         if (unusedNativeToken > 0) {
             (bool success, ) = msg.sender.call{ value: unusedNativeToken }("");
             if (!success) revert FailedToSendNativeToken();

--- a/contracts/bulkers/MainnetBulker.sol
+++ b/contracts/bulkers/MainnetBulker.sol
@@ -61,7 +61,7 @@ contract MainnetBulker is BaseBulker {
      * @dev Note: This contract must have permission to manage msg.sender's Comet account
      */
     function supplyStEthTo(address comet, address to, uint stETHAmount) internal {
-        ERC20(steth).transferFrom(msg.sender, address(this), stETHAmount);
+        doTransferIn(steth, msg.sender, stETHAmount);
         ERC20(steth).approve(wsteth, stETHAmount);
         uint wstETHAmount = IWstETH(wsteth).wrap(stETHAmount);
         ERC20(wsteth).approve(comet, wstETHAmount);
@@ -75,6 +75,6 @@ contract MainnetBulker is BaseBulker {
     function withdrawStEthTo(address comet, address to, uint wstETHAmount) internal {
         CometInterface(comet).withdrawFrom(msg.sender, address(this), wsteth, wstETHAmount);
         uint stETHAmount = IWstETH(wsteth).unwrap(wstETHAmount);
-        ERC20(steth).transfer(to, stETHAmount);
+        doTransferOut(steth, to, stETHAmount);
     }
 }

--- a/contracts/test/NonStandardFaucetToken.sol
+++ b/contracts/test/NonStandardFaucetToken.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.15;
+
+/**
+ * @title Non-standard ERC20 token
+ * @dev Implementation of the basic standard token.
+ *  See https://github.com/ethereum/EIPs/issues/20
+ * @dev Note: `transfer` and `transferFrom` do not return a boolean
+ */
+contract NonStandardToken {
+    string public name;
+    string public symbol;
+    uint8 public decimals;
+    uint256 public totalSupply;
+    mapping (address => mapping (address => uint256)) public allowance;
+    mapping(address => uint256) public balanceOf;
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    constructor(uint256 _initialAmount, string memory _tokenName, uint8 _decimalUnits, string memory _tokenSymbol) {
+        totalSupply = _initialAmount;
+        balanceOf[msg.sender] = _initialAmount;
+        name = _tokenName;
+        symbol = _tokenSymbol;
+        decimals = _decimalUnits;
+    }
+
+    function transfer(address dst, uint256 amount) external virtual {
+        require(amount <= balanceOf[msg.sender], "ERC20: transfer amount exceeds balance");
+        balanceOf[msg.sender] = balanceOf[msg.sender] - amount;
+        balanceOf[dst] = balanceOf[dst] + amount;
+        emit Transfer(msg.sender, dst, amount);
+    }
+
+    function transferFrom(address src, address dst, uint256 amount) external virtual {
+        require(amount <= allowance[src][msg.sender], "ERC20: transfer amount exceeds allowance");
+        require(amount <= balanceOf[src], "ERC20: transfer amount exceeds balance");
+        allowance[src][msg.sender] = allowance[src][msg.sender] - amount;
+        balanceOf[src] = balanceOf[src] - amount;
+        balanceOf[dst] = balanceOf[dst] + amount;
+        emit Transfer(src, dst, amount);
+    }
+
+    function approve(address _spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][_spender] = amount;
+        emit Approval(msg.sender, _spender, amount);
+        return true;
+    }
+}
+
+/**
+ * @title The Compound Faucet Test Token
+ * @author Compound
+ * @notice A simple test token that lets anyone get more of it.
+ */
+contract NonStandardFaucetToken is NonStandardToken {
+    constructor(uint256 _initialAmount, string memory _tokenName, uint8 _decimalUnits, string memory _tokenSymbol)
+        NonStandardToken(_initialAmount, _tokenName, _decimalUnits, _tokenSymbol) {
+    }
+
+    function allocateTo(address _owner, uint256 value) public {
+        balanceOf[_owner] += value;
+        totalSupply += value;
+        emit Transfer(address(this), _owner, value);
+    }
+}

--- a/test/bulker-test.ts
+++ b/test/bulker-test.ts
@@ -1,5 +1,5 @@
-import { baseBalanceOf, ethers, expect, exp, makeProtocol, wait, makeBulker, defaultAssets, getGasUsed, makeRewards, fastForward } from './helpers';
-import { FaucetWETH__factory } from '../build/types';
+import { baseBalanceOf, ethers, expect, exp, makeProtocol, wait, makeBulker, defaultAssets, getGasUsed, makeRewards, fastForward, event } from './helpers';
+import { FaucetWETH__factory, NonStandardFaucetToken__factory } from '../build/types';
 
 // XXX Improve the "no permission" tests that should expect a custom error when
 // when https://github.com/nomiclabs/hardhat/issues/1618 gets fixed.
@@ -364,7 +364,38 @@ describe('bulker', function () {
   });
 
   describe('admin functions', function () {
-    it('sweep ERC20 token', async () => {
+    it('transferAdmin', async () => {
+      const protocol = await makeProtocol({});
+      const { governor, tokens: { WETH }, users: [alice] } = protocol;
+      const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
+      const { bulker } = bulkerInfo;
+
+      expect(await bulker.admin()).to.be.equal(governor.address);
+
+      // Admin transferred
+      const txn = await wait(bulker.connect(governor).transferAdmin(alice.address));
+
+      expect(event(txn, 0)).to.be.deep.equal({
+        AdminTransferred: {
+          oldAdmin: governor.address,
+          newAdmin: alice.address
+        }
+      });
+      expect(await bulker.admin()).to.be.equal(alice.address);
+    });
+
+    it('revert is transferAdmin called by non-admin', async () => {
+      const protocol = await makeProtocol({});
+      const { governor, tokens: { WETH }, users: [alice] } = protocol;
+      const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
+      const { bulker } = bulkerInfo;
+
+      await expect(
+        bulker.connect(alice).transferAdmin(alice.address)
+      ).to.be.revertedWith("custom error 'Unauthorized()'");
+    });
+
+    it('sweep standard ERC20 token', async () => {
       const protocol = await makeProtocol({});
       const { governor, tokens: { USDC, WETH }, users: [alice] } = protocol;
       const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
@@ -383,6 +414,35 @@ describe('bulker', function () {
 
       const newBulkerBalance = await USDC.balanceOf(bulker.address);
       const newGovBalance = await USDC.balanceOf(governor.address);
+
+      expect(newBulkerBalance.sub(oldBulkerBalance)).to.be.equal(-transferAmount);
+      expect(newGovBalance.sub(oldGovBalance)).to.be.equal(transferAmount);
+    });
+
+    it('sweep non-standard ERC20 token', async () => {
+      const protocol = await makeProtocol({});
+      const { governor, tokens: { WETH }, users: [alice] } = protocol;
+      const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
+      const { bulker } = bulkerInfo;
+
+      // Deploy non-standard token
+      const factory = (await ethers.getContractFactory('NonStandardFaucetToken')) as NonStandardFaucetToken__factory;
+      const nonStandardToken = await factory.deploy(1000e6, 'Tether', 6, 'USDT');
+      await nonStandardToken.deployed();
+
+      // Alice "accidentally" sends 10 non-standard tokens to the Bulker
+      const transferAmount = exp(10, 6);
+      await nonStandardToken.allocateTo(alice.address, transferAmount);
+      await nonStandardToken.connect(alice).transfer(bulker.address, transferAmount);
+
+      const oldBulkerBalance = await nonStandardToken.balanceOf(bulker.address);
+      const oldGovBalance = await nonStandardToken.balanceOf(governor.address);
+
+      // Governor sweeps tokens
+      await bulker.connect(governor).sweepToken(governor.address, nonStandardToken.address);
+
+      const newBulkerBalance = await nonStandardToken.balanceOf(bulker.address);
+      const newGovBalance = await nonStandardToken.balanceOf(governor.address);
 
       expect(newBulkerBalance.sub(oldBulkerBalance)).to.be.equal(-transferAmount);
       expect(newGovBalance.sub(oldGovBalance)).to.be.equal(transferAmount);


### PR DESCRIPTION
This PR contains changes to the following (mostly stylistic) issues highlighted in OZ's audit:

- **L-04 Missing docstrings** - We added a comprehensive set of docstrings to the various constants and functions in the `BaseBulker` and `MainnetBulker` contracts.
- **L-06 Possible mismatch between native and wrapped tokens in different chains** - It is true that the `BaseBulker` is only intended to work for EVM chains with a native token and wrapped native token that implements the IWETH interface. We have documented this requirement more clearly.
- **L-07 sweepToken can potentially call a malicious token** - We expect the admin of the `Bulker` (the `Timelock`) to never sweep malicious tokens, but we added a cautionary note just in case. That being said, we think that a malicious token is unable to attack the contract and steal user’s funds since the `Bulker` never delegatecalls to any external contracts.
- **L-08 Unsafe explicit casting of integers** - We purposely avoided the safe conversion of `wstETHScale` because it is always going to be less than `type(int256).max`. We added a note to explain this.
- **N-01 Coding style could be improved** - We updated the `wstETHPriceScale` immutable variable to be an int256.
- **N-02 Confusing documentation** - We fixed the documentations mentioned in this issue.
