### PR TITLE
Refactor deploy to support second markets

### DIFF
--- a/deployments/fuji/usdc/configuration.json
+++ b/deployments/fuji/usdc/configuration.json
@@ -29,7 +29,7 @@
       "borrowCF": 0.7,
       "liquidateCF": 0.75,
       "liquidationFactor": 0.93,
-      "supplyCap": "35000e8"
+      "supplyCap": "35000"
     },
     "WAVAX": {
       "priceFeed": "0x5498BB86BC934c8D34FDA08E81D444153d0D06aD",
@@ -37,7 +37,7 @@
       "borrowCF": 0.82,
       "liquidateCF": 0.85,
       "liquidationFactor": 0.93,
-      "supplyCap": "1000000e18"
+      "supplyCap": "1000000"
     }
   }
 }

--- a/deployments/goerli/usdc/configuration.json
+++ b/deployments/goerli/usdc/configuration.json
@@ -30,7 +30,7 @@
       "borrowCF": 0.65,
       "liquidateCF": 0.7,
       "liquidationFactor": 0.92,
-      "supplyCap": "500000e18"
+      "supplyCap": "500000"
     },
     "WBTC": {
       "priceFeed": "0xA39434A63A52E749F02807ae27335515BA4b07F7",
@@ -38,7 +38,7 @@
       "borrowCF": 0.7,
       "liquidateCF": 0.75,
       "liquidationFactor": 0.93,
-      "supplyCap": "35000e8"
+      "supplyCap": "35000"
     },
     "WETH": {
       "priceFeed": "0xD4a33860578De61DBAbDc8BFdb98FD742fA7028e",
@@ -46,7 +46,7 @@
       "borrowCF": 0.82,
       "liquidateCF": 0.85,
       "liquidationFactor": 0.93,
-      "supplyCap": "1000000e18"
+      "supplyCap": "1000000"
     }
   }
 }

--- a/deployments/kovan/usdc/configuration.json
+++ b/deployments/kovan/usdc/configuration.json
@@ -30,7 +30,7 @@
       "borrowCF": 0.65,
       "liquidateCF": 0.7,
       "liquidationFactor": 0.92,
-      "supplyCap": "500000e18"
+      "supplyCap": "500000"
     },
     "WBTC": {
       "priceFeed": "0x6135b13325bfC4B00278B4abC5e20bbce2D6580e",
@@ -38,7 +38,7 @@
       "borrowCF": 0.7,
       "liquidateCF": 0.75,
       "liquidationFactor": 0.93,
-      "supplyCap": "35000e8"
+      "supplyCap": "35000"
     },
     "WETH": {
       "priceFeed": "0x9326BFA02ADD2366b30bacB125260Af641031331",
@@ -46,7 +46,7 @@
       "borrowCF": 0.82,
       "liquidateCF": 0.85,
       "liquidationFactor": 0.93,
-      "supplyCap": "1000000e18"
+      "supplyCap": "1000000"
     },
     "UNI": {
       "priceFeed": "0xDA5904BdBfB4EF12a3955aEcA103F51dc87c7C39",
@@ -54,7 +54,7 @@
       "borrowCF": 0.75,
       "liquidateCF": 0.8,
       "liquidationFactor": 0.92,
-      "supplyCap": "50000000e18"
+      "supplyCap": "50000000"
     },
     "LINK": {
       "priceFeed": "0x396c5E36DD0a0F5a5D33dae44368D4193f69a1F0",
@@ -62,7 +62,7 @@
       "borrowCF": 0.75,
       "liquidateCF": 0.8,
       "liquidationFactor": 0.92,
-      "supplyCap": "50000000e18"
+      "supplyCap": "50000000"
     }
   }
 }

--- a/deployments/mainnet/usdc/configuration.json
+++ b/deployments/mainnet/usdc/configuration.json
@@ -34,7 +34,7 @@
       "borrowCF": 0.65,
       "liquidateCF": 0.70,
       "liquidationFactor": 0.93,
-      "supplyCap": "0e18"
+      "supplyCap": "0"
     },
     "WBTC": {
       "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -43,7 +43,7 @@
       "borrowCF": 0.70,
       "liquidateCF": 0.77,
       "liquidationFactor": 0.95,
-      "supplyCap": "0e8"
+      "supplyCap": "0"
     },
     "WETH": {
       "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -52,7 +52,7 @@
       "borrowCF": 0.825,
       "liquidateCF": 0.895,
       "liquidationFactor": 0.95,
-      "supplyCap": "0e18"
+      "supplyCap": "0"
     },
     "UNI": {
       "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -61,7 +61,7 @@
       "borrowCF": 0.75,
       "liquidateCF": 0.81,
       "liquidationFactor": 0.93,
-      "supplyCap": "0e18"
+      "supplyCap": "0"
     },
     "LINK": {
       "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -70,7 +70,7 @@
       "borrowCF": 0.79,
       "liquidateCF": 0.85,
       "liquidationFactor": 0.93,
-      "supplyCap": "0e18"
+      "supplyCap": "0"
     }
   }
 }

--- a/deployments/mainnet/weth/configuration.json
+++ b/deployments/mainnet/weth/configuration.json
@@ -24,6 +24,7 @@
     "baseBorrowSpeed": "0e15",
     "baseMinForRewards": "1000000e6"
   },
+  "rewardTokenAddress": "0xc00e94cb662c3520282e6f5717214004a7f26888",
   "assets": {
     "cbETH": {
       "address": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",

--- a/deployments/mainnet/weth/deploy.ts
+++ b/deployments/mainnet/weth/deploy.ts
@@ -36,6 +36,13 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
     ]
   );
 
+  // Import shared contracts from cUSDCv3
+  const cometAdmin = await deploymentManager.fromDep('cometAdmin', 'mainnet', 'usdc');
+  const cometFactory = await deploymentManager.fromDep('cometFactory', 'mainnet', 'usdc');
+  const $configuratorImpl = await deploymentManager.fromDep('configurator:implementation', 'mainnet', 'usdc');
+  const configurator = await deploymentManager.fromDep('configurator', 'mainnet', 'usdc');
+  const rewards = await deploymentManager.fromDep('rewards', 'mainnet', 'usdc');
+
   // Deploy all Comet-related contracts
   const deployed = await deployComet(deploymentManager, deploySpec);
   const { comet } = deployed;

--- a/deployments/mumbai/usdc/configuration.json
+++ b/deployments/mumbai/usdc/configuration.json
@@ -29,7 +29,7 @@
       "borrowCF": 0.79,
       "liquidateCF": 0.85,
       "liquidationFactor": 0.93,
-      "supplyCap": "500000e18"
+      "supplyCap": "500000"
     },
     "WETH": {
       "priceFeed": "0x0715A7794a1dc8e42615F059dD6e406A6594651A",
@@ -37,7 +37,7 @@
       "borrowCF": 0.82,
       "liquidateCF": 0.85,
       "liquidationFactor": 0.93,
-      "supplyCap": "1000000e18"
+      "supplyCap": "1000000"
     },
     "WBTC": {
       "priceFeed": "0x007A22900a3B98143368Bd5906f8E17e9867581b",
@@ -45,7 +45,7 @@
       "borrowCF": 0.7,
       "liquidateCF": 0.75,
       "liquidationFactor": 0.93,
-      "supplyCap": "35000e8"
+      "supplyCap": "35000"
     },
     "WMATIC": {
       "priceFeed": "0xd0D5e3DB44DE05E9F294BB0a3bEEaF030DE24Ada",
@@ -53,7 +53,7 @@
       "borrowCF": 0.82,
       "liquidateCF": 0.85,
       "liquidationFactor": 0.93,
-      "supplyCap": "1000000e18"
+      "supplyCap": "1000000"
     }
   }
 }

--- a/plugins/deployment_manager/Cache.ts
+++ b/plugins/deployment_manager/Cache.ts
@@ -46,6 +46,12 @@ export class Cache {
     this.writeCacheToDisk = writeCacheToDisk ?? false;
   }
 
+  asDeployment(network: string, deployment: string): Cache {
+    const cache = new Cache(network, deployment, this.writeCacheToDisk, this.deploymentDir);
+    cache.cache = this.cache;
+    return cache;
+  }
+
   private getPath(spec: FileSpec): string[] {
     if (typeof spec === 'string') {
       return [spec.toLowerCase()];

--- a/plugins/scenario/utils/TokenSourcer.ts
+++ b/plugins/scenario/utils/TokenSourcer.ts
@@ -11,7 +11,7 @@ interface SourceTokenParameters {
   amount: number | bigint;
   asset: string;
   address: string;
-  blacklist: string[] | undefined;
+  blacklist: string[];
 }
 
 export async function fetchQuery(
@@ -62,7 +62,7 @@ export async function sourceTokens({
   } else if (amount.isNegative()) {
     await removeTokens(dm, amount.abs(), asset, address);
   } else {
-    await addTokens(dm, amount, asset, address, blacklist);
+    await addTokens(dm, amount, asset, address, [address].concat(blacklist));
   }
 }
 
@@ -94,7 +94,7 @@ async function addTokens(
   amount: BigNumber,
   asset: string,
   address: string,
-  blacklist?: string[],
+  blacklist: string[],
   block?: number,
   offsetBlocks?: number,
   MAX_SEARCH_BLOCKS = 40000,

--- a/scenario/constraints/MigrationConstraint.ts
+++ b/scenario/constraints/MigrationConstraint.ts
@@ -23,6 +23,8 @@ export class MigrationConstraint<T extends CometContext, R extends Requirements>
     const solutions: Solution<T>[] = [];
 
     for (const migrationList of subsets(await getMigrations(context, requirements))) {
+      if (migrationList.length == 0 && process.env['MIGRATIONS_ONLY'])
+        continue;
       solutions.push(async function (ctx: T): Promise<T> {
         const proposer = await ctx.getProposer();
 

--- a/scenario/constraints/ModernConstraint.ts
+++ b/scenario/constraints/ModernConstraint.ts
@@ -1,30 +1,18 @@
 import { Constraint } from '../../plugins/scenario';
 import { CometContext } from '../context/CometContext';
-import { ProtocolConfiguration } from '../../src/deploy';
 import { getFuzzedRequirements } from './Fuzzing';
 import { Requirements } from './Requirements';
 
-interface ModernConfig {
-  // Whether to upgrade or Comet config overrides to use for an upgrade
-  upgrade: ProtocolConfiguration;
-}
-
-async function getModernConfigs(context: CometContext, requirements: Requirements): Promise<ModernConfig[]> {
-  const currentConfig = await context.getConfiguration();
-  const fuzzedConfigs = getFuzzedRequirements(requirements).map((r) => ({
-    upgrade: r.upgrade && Object.assign({}, currentConfig, r.upgrade),
-  }));
-  return fuzzedConfigs;
-}
-
 export class ModernConstraint<T extends CometContext, R extends Requirements> implements Constraint<T, R> {
-  async solve(requirements: R, context: T) {
-    const configs = await getModernConfigs(context, requirements);
+  async solve(requirements: R, _context: T) {
+    const fuzzed = await getFuzzedRequirements(requirements);
     const solutions = [];
-    for (const config of configs) {
-      if (config.upgrade) {
+    for (const req of fuzzed) {
+      if (req.upgrade) {
         solutions.push(async function solution(ctx: T): Promise<T> {
-          return await ctx.upgrade(config.upgrade) as T; // It's been modified
+          const current = await ctx.getConfiguration();
+          const upgrade = Object.assign({}, current, req.upgrade);
+          return await ctx.upgrade(upgrade) as T; // It's been modified
         });
       }
     }

--- a/scenario/constraints/UtilizationConstraint.ts
+++ b/scenario/constraints/UtilizationConstraint.ts
@@ -126,7 +126,6 @@ export class UtilizationConstraint<T extends CometContext, R extends Requirement
             collateralNeeded = (collateralNeeded * 11n) / 10n; // add fudge factor
 
             try {
-              // XXX sourceTokens can silently fail, which can somehow leave borrowActor unimpersonated and an approve failure...
               await context.sourceTokens(collateralNeeded, collateralToken, borrowActor);
               await collateralToken.approve(borrowActor, comet);
               await borrowActor.safeSupplyAsset({ asset: collateralToken.address, amount: collateralNeeded });

--- a/src/deploy/Network.ts
+++ b/src/deploy/Network.ts
@@ -146,13 +146,6 @@ export async function deployNetworkComet(
     maybeForce(deploySpec.cometMain)
   );
 
-  const cometProxy = await deploymentManager.deploy(
-    'comet',
-    'vendor/proxy/transparent/TransparentUpgradeableProxy.sol',
-    [cometFactory.address, cometAdmin.address, []], // NB: temporary implementation contract
-    maybeForce(),
-  );
-
   const configuration = {
     governor,
     pauseGuardian,
@@ -176,6 +169,19 @@ export async function deployNetworkComet(
     targetReserves,
     assetConfigs,
   };
+
+  const tmpCometImpl = await deploymentManager.deploy(
+    'comet:implementation',
+    'Comet.sol',
+    [configuration],
+    maybeForce(),
+  );
+  const cometProxy = await deploymentManager.deploy(
+    'comet',
+    'vendor/proxy/transparent/TransparentUpgradeableProxy.sol',
+    [tmpCometImpl.address, cometAdmin.address, []], // NB: temporary implementation contract
+    maybeForce(),
+  );
 
   const configuratorImpl = await deploymentManager.deploy(
     'configurator:implementation',
@@ -211,13 +217,27 @@ export async function deployNetworkComet(
   // Also get a handle for Comet, although it may not *actually* support the interface yet
   const comet = await deploymentManager.cast(cometProxy.address, 'contracts/CometInterface.sol:CometInterface');
 
-  // Get the currently impl addresses for the proxies, and determine if this is the first deploy
+  // Call initializeStorage if storage not initialized
+  // Note: we now rely on the fact that anyone may call, which helps separate the proposal
+  await deploymentManager.idempotent(
+    async () => (await comet.totalsBasic()).lastAccrualTime == 0,
+    async () => {
+      trace(`Initializing Comet at ${comet.address}`);
+      trace(await wait(comet.connect(admin).initializeStorage()));
+    }
+  );
+
+  // If we aren't admin, we'll need proposals to configure things
+  const amAdmin = sameAddress(await cometAdmin.owner(), admin.address);
+
+  // Get the current impl addresses for the proxies, and determine if we've configurated
   const $configuratorImpl = await cometAdmin.getProxyImplementation(configurator.address);
   const $cometImpl = await cometAdmin.getProxyImplementation(comet.address);
-  const isFirstDeploy = sameAddress($cometImpl, cometFactory.address);
+  const isTmpImpl = sameAddress($cometImpl, tmpCometImpl.address);
 
+  // Note: these next setup steps may require a follow-up proposal to complete, if we cannot admin here
   await deploymentManager.idempotent(
-    async () => !sameAddress($configuratorImpl, configuratorImpl.address),
+    async () => amAdmin && !sameAddress($configuratorImpl, configuratorImpl.address),
     async () => {
       trace(`Setting Configurator implementation to ${configuratorImpl.address}`);
       trace(await wait(cometAdmin.connect(admin).upgrade(configurator.address, configuratorImpl.address)));
@@ -225,7 +245,7 @@ export async function deployNetworkComet(
   );
 
   await deploymentManager.idempotent(
-    async () => !sameAddress(await configurator.factory(comet.address), cometFactory.address),
+    async () => amAdmin && !sameAddress(await configurator.factory(comet.address), cometFactory.address),
     async () => {
       trace(`Setting factory in Configurator to ${cometFactory.address}`);
       trace(await wait(configurator.connect(admin).setFactory(comet.address, cometFactory.address)));
@@ -233,26 +253,20 @@ export async function deployNetworkComet(
   );
 
   await deploymentManager.idempotent(
-    async () => isFirstDeploy || deploySpec.all || deploySpec.cometMain || deploySpec.cometExt,
+    async () => amAdmin && (isTmpImpl || deploySpec.all || deploySpec.cometMain || deploySpec.cometExt),
     async () => {
-      trace(`Setting configuration in Configurator for ${comet.address}`);
+      trace(`Setting configuration in Configurator for ${comet.address} (${isTmpImpl})`);
       trace(await wait(configurator.connect(admin).setConfiguration(comet.address, configuration)));
 
-      if (isFirstDeploy) {
-        trace(`Deploying first implementation of Comet and initializing...`);
-        const data = (await comet.populateTransaction.initializeStorage()).data;
-        trace(await wait(cometAdmin.connect(admin).deployUpgradeToAndCall(configurator.address, comet.address, data)));
-      } else {
-        trace(`Upgrading implementation of Comet...`);
-        trace(await wait(cometAdmin.connect(admin).deployAndUpgradeTo(configurator.address, comet.address)));
-      }
+      trace(`Upgrading implementation of Comet...`);
+      trace(await wait(cometAdmin.connect(admin).deployAndUpgradeTo(configurator.address, comet.address)));
 
       trace(`New Comet implementation at ${await cometAdmin.getProxyImplementation(comet.address)}`);
     }
   );
 
   await deploymentManager.idempotent(
-    async () => !sameAddress((await rewards.rewardConfig(comet.address)).token, rewardTokenAddress),
+    async () => amAdmin && !sameAddress((await rewards.rewardConfig(comet.address)).token, rewardTokenAddress),
     async () => {
       trace(`Setting reward token in CometRewards to ${rewardTokenAddress} for ${comet.address}`);
       trace(await wait(rewards.connect(admin).setRewardConfig(comet.address, rewardTokenAddress)));

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -2,6 +2,7 @@ import { AssetConfigStruct } from '../../build/types/Comet';
 import { BigNumberish, Contract, PopulatedTransaction } from 'ethers';
 
 export { cloneGov, deployNetworkComet as deployComet, sameAddress } from './Network';
+export { getConfiguration, getConfigurationStruct } from './NetworkConfiguration';
 export { exp, getBlock, wait } from '../../test/helpers';
 export { debug } from '../../plugins/deployment_manager/Utils';
 


### PR DESCRIPTION
* Add a fromDep to deployment manager which can be used for sharing dependency contracts from another deployment
* Always attempt to initialize storage if needed, and not necessarily as gov
* Always deploy an initial implementation contract instead of using the factory marker
* Only take gov admin actions if we own the cometAdmin
* Expose the primitives necessary for a proposal to configurate later, if/when admin cannot

* Add an env flag for migration constraint to skip non-migration scenarios
* Defer reading current config in modern constraint (bugfix)