### PR TITLE
Convert from scientific notation to bigint in configuration

### DIFF
--- a/deployments/fuji/usdc/configuration.json
+++ b/deployments/fuji/usdc/configuration.json
@@ -29,7 +29,7 @@
       "borrowCF": 0.7,
       "liquidateCF": 0.75,
       "liquidationFactor": 0.93,
-      "supplyCap": "35000"
+      "supplyCap": "35000e8"
     },
     "WAVAX": {
       "priceFeed": "0x5498BB86BC934c8D34FDA08E81D444153d0D06aD",
@@ -37,7 +37,7 @@
       "borrowCF": 0.82,
       "liquidateCF": 0.85,
       "liquidationFactor": 0.93,
-      "supplyCap": "1000000"
+      "supplyCap": "1000000e18"
     }
   }
 }

--- a/deployments/goerli/usdc/configuration.json
+++ b/deployments/goerli/usdc/configuration.json
@@ -30,7 +30,7 @@
       "borrowCF": 0.65,
       "liquidateCF": 0.7,
       "liquidationFactor": 0.92,
-      "supplyCap": "500000"
+      "supplyCap": "500000e18"
     },
     "WBTC": {
       "priceFeed": "0xA39434A63A52E749F02807ae27335515BA4b07F7",
@@ -38,7 +38,7 @@
       "borrowCF": 0.7,
       "liquidateCF": 0.75,
       "liquidationFactor": 0.93,
-      "supplyCap": "35000"
+      "supplyCap": "35000e8"
     },
     "WETH": {
       "priceFeed": "0xD4a33860578De61DBAbDc8BFdb98FD742fA7028e",
@@ -46,7 +46,7 @@
       "borrowCF": 0.82,
       "liquidateCF": 0.85,
       "liquidationFactor": 0.93,
-      "supplyCap": "1000000"
+      "supplyCap": "1000000e18"
     }
   }
 }

--- a/deployments/kovan/usdc/configuration.json
+++ b/deployments/kovan/usdc/configuration.json
@@ -30,7 +30,7 @@
       "borrowCF": 0.65,
       "liquidateCF": 0.7,
       "liquidationFactor": 0.92,
-      "supplyCap": "500000"
+      "supplyCap": "500000e18"
     },
     "WBTC": {
       "priceFeed": "0x6135b13325bfC4B00278B4abC5e20bbce2D6580e",
@@ -38,7 +38,7 @@
       "borrowCF": 0.7,
       "liquidateCF": 0.75,
       "liquidationFactor": 0.93,
-      "supplyCap": "35000"
+      "supplyCap": "35000e8"
     },
     "WETH": {
       "priceFeed": "0x9326BFA02ADD2366b30bacB125260Af641031331",
@@ -46,7 +46,7 @@
       "borrowCF": 0.82,
       "liquidateCF": 0.85,
       "liquidationFactor": 0.93,
-      "supplyCap": "1000000"
+      "supplyCap": "1000000e18"
     },
     "UNI": {
       "priceFeed": "0xDA5904BdBfB4EF12a3955aEcA103F51dc87c7C39",
@@ -54,7 +54,7 @@
       "borrowCF": 0.75,
       "liquidateCF": 0.8,
       "liquidationFactor": 0.92,
-      "supplyCap": "50000000"
+      "supplyCap": "50000000e18"
     },
     "LINK": {
       "priceFeed": "0x396c5E36DD0a0F5a5D33dae44368D4193f69a1F0",
@@ -62,7 +62,7 @@
       "borrowCF": 0.75,
       "liquidateCF": 0.8,
       "liquidationFactor": 0.92,
-      "supplyCap": "50000000"
+      "supplyCap": "50000000e18"
     }
   }
 }

--- a/deployments/mainnet/usdc/configuration.json
+++ b/deployments/mainnet/usdc/configuration.json
@@ -34,7 +34,7 @@
       "borrowCF": 0.65,
       "liquidateCF": 0.70,
       "liquidationFactor": 0.93,
-      "supplyCap": "0"
+      "supplyCap": "0e18"
     },
     "WBTC": {
       "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -43,7 +43,7 @@
       "borrowCF": 0.70,
       "liquidateCF": 0.77,
       "liquidationFactor": 0.95,
-      "supplyCap": "0"
+      "supplyCap": "0e8"
     },
     "WETH": {
       "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -52,7 +52,7 @@
       "borrowCF": 0.825,
       "liquidateCF": 0.895,
       "liquidationFactor": 0.95,
-      "supplyCap": "0"
+      "supplyCap": "0e18"
     },
     "UNI": {
       "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -61,7 +61,7 @@
       "borrowCF": 0.75,
       "liquidateCF": 0.81,
       "liquidationFactor": 0.93,
-      "supplyCap": "0"
+      "supplyCap": "0e18"
     },
     "LINK": {
       "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -70,7 +70,7 @@
       "borrowCF": 0.79,
       "liquidateCF": 0.85,
       "liquidationFactor": 0.93,
-      "supplyCap": "0"
+      "supplyCap": "0e18"
     }
   }
 }

--- a/deployments/mainnet/weth/configuration.json
+++ b/deployments/mainnet/weth/configuration.json
@@ -32,7 +32,7 @@
       "borrowCF": 0.90,
       "liquidateCF": 0.93,
       "liquidationFactor": 0.95,
-      "supplyCap": "0"
+      "supplyCap": "0e18"
     },
     "wstETH": {
       "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
@@ -40,7 +40,7 @@
       "borrowCF": 0.90,
       "liquidateCF": 0.93,
       "liquidationFactor": 0.95,
-      "supplyCap": "0"
+      "supplyCap": "0e18"
     }
   }
 }

--- a/deployments/mumbai/usdc/configuration.json
+++ b/deployments/mumbai/usdc/configuration.json
@@ -29,7 +29,7 @@
       "borrowCF": 0.79,
       "liquidateCF": 0.85,
       "liquidationFactor": 0.93,
-      "supplyCap": "500000"
+      "supplyCap": "500000e18"
     },
     "WETH": {
       "priceFeed": "0x0715A7794a1dc8e42615F059dD6e406A6594651A",
@@ -37,7 +37,7 @@
       "borrowCF": 0.82,
       "liquidateCF": 0.85,
       "liquidationFactor": 0.93,
-      "supplyCap": "1000000"
+      "supplyCap": "1000000e18"
     },
     "WBTC": {
       "priceFeed": "0x007A22900a3B98143368Bd5906f8E17e9867581b",
@@ -45,7 +45,7 @@
       "borrowCF": 0.7,
       "liquidateCF": 0.75,
       "liquidationFactor": 0.93,
-      "supplyCap": "35000"
+      "supplyCap": "35000e8"
     },
     "WMATIC": {
       "priceFeed": "0xd0D5e3DB44DE05E9F294BB0a3bEEaF030DE24Ada",
@@ -53,7 +53,7 @@
       "borrowCF": 0.82,
       "liquidateCF": 0.85,
       "liquidationFactor": 0.93,
-      "supplyCap": "1000000"
+      "supplyCap": "1000000e18"
     }
   }
 }

--- a/src/deploy/NetworkConfiguration.ts
+++ b/src/deploy/NetworkConfiguration.ts
@@ -36,17 +36,18 @@ function stringToBigInt(x: ScientificNotation) {
   if (typeof x !== 'string') {
     throw new Error(`expected argument to be string, got ${x}`);
   }
-  if (!x.match(/^[0-9]+([.][0-9]+)?e[0-9]+$/)) {
+  let sanitizedInput = x.replace(/_/g, '');
+  if (!sanitizedInput.match(/^[0-9]+([.][0-9]+)?e[0-9]+$/)) {
     throw new Error(`expected string in scientific notation form, got ${x}`);
   }
 
-  const nums = x.split('e');
+  const nums = sanitizedInput.split('e');
   const coefficient = Number(nums[0]);
   const exponent = Number(nums[1]);
   // If exponent is a decimal, then just convert it directly using `number()`.
   // Note: This does mean we could lose some precision when using a decimal coefficient
   if (!Number.isInteger(coefficient)) {
-    return number(Number(x));
+    return number(Number(sanitizedInput));
   } else {
     return BigInt(coefficient) * (10n ** BigInt(exponent));
   }

--- a/src/deploy/NetworkConfiguration.ts
+++ b/src/deploy/NetworkConfiguration.ts
@@ -31,12 +31,12 @@ function percentage(n: number, checkRange: boolean = true): bigint {
   return floor(n * 1e18);
 }
 
-// Note: Expects a string in scientific notation format (e.g. 100e18)
+// Note: Expects a string in scientific notation format (e.g. 1000e18 or 1_000e18)
 function stringToBigInt(x: ScientificNotation) {
   if (typeof x !== 'string') {
     throw new Error(`expected argument to be string, got ${x}`);
   }
-  let sanitizedInput = x.replace(/_/g, '');
+  const sanitizedInput = x.replace(/_/g, '');
   if (!sanitizedInput.match(/^[0-9]+([.][0-9]+)?e[0-9]+$/)) {
     throw new Error(`expected string in scientific notation form, got ${x}`);
   }

--- a/src/deploy/NetworkConfiguration.ts
+++ b/src/deploy/NetworkConfiguration.ts
@@ -37,7 +37,7 @@ function stringToBigInt(x: ScientificNotation) {
     throw new Error(`expected argument to be string, got ${x}`);
   }
   if (!x.match(/^[0-9]+([.][0-9]+)?e[0-9]+$/)) {
-    throw new Error(`expected string in scientific notation form, got ${x}`)
+    throw new Error(`expected string in scientific notation form, got ${x}`);
   }
 
   const nums = x.split('e');


### PR DESCRIPTION
This PR adds a new `ScientificNotation` string type to `NetworkConfiguration` that is required for certain fields (e.g. `supplyCap`, `baseMinForRewards`). The configuration parser will safely convert these values into bigints without losing precision; with one caveat, scientific notations that use decimals in the coefficient still run the risk of precision loss because those are converted directly to javascript numbers.