### PR TITLE
Add unit tests to sanity check tracking index scale bounds for WETH

### DIFF
--- a/test/tracking-index-bounds-test.ts
+++ b/test/tracking-index-bounds-test.ts
@@ -2,128 +2,260 @@ import { expect, exp, fastForward, makeProtocol, setTotalsBasic, toYears } from 
 import { BigNumber } from 'ethers';
 
 describe('total tracking index bounds', function () {
-  it('upper bound hit on tracking supply index', async () => {
-    const baseMinForRewards = exp(10_000, 6); // 10k USDC
-    const params = {
-      trackingIndexScale: exp(1, 15),
-      baseTrackingSupplySpeed: exp(1, 15),
-      baseTrackingBorrowSpeed: exp(1, 15),
-      baseMinForRewards
-    };
-    const protocol = await makeProtocol(params);
-    const { comet } = protocol;
+  describe('base scale of 6', function () {
+    it('upper bound hit on tracking supply index', async () => {
+      const baseMinForRewards = exp(10_000, 6); // 10k USDC
+      const params = {
+        trackingIndexScale: exp(1, 15),
+        baseTrackingSupplySpeed: exp(1, 15),
+        baseTrackingBorrowSpeed: exp(1, 15),
+        baseMinForRewards
+      };
+      const protocol = await makeProtocol(params);
+      const { comet } = protocol;
 
-    const baseScale = (await comet.baseScale()).toBigInt();
-    // Formula: MAX_UINT64 / (baseTrackingSupplySpeed * baseScale / baseMinForRewards)
-    const secondsUntilOverflow = Number(2n**64n * (baseMinForRewards / baseScale) / params.baseTrackingSupplySpeed);
+      const baseScale = (await comet.baseScale()).toBigInt();
+      // Formula: MAX_UINT64 / (baseTrackingSupplySpeed * baseScale / baseMinForRewards)
+      const secondsUntilOverflow = Number(2n**64n * (baseMinForRewards / baseScale) / params.baseTrackingSupplySpeed);
 
-    // Assert there are at least 5.85 years until tracking index can overflow
-    const expectedYearsUntilOverflow = 5.85;
-    expect(toYears(secondsUntilOverflow)).to.be.approximately(expectedYearsUntilOverflow, 0.01);
+      // Assert there are at least 5.85 years until tracking index can overflow
+      const expectedYearsUntilOverflow = 5.85;
+      expect(toYears(secondsUntilOverflow)).to.be.approximately(expectedYearsUntilOverflow, 0.01);
 
-    await setTotalsBasic(comet, {
-      totalSupplyBase: BigNumber.from(baseMinForRewards), // 10k USDC base units
+      await setTotalsBasic(comet, {
+        totalSupplyBase: BigNumber.from(baseMinForRewards), // 10k USDC base units
+      });
+
+      await fastForward(secondsUntilOverflow-1);
+
+      // First accrue is successful without overflow
+      await comet.accrue();
+
+      // Second accrue should overflow
+      await expect(comet.accrue()).to.be.revertedWith('code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)');
     });
 
-    await fastForward(secondsUntilOverflow-1);
+    it('upper bound hit on tracking borrow index', async () => {
+      const baseMinForRewards = exp(10_000, 6); // 10k USDC
+      const params = {
+        trackingIndexScale: exp(1, 15),
+        baseTrackingSupplySpeed: exp(1, 15),
+        baseTrackingBorrowSpeed: exp(1, 15),
+        baseMinForRewards
+      };
+      const protocol = await makeProtocol(params);
+      const { comet } = protocol;
 
-    // First accrue is successful without overflow
-    await comet.accrue();
+      const baseScale = (await comet.baseScale()).toBigInt();
+      // Formula: MAX_UINT64 / (baseTrackingBorrowSpeed * baseScale / baseMinForRewards)
+      const secondsUntilOverflow = Number(2n**64n * (baseMinForRewards / baseScale) / params.baseTrackingBorrowSpeed);
 
-    // Second accrue should overflow
-    await expect(comet.accrue()).to.be.revertedWith('code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)');
+      // Assert there are at least 5.85 years until tracking index can overflow
+      const expectedYearsUntilOverflow = 5.85;
+      expect(toYears(secondsUntilOverflow)).to.be.approximately(expectedYearsUntilOverflow, 0.01);
+
+      await setTotalsBasic(comet, {
+        totalBorrowBase: BigNumber.from(baseMinForRewards), // 10k USDC base units
+      });
+
+      await fastForward(secondsUntilOverflow-1);
+
+      // First accrue is successful without overflow
+      await comet.accrue();
+
+      // Second accrue should overflow
+      await expect(comet.accrue()).to.be.revertedWith('code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)');
+    });
+
+    it('lower bound hit on tracking supply index', async () => {
+      const params = {
+        trackingIndexScale: exp(1, 15),
+        baseTrackingSupplySpeed: exp(1, 15),
+        baseTrackingBorrowSpeed: exp(1, 15),
+      };
+      const protocol = await makeProtocol(params);
+      const { comet } = protocol;
+
+      const t0 = await setTotalsBasic(comet, {
+        totalSupplyBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()), // 1e15 base units
+      });
+
+      await comet.accrue();
+      const t1 = await comet.totalsBasic();
+
+      // Tracking index should properly accrue
+      expect(t1.trackingSupplyIndex).to.not.be.equal(t0.trackingSupplyIndex);
+
+      const t2 = await setTotalsBasic(comet, {
+        totalSupplyBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()).mul(3), // 3e15 base units
+      });
+
+      await comet.accrue();
+      const t3 = await comet.totalsBasic();
+
+      // Lower bound has hit and tracking index no longer accrues
+      expect(t3.trackingSupplyIndex).to.be.equal(t2.trackingSupplyIndex);
+    });
+
+    it('lower bound hit on tracking borrow index', async () => {
+      const params = {
+        trackingIndexScale: exp(1, 15),
+        baseTrackingSupplySpeed: exp(1, 15),
+        baseTrackingBorrowSpeed: exp(1, 15),
+      };
+      const protocol = await makeProtocol(params);
+      const { comet } = protocol;
+
+      const t0 = await setTotalsBasic(comet, {
+        totalBorrowBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()), // 1e15 base units
+      });
+
+      await comet.accrue();
+      const t1 = await comet.totalsBasic();
+
+      // Tracking index should properly accrue
+      expect(t1.trackingBorrowIndex).to.not.be.equal(t0.trackingBorrowIndex);
+
+      const t2 = await setTotalsBasic(comet, {
+        totalBorrowBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()).mul(3), // 3e15 base units
+      });
+
+      await comet.accrue();
+      const t3 = await comet.totalsBasic();
+
+      // Lower bound has hit and tracking index no longer accrues
+      expect(t3.trackingBorrowIndex).to.be.equal(t2.trackingBorrowIndex);
+    });
   });
 
-  it('upper bound hit on borrow supply index', async () => {
-    const baseMinForRewards = exp(10_000, 6); // 10k USDC
-    const params = {
-      trackingIndexScale: exp(1, 15),
-      baseTrackingSupplySpeed: exp(1, 15),
-      baseTrackingBorrowSpeed: exp(1, 15),
-      baseMinForRewards
-    };
-    const protocol = await makeProtocol(params);
-    const { comet } = protocol;
+  describe('base scale of 18', function () {
+    it('upper bound hit on tracking supply index', async () => {
+      const baseMinForRewards = exp(100, 18); // 100 WETH
+      const params = {
+        base: 'WETH',
+        trackingIndexScale: exp(1, 15),
+        baseTrackingSupplySpeed: exp(0.001, 15), // 86.4 units/day
+        baseTrackingBorrowSpeed: exp(0.001, 15),
+        baseMinForRewards
+      };
+      const protocol = await makeProtocol(params);
+      const { comet } = protocol;
 
-    const baseScale = (await comet.baseScale()).toBigInt();
-    // Formula: MAX_UINT64 / (baseTrackingBorrowSpeed * baseScale / baseMinForRewards)
-    const secondsUntilOverflow = Number(2n**64n * (baseMinForRewards / baseScale) / params.baseTrackingBorrowSpeed);
+      const baseScale = (await comet.baseScale()).toBigInt();
+      // Formula: MAX_UINT64 / (baseTrackingSupplySpeed * baseScale / baseMinForRewards)
+      const secondsUntilOverflow = Number(2n**64n * (baseMinForRewards / baseScale) / params.baseTrackingSupplySpeed);
 
-    // Assert there are at least 5.85 years until tracking index can overflow
-    const expectedYearsUntilOverflow = 5.85;
-    expect(toYears(secondsUntilOverflow)).to.be.approximately(expectedYearsUntilOverflow, 0.01);
+      // Assert there are at least 58.5 years until tracking index can overflow
+      const expectedYearsUntilOverflow = 58.5;
+      expect(toYears(secondsUntilOverflow)).to.be.approximately(expectedYearsUntilOverflow, 0.01);
 
-    await setTotalsBasic(comet, {
-      totalBorrowBase: BigNumber.from(baseMinForRewards), // 10k USDC base units
+      await setTotalsBasic(comet, {
+        totalSupplyBase: BigNumber.from(baseMinForRewards), // 100 WETH base units
+      });
+
+      await fastForward(secondsUntilOverflow-1);
+
+      // First accrue is successful without overflow
+      await comet.accrue();
+
+      // Second accrue should overflow
+      await expect(comet.accrue()).to.be.revertedWith('code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)');
     });
 
-    await fastForward(secondsUntilOverflow-1);
+    it('upper bound hit on tracking borrow index', async () => {
+      const baseMinForRewards = exp(100, 18); // 100 WETH
+      const params = {
+        base: 'WETH',
+        trackingIndexScale: exp(1, 15),
+        baseTrackingSupplySpeed: exp(0.001, 15), // 86.4 units/day
+        baseTrackingBorrowSpeed: exp(0.001, 15),
+        baseMinForRewards
+      };
+      const protocol = await makeProtocol(params);
+      const { comet } = protocol;
 
-    // First accrue is successful without overflow
-    await comet.accrue();
+      const baseScale = (await comet.baseScale()).toBigInt();
+      // Formula: MAX_UINT64 / (baseTrackingBorrowSpeed * baseScale / baseMinForRewards)
+      const secondsUntilOverflow = Number(2n**64n * (baseMinForRewards / baseScale) / params.baseTrackingBorrowSpeed);
 
-    // Second accrue should overflow
-    await expect(comet.accrue()).to.be.revertedWith('code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)');
-  });
+      // Assert there are at least 58.5 years until tracking index can overflow
+      const expectedYearsUntilOverflow = 58.5;
+      expect(toYears(secondsUntilOverflow)).to.be.approximately(expectedYearsUntilOverflow, 0.01);
 
-  it('lower bound hit on tracking supply index', async () => {
-    const params = {
-      trackingIndexScale: exp(1, 15),
-      baseTrackingSupplySpeed: exp(1, 15),
-      baseTrackingBorrowSpeed: exp(1, 15),
-    };
-    const protocol = await makeProtocol(params);
-    const { comet } = protocol;
+      await setTotalsBasic(comet, {
+        totalBorrowBase: BigNumber.from(baseMinForRewards), // 10k USDC base units
+      });
 
-    const t0 = await setTotalsBasic(comet, {
-      totalSupplyBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()), // 1e15 base units
+      await fastForward(secondsUntilOverflow-1);
+
+      // First accrue is successful without overflow
+      await comet.accrue();
+
+      // Second accrue should overflow
+      await expect(comet.accrue()).to.be.revertedWith('code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)');
     });
 
-    await comet.accrue();
-    const t1 = await comet.totalsBasic();
+    it('lower bound hit on tracking supply index', async () => {
+      const params = {
+        base: 'WETH',
+        trackingIndexScale: exp(1, 15),
+        baseTrackingSupplySpeed: exp(0.001, 15), // 86.4 units/day
+        baseTrackingBorrowSpeed: exp(0.001, 15),
+      };
+      const protocol = await makeProtocol(params);
+      const { comet } = protocol;
 
-    // Tracking index should properly accrue
-    expect(t1.trackingSupplyIndex).to.not.be.equal(t0.trackingSupplyIndex);
+      const t0 = await setTotalsBasic(comet, {
+        totalSupplyBase: BigNumber.from(exp(1, 12)).mul(await comet.baseScale()), // 1e12 base units
+      });
 
-    const t2 = await setTotalsBasic(comet, {
-      totalSupplyBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()).mul(3), // 3e15 base units
+      await comet.accrue();
+      const t1 = await comet.totalsBasic();
+
+      // Tracking index should properly accrue
+      expect(t1.trackingSupplyIndex).to.not.be.equal(t0.trackingSupplyIndex);
+
+      const t2 = await setTotalsBasic(comet, {
+        totalSupplyBase: BigNumber.from(exp(1, 13)).mul(await comet.baseScale()), // 1e13 base units
+      });
+
+      await comet.accrue();
+      const t3 = await comet.totalsBasic();
+
+      // Lower bound has hit and tracking index no longer accrues
+      expect(t3.trackingSupplyIndex).to.be.equal(t2.trackingSupplyIndex);
     });
 
-    await comet.accrue();
-    const t3 = await comet.totalsBasic();
+    it('lower bound hit on tracking borrow index', async () => {
+      const params = {
+        base: 'WETH',
+        trackingIndexScale: exp(1, 15),
+        baseTrackingSupplySpeed: exp(0.001, 15), // 86.4 units/day
+        baseTrackingBorrowSpeed: exp(0.001, 15),
+      };
+      const protocol = await makeProtocol(params);
+      const { comet } = protocol;
 
-    // Lower bound has hit and tracking index no longer accrues
-    expect(t3.trackingSupplyIndex).to.be.equal(t2.trackingSupplyIndex);
-  });
+      const t0 = await setTotalsBasic(comet, {
+        totalBorrowBase: BigNumber.from(exp(1, 12)).mul(await comet.baseScale()), // 1e12 base units
+      });
 
-  it('lower bound hit on tracking borrow index', async () => {
-    const params = {
-      trackingIndexScale: exp(1, 15),
-      baseTrackingSupplySpeed: exp(1, 15),
-      baseTrackingBorrowSpeed: exp(1, 15),
-    };
-    const protocol = await makeProtocol(params);
-    const { comet } = protocol;
+      await comet.accrue();
+      const t1 = await comet.totalsBasic();
 
-    const t0 = await setTotalsBasic(comet, {
-      totalBorrowBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()), // 1e15 base units
+      // Tracking index should properly accrue
+      expect(t1.trackingBorrowIndex).to.not.be.equal(t0.trackingBorrowIndex);
+
+      const t2 = await setTotalsBasic(comet, {
+        totalBorrowBase: BigNumber.from(exp(1, 13)).mul(await comet.baseScale()), // 1e13 base units
+      });
+
+      await comet.accrue();
+      const t3 = await comet.totalsBasic();
+
+      // Lower bound has hit and tracking index no longer accrues
+      expect(t3.trackingBorrowIndex).to.be.equal(t2.trackingBorrowIndex);
     });
-
-    await comet.accrue();
-    const t1 = await comet.totalsBasic();
-
-    // Tracking index should properly accrue
-    expect(t1.trackingBorrowIndex).to.not.be.equal(t0.trackingBorrowIndex);
-
-    const t2 = await setTotalsBasic(comet, {
-      totalBorrowBase: BigNumber.from(exp(1, 15)).mul(await comet.baseScale()).mul(3), // 3e15 base units
-    });
-
-    await comet.accrue();
-    const t3 = await comet.totalsBasic();
-
-    // Lower bound has hit and tracking index no longer accrues
-    expect(t3.trackingBorrowIndex).to.be.equal(t2.trackingBorrowIndex);
   });
 });
 


### PR DESCRIPTION
Looks like `1e15` is a reasonable `trackingIndexScale` for the `WETH` deploy. We could consider `1e12` to increase the upper bound (less chance of overflow), but it's nice to keep the index scale the same as that of the `USDC` deploy.

A `baseMinForRewards` of `100e18` seems to be good enough, but I recommend `1000e18` just to be safe.