### PR TITLE
Cleanup some old XXXes

### DIFF
--- a/test/bulker-test.ts
+++ b/test/bulker-test.ts
@@ -468,7 +468,7 @@ describe('bulker multiple actions', function () {
     );
 
     expect(await comet.collateralBalanceOf(alice.address, COMP.address)).to.be.equal(supplyAmount);
-    // expect(await comet.baseBalanceOf(alice.address)).to.be.equal(-borrowAmount); // XXX uncomment once rounding bug from PR 260 is merged
+    expect(await comet.borrowBalanceOf(alice.address)).to.be.equal(borrowAmount);
     expect(await USDC.balanceOf(alice.address)).to.be.equal(borrowAmount);
   });
 


### PR DESCRIPTION
Opening this so we can close #545. #645 adds tests for the global tracking indices, and more user indices tests could be added separately, but the open PR doesn't address and there are still open XXXs to record