### PR TITLE
reduce LINK amounts in LiquidationBot scenarios

### DIFF
--- a/scenario/LiquidationBotScenario.ts
+++ b/scenario/LiquidationBotScenario.ts
@@ -49,7 +49,7 @@ for (let i = 0; i < MAX_ASSETS; i++) {
       // UNI:
       ' == 150000',
       // LINK
-      ' == 250000'
+      ' == 150000'
     ],
     'weth': [
       // CB_ETH
@@ -191,7 +191,7 @@ for (let i = 0; i < MAX_ASSETS; i++) {
       // UNI:
       exp(150000, 18),
       // LINK
-      exp(250000, 18)
+      exp(150000, 18)
     ],
     'weth': [
       // CB_ETH


### PR DESCRIPTION
Liquidity for LINK has become a bit tighter; swapping 250,000 LINK currently results in >4% slippage (which makes liquidating unprofitable):

![image](https://user-images.githubusercontent.com/2570291/215613222-f4c6a78a-d66b-456a-9919-7d836dae404f.png)

So we're starting to see LiquidationBot scenario failures:

<img width="2056" alt="Screen Shot 2023-01-30 at 2 41 28 PM" src="https://user-images.githubusercontent.com/2570291/215613518-01362c7e-e3ec-4abb-8507-e8125775dad2.png">

Reducing the amount we attempt to liquidate in LiquidationBot scenarios.
