### PR TITLE
WETH deployment audit changes

### DIFF
--- a/contracts/ConstantPriceFeed.sol
+++ b/contracts/ConstantPriceFeed.sol
@@ -40,6 +40,6 @@ contract ConstantPriceFeed is IPriceFeed {
         uint256 updatedAt,
         uint80 answeredInRound
     ) {
-        return (0, constantPrice, block.timestamp, block.timestamp, 0);
+        return (1, constantPrice, block.timestamp, block.timestamp, 1);
     }
 }

--- a/contracts/ConstantPriceFeed.sol
+++ b/contracts/ConstantPriceFeed.sol
@@ -3,6 +3,11 @@ pragma solidity 0.8.15;
 
 import "./IPriceFeed.sol";
 
+/**
+ * @title Constant price feed
+ * @notice A custom price feed that always returns a constant price
+ * @author Compound
+ */
 contract ConstantPriceFeed is IPriceFeed {
     /// @notice Version of the price feed
     uint public constant override version = 1;

--- a/contracts/IERC20NonStandard.sol
+++ b/contracts/IERC20NonStandard.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 /**
  * @title IERC20NonStandard
- * @dev Version of ERC20 with no return values for `transfer` and `transferFrom`
+ * @dev Version of ERC20 with no return values for `approve`, `transfer`, and `transferFrom`
  *  See https://medium.com/coinmonks/missing-return-value-bug-at-least-130-tokens-affected-d67bf08521ca
  */
 interface IERC20NonStandard {

--- a/contracts/ScalingPriceFeed.sol
+++ b/contracts/ScalingPriceFeed.sol
@@ -4,6 +4,11 @@ pragma solidity 0.8.15;
 import "./vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 import "./IPriceFeed.sol";
 
+/**
+ * @title Scaling price feed
+ * @notice A custom price feed that scales up or down the price received from an underlying Chainlink price feed and returns the result
+ * @author Compound
+ */
 contract ScalingPriceFeed is IPriceFeed {
     /** Custom errors **/
     error InvalidInt256();

--- a/contracts/WstETHPriceFeed.sol
+++ b/contracts/WstETHPriceFeed.sol
@@ -5,6 +5,11 @@ import "./vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.
 import "./IPriceFeed.sol";
 import "./IWstETH.sol";
 
+/**
+ * @title wstETH price feed
+ * @notice A custom price feed that calculates the price for wstETH / ETH
+ * @author Compound
+ */
 contract WstETHPriceFeed is IPriceFeed {
     /** Custom errors **/
     error BadDecimals();
@@ -66,7 +71,7 @@ contract WstETHPriceFeed is IPriceFeed {
         (uint80 roundId_, int256 stETHPrice, uint256 startedAt_, uint256 updatedAt_, uint80 answeredInRound_) = AggregatorV3Interface(stETHtoETHPriceFeed).latestRoundData();
         uint256 tokensPerStEth = IWstETH(wstETH).tokensPerStEth();
         int256 price = stETHPrice * wstETHScale / signed256(tokensPerStEth);
-        // Note: Assumes the stETH price feed has an equal or larger amount of decimals than this price feed
+        // Note: The stETH price feed should always have an equal or larger amount of decimals than this price feed (enforced by validation in constructor)
         int256 scaledPrice = price / int256(10 ** (stETHToETHPriceFeedDecimals - decimals));
         return (roundId_, scaledPrice, startedAt_, updatedAt_, answeredInRound_);
     }

--- a/contracts/bulkers/BaseBulker.sol
+++ b/contracts/bulkers/BaseBulker.sol
@@ -55,6 +55,7 @@ contract BaseBulker {
 
     /** Custom errors **/
 
+    error InvalidAddress();
     error InvalidArgument();
     error FailedToSendNativeToken();
     error TransferInFailed();
@@ -104,9 +105,11 @@ contract BaseBulker {
 
     /**
      * @notice Transfers the admin rights to a new address
+     * @param newAdmin The address that will become the new admin
      */
     function transferAdmin(address newAdmin) external {
         if (msg.sender != admin) revert Unauthorized();
+        if (newAdmin == address(0)) revert InvalidAddress();
 
         address oldAdmin = admin;
         admin = newAdmin;

--- a/test/bulker-test.ts
+++ b/test/bulker-test.ts
@@ -384,7 +384,7 @@ describe('bulker', function () {
       expect(await bulker.admin()).to.be.equal(alice.address);
     });
 
-    it('revert is transferAdmin called by non-admin', async () => {
+    it('revert if transferAdmin called by non-admin', async () => {
       const protocol = await makeProtocol({});
       const { governor, tokens: { WETH }, users: [alice] } = protocol;
       const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
@@ -393,6 +393,17 @@ describe('bulker', function () {
       await expect(
         bulker.connect(alice).transferAdmin(alice.address)
       ).to.be.revertedWith("custom error 'Unauthorized()'");
+    });
+
+    it('revert if transferAdmin to zero address', async () => {
+      const protocol = await makeProtocol({});
+      const { governor, tokens: { WETH } } = protocol;
+      const bulkerInfo = await makeBulker({ admin: governor, weth: WETH.address });
+      const { bulker } = bulkerInfo;
+
+      await expect(
+        bulker.connect(governor).transferAdmin(ethers.constants.AddressZero)
+      ).to.be.revertedWith("custom error 'InvalidAddress()'");
     });
 
     it('sweep standard ERC20 token', async () => {

--- a/test/constant-price-feed-test.ts
+++ b/test/constant-price-feed-test.ts
@@ -40,10 +40,10 @@ describe('constant price feed', function () {
       } = await constantPriceFeed.latestRoundData();
       const currentTimestamp = (await getBlock()).timestamp;
 
-      expect(roundId).to.eq(0);
+      expect(roundId).to.eq(1);
       expect(startedAt).to.eq(currentTimestamp);
       expect(updatedAt).to.eq(currentTimestamp);
-      expect(answeredInRound).to.eq(0);
+      expect(answeredInRound).to.eq(1);
     });
   });
 });


### PR DESCRIPTION
These are changes in response to the WETH deployment [audit](https://gist.github.com/andresbach/a01686b1ef8bdf51d46046f2cfc93307) conducted by OZ:

- **L01 - Lack of input validation** - We originally avoided zero address checks because there are a vast amount of accidental addresses that can be set here and checking for a specific one seems unnecessary. However, we have reconsidered that position after seeing the reasons for including a zero address check listed in this [post](https://forum.openzeppelin.com/t/removing-address-0x0-checks-from-openzeppelin-contracts/2222/13).
- **L02 - Improper implementation of Chainlink AggregatorV3Interface** - We updated the hard-coded return values for `roundId` and `answeredInRound` to be 1 to comply with the Chainlink specification.
- **L04 - Incomplete/confusing documentation** - We updated the documentation based on the provided suggestions.

Our full audit responses are [here](https://docs.google.com/document/d/1A8TrUdTtD7DXr1U5HOqSS1Xl81rjBZdlDC7LS4No4Bw).