### PR TITLE
Spider USDC deployment before calling `fromDep`

### DIFF
--- a/deployments/mainnet/weth/deploy.ts
+++ b/deployments/mainnet/weth/deploy.ts
@@ -37,6 +37,16 @@ export default async function deploy(deploymentManager: DeploymentManager, deplo
   );
 
   // Import shared contracts from cUSDCv3
+  // Note: We need to first spider the contracts on the cUSDC base. Consider moving this spider logic into `fromDep`.
+  const usdcDm = new DeploymentManager(
+    'mainnet',
+    'usdc',
+    deploymentManager.hre,
+    {
+      writeCacheToDisk: true,
+    }
+  );
+  await usdcDm.spider();
   const cometAdmin = await deploymentManager.fromDep('cometAdmin', 'mainnet', 'usdc');
   const cometFactory = await deploymentManager.fromDep('cometFactory', 'mainnet', 'usdc');
   const $configuratorImpl = await deploymentManager.fromDep('configurator:implementation', 'mainnet', 'usdc');

--- a/plugins/deployment_manager/DeploymentManager.ts
+++ b/plugins/deployment_manager/DeploymentManager.ts
@@ -215,7 +215,19 @@ export class DeploymentManager {
     const maybeExisting = await this.contract<C>(alias);
     if (!maybeExisting) {
       const trace = this.tracer();
-      const address = await this.readAlias(network, deployment, otherAlias);
+      let address = await this.readAlias(network, deployment, otherAlias);
+      if (address == null) {
+        const dm = new DeploymentManager(
+          network,
+          deployment,
+          this.hre,
+          {
+            writeCacheToDisk: true,
+          }
+        );
+        await dm.spider();
+        address = await this.readAlias(network, deployment, otherAlias);
+      }
       const buildFile = await this.import(address, network);
       const contract = getEthersContract<C>(address, buildFile, this.hre);
       await this.putAlias(alias, contract);

--- a/plugins/deployment_manager/DeploymentManager.ts
+++ b/plugins/deployment_manager/DeploymentManager.ts
@@ -215,19 +215,7 @@ export class DeploymentManager {
     const maybeExisting = await this.contract<C>(alias);
     if (!maybeExisting) {
       const trace = this.tracer();
-      let address = await this.readAlias(network, deployment, otherAlias);
-      if (address == null) {
-        const dm = new DeploymentManager(
-          network,
-          deployment,
-          this.hre,
-          {
-            writeCacheToDisk: true,
-          }
-        );
-        await dm.spider();
-        address = await this.readAlias(network, deployment, otherAlias);
-      }
+      const address = await this.readAlias(network, deployment, otherAlias);
       const buildFile = await this.import(address, network);
       const contract = getEthersContract<C>(address, buildFile, this.hre);
       await this.putAlias(alias, contract);


### PR DESCRIPTION
We need to spider the `USDC` deployment before calling `fromDep` on it so all the aliases are populated in the cache. Otherwise, `fromDep` may try to import an `undefined` contract. 

There are many approaches to this and this PR takes the simplest approach of spidering in the deploy script. Another approach could be to handle the spidering directly in `fromDep`.