### PR TITLE
Polygon liquidator updates

### DIFF
--- a/forge/test/PolygonLiquidator.t.sol
+++ b/forge/test/PolygonLiquidator.t.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "../../contracts/Comet.sol";
+import "../../contracts/CometConfiguration.sol";
+import "../../contracts/liquidator/OnChainLiquidator.sol";
+import "../../contracts/test/SimplePriceFeed.sol";
+
+contract PolygonLiquidatorTest is Test {
+    Comet public comet;
+    OnChainLiquidator public liquidator;
+
+    // contracts
+    address public constant BALANCER_VAULT = 0xBA12222222228d8Ba445958a75a0704d566BF2C8;
+    address public constant COMET_EXT = 0x285617313887d43256F852cAE0Ee4de4b68D45B0; // XXX replace with actual address after Polygon launch
+    address public constant GNOSIS_SAFE = address(0); // XXX replace with actual address after Polygon launch
+    address public constant SUSHISWAP_ROUTER = 0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506;
+    address public constant TIMELOCK = address(0); // XXX replace with actual address after Polygon launch
+    address public constant UNISWAP_ROUTER = 0xE592427A0AEce92De3Edee1F18E0157C05861564;
+    address public constant UNISWAP_V3_FACTORY = 0x1F98431c8aD98523631AE4a59f267346ea31F984;
+
+    // assets
+    address public constant ST_MATIC = 0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4;
+    address public constant USDC = 0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174;
+    address public constant WETH9 = 0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619;
+    address public constant WST_ETH = address(0); // wst_matic doesn't exist
+    address public constant METADEX = 0x210E69a578CfCDbB7A829C7c6379Ac29E64A357a;
+    address public constant WBTC = 0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6;
+    address public constant WMATIC = 0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270;
+
+    // whales
+    address public constant WETH9_WHALE = 0x2093b4281990A568C9D588b8BCE3BFD7a1557Ebd;
+    address public constant WBTC_WHALE = 0x2093b4281990A568C9D588b8BCE3BFD7a1557Ebd;
+    address public constant WMATIC_WHALE = 0x21Cb017B40abE17B6DFb9Ba64A3Ab0f24A7e60EA;
+
+    // price feeds
+    address public constant USDC_PRICE_FEED = 0xfE4A8cc5b5B2366C1B58Bea3858e81843581b2F7;
+    address public constant WETH9_PRICE_FEED = 0xF9680D99D6C9589e2a93a78A04A279e509205945;
+    address public constant WBTC_PRICE_FEED = 0xDE31F8bFBD8c84b5360CFACCa3539B938dd78ae6;
+    address public constant WMATIC_PRICE_FEED = 0xAB594600376Ec9fD91F8e885dADF0CE036862dE0;
+
+    function setUp() public {
+        vm.createSelectFork(string.concat("https://polygon-mainnet.infura.io/v3/", vm.envString("INFURA_KEY")));
+
+        liquidator = new OnChainLiquidator(
+            BALANCER_VAULT,
+            SUSHISWAP_ROUTER,
+            UNISWAP_ROUTER,
+            UNISWAP_V3_FACTORY,
+            ST_MATIC,
+            WST_ETH,
+            WETH9
+        );
+
+        CometConfiguration.AssetConfig[] memory assetConfigs = new CometConfiguration.AssetConfig[](3);
+        assetConfigs[0] = CometConfiguration.AssetConfig({
+            asset: WETH9,
+            priceFeed: WETH9_PRICE_FEED,
+            decimals: 18,
+            borrowCollateralFactor: 9e17,
+            liquidateCollateralFactor: 93e16,
+            liquidationFactor: 95e16,
+            supplyCap: 0
+        });
+
+        assetConfigs[1] = CometConfiguration.AssetConfig({
+            asset: WBTC,
+            priceFeed: WBTC_PRICE_FEED,
+            decimals: 8,
+            borrowCollateralFactor: 7e17,
+            liquidateCollateralFactor: 95e16,
+            liquidationFactor: 95e16,
+            supplyCap: 0
+        });
+
+        assetConfigs[2] = CometConfiguration.AssetConfig({
+            asset: WMATIC,
+            priceFeed: WMATIC_PRICE_FEED,
+            decimals: 18,
+            borrowCollateralFactor: 8e17,
+            liquidateCollateralFactor: 895e15,
+            liquidationFactor: 95e16,
+            supplyCap: 0
+        });
+
+        comet = new Comet(CometConfiguration.Configuration(
+            {
+                governor: TIMELOCK,
+                pauseGuardian: GNOSIS_SAFE,
+                baseToken: USDC,
+                baseTokenPriceFeed: USDC_PRICE_FEED,
+                extensionDelegate: COMET_EXT,
+                supplyKink: 8e17,
+                supplyPerYearInterestRateSlopeLow: 3e16,
+                supplyPerYearInterestRateSlopeHigh: 4e17,
+                supplyPerYearInterestRateBase: 0,
+                borrowKink: 8e17,
+                borrowPerYearInterestRateSlopeLow: 3e16,
+                borrowPerYearInterestRateSlopeHigh: 2e17,
+                borrowPerYearInterestRateBase: 1e16,
+                storeFrontPriceFactor: 5e17,
+                trackingIndexScale: 1e15,
+                baseTrackingSupplySpeed: 0,
+                baseTrackingBorrowSpeed: 0,
+                baseMinForRewards: 1000000e6,
+                baseBorrowMin: 100e6,
+                targetReserves: 5000000e6,
+                assetConfigs: assetConfigs
+            }
+        ));
+
+        // contracts
+        vm.label(UNISWAP_V3_FACTORY, "UniswapV3 Factory");
+        vm.label(TIMELOCK, "Timelock");
+        vm.label(GNOSIS_SAFE, "Gnosis Safe");
+        vm.label(COMET_EXT, "Comet Ext");
+
+        // assets
+        vm.label(ST_MATIC, "ST_MATIC");
+        vm.label(USDC, "USDC");
+        vm.label(WETH9, "WETH9");
+        vm.label(WST_ETH, "WST_ETH");
+        vm.label(METADEX, "METADEX");
+        vm.label(WBTC, "WBTC");
+        vm.label(WMATIC, "WMATIC");
+
+        // whales
+        vm.label(WETH9_WHALE, "WETH9_WHALE");
+        vm.label(WBTC_WHALE, "WBTC_WHALE");
+        vm.label(WMATIC_WHALE, "WMATIC_WHALE");
+    }
+
+    function testWETHSwapViaUniswap() external {
+        swapWithNoMax(
+            WETH9,
+            WETH9_WHALE,
+            500e18,
+            OnChainLiquidator.PoolConfig({
+                exchange: OnChainLiquidator.Exchange.Uniswap,
+                uniswapPoolFee: 500,
+                swapViaWeth: false,
+                balancerPoolId: bytes32(""),
+                curvePool: address(0)
+            })
+        );
+    }
+
+    function testWBTCSwapViaUniswap() external {
+        swapWithNoMax(
+            WBTC,
+            WBTC_WHALE,
+            30e8,
+            OnChainLiquidator.PoolConfig({
+                exchange: OnChainLiquidator.Exchange.Uniswap,
+                uniswapPoolFee: 500,
+                swapViaWeth: true,
+                balancerPoolId: bytes32(""),
+                curvePool: address(0)
+            })
+        );
+    }
+
+    function testWMATICSwapViaUniswap() external {
+        swapWithNoMax(
+            WMATIC,
+            WMATIC_WHALE,
+            500_000e18,
+            OnChainLiquidator.PoolConfig({
+                exchange: OnChainLiquidator.Exchange.Uniswap,
+                uniswapPoolFee: 500,
+                swapViaWeth: false,
+                balancerPoolId: bytes32(""),
+                curvePool: address(0)
+            })
+        );
+    }
+
+    function swapWithNoMax(
+        address asset,
+        address whale,
+        uint256 transferAmount,
+        OnChainLiquidator.PoolConfig memory poolConfig
+    ) internal {
+        uint256 initialRecipientBalance = ERC20(USDC).balanceOf(address(this));
+        int256 initialReserves = comet.getReserves();
+
+        address[] memory liquidatableAccounts;
+
+        OnChainLiquidator.PoolConfig[] memory poolConfigs = new OnChainLiquidator.PoolConfig[](1);
+        poolConfigs[0] = poolConfig;
+
+        uint256[] memory maxAmountsToPurchase = new uint256[](1);
+        maxAmountsToPurchase[0] = type(uint256).max;
+
+        address[] memory assets =  new address[](1);
+        assets[0] = asset;
+
+        vm.prank(whale);
+        ERC20(asset).transfer(address(comet), transferAmount);
+
+        liquidator.absorbAndArbitrage(
+            address(comet),
+            liquidatableAccounts, // liquidatableAccounts
+            assets,               // assets
+            poolConfigs,          // poolConfigs
+            maxAmountsToPurchase, // maxAmountsToPurchase
+            METADEX,              // flash loan pair token
+            3000,                 // flash loan pool fee
+            10e6                  // liquidation threshold
+        );
+
+        // expect that there is only dust (< 1 unit) left of the asset
+        assertLt(comet.getCollateralReserves(asset), 10 ** ERC20(asset).decimals());
+
+        // expect the base balance of the recipient to have increased
+        assertGt(ERC20(USDC).balanceOf(address(this)), initialRecipientBalance);
+
+        // expect the protocol reserves to have increased
+        assertGt(comet.getReserves(), initialReserves);
+    }
+}

--- a/plugins/deployment_manager/DeploymentManager.ts
+++ b/plugins/deployment_manager/DeploymentManager.ts
@@ -417,7 +417,7 @@ export class DeploymentManager {
    * Call an async function with a given amount of retries
    * @param fn an async function that takes a signer as an argument. The function takes a signer
    * because a new instance of a signer needs to be used on each retry
-   * @param retries the number of times to retry the function. Default is 5 retries
+   * @param retries the number of times to retry the function. Default is 7 retries
    * @param timeLimit time limit before timeout in milliseconds
    * @param wait time to wait between tries in milliseconds
    */

--- a/scenario/LiquidationBotScenario.ts
+++ b/scenario/LiquidationBotScenario.ts
@@ -1,19 +1,44 @@
 import { scenario } from './context/CometContext';
 import { expect } from 'chai';
-import { isValidAssetIndex, MAX_ASSETS, timeUntilUnderwater } from './utils';
+import { isValidAssetIndex, matchesDeployment, MAX_ASSETS, timeUntilUnderwater } from './utils';
 import { ethers, event, exp, wait } from '../test/helpers';
 import CometActor from './context/CometActor';
 import { CometInterface, OnChainLiquidator } from '../build/types';
 import { getPoolConfig, flashLoanPools } from '../scripts/liquidation_bot/liquidateUnderwaterBorrowers';
 
-const BALANCER_VAULT = '0xBA12222222228d8Ba445958a75a0704d566BF2C8';
-const SUSHISWAP_ROUTER = '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F';
-const UNISWAP_ROUTER = '0xE592427A0AEce92De3Edee1F18E0157C05861564';
-const UNISWAP_V3_FACTORY = '0x1F98431c8aD98523631AE4a59f267346ea31F984';
+interface LiquidationAddresses {
+  balancerVault: string;
+  uniswapRouter: string;
+  uniswapV3Factory: string;
+  sushiswapRouter: string;
+  stakedNativeToken: string;
+  weth9: string;
+  wrappedStakedNativeToken: string;
+}
 
-const ST_ETH = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84';
-const WETH9 = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-const WST_ETH = '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0';
+const sharedAddresses = {
+  balancerVault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+  uniswapRouter: '0xE592427A0AEce92De3Edee1F18E0157C05861564',
+  uniswapV3Factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
+};
+
+const addresses: {[chain: string]: LiquidationAddresses} = {
+  'mainnet': {
+    ...sharedAddresses,
+    sushiswapRouter: '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F',
+    stakedNativeToken: '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84',
+    weth9: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+    wrappedStakedNativeToken: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0'
+
+  },
+  'polygon': {
+    ...sharedAddresses,
+    sushiswapRouter: '0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506',
+    stakedNativeToken: '0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4', // stMatic
+    weth9: '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619',
+    wrappedStakedNativeToken: ethers.constants.AddressZero // wstMatic does not exist
+  }
+};
 
 async function borrowCapacityForAsset(comet: CometInterface, actor: CometActor, assetIndex: number) {
   const {
@@ -39,24 +64,36 @@ async function borrowCapacityForAsset(comet: CometInterface, actor: CometActor, 
 
 for (let i = 0; i < MAX_ASSETS; i++) {
   const assetAmounts = {
-    'usdc': [
-      // COMP
-      ' == 500',
-      // WBTC
-      ' == 120',
-      // WETH9
-      ' == 5000',
-      // UNI:
-      ' == 150000',
-      // LINK
-      ' == 150000'
-    ],
-    'weth': [
-      // CB_ETH
-      ' == 1000',
-      // WST_ETH
-      ' == 2000'
-    ]
+    'mainnet': {
+      'usdc': [
+        // COMP
+        ' == 500',
+        // WBTC
+        ' == 120',
+        // WETH9
+        ' == 5000',
+        // UNI:
+        ' == 150000',
+        // LINK
+        ' == 150000'
+      ],
+      'weth': [
+        // CB_ETH
+        ' == 1000',
+        // WST_ETH
+        ' == 2000'
+      ]
+    },
+    'polygon': {
+      'usdc': [
+        // WETH
+        ' == 400',
+        // WBTC
+        ' == 40',
+        // WMATIC
+        ' == 500000',
+      ],
+    }
   };
   scenario(
     `LiquidationBot > liquidates an underwater position of $asset${i} with no maxAmountToPurchase`,
@@ -64,14 +101,16 @@ for (let i = 0; i < MAX_ASSETS; i++) {
       upgrade: {
         targetReserves: exp(20_000, 18)
       },
-      filter: async (ctx) => ctx.world.base.network === 'mainnet' && await isValidAssetIndex(ctx, i),
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && matchesDeployment(ctx, [{deployment: 'mainnet'}, {network: 'polygon'}]),
       tokenBalances: {
-        $comet: { $base: 10000 },
+        $comet: {
+          $base: 2250000,
+        },
       },
       cometBalances: async (ctx) => (
         {
           albert: {
-            [`$asset${i}`]: assetAmounts[ctx.world.base.deployment]?.[i] || 0
+            [`$asset${i}`]: assetAmounts[ctx.world.base.network]?.[ctx.world.base.deployment]?.[i] || 0
           },
         }
       ),
@@ -80,18 +119,27 @@ for (let i = 0; i < MAX_ASSETS; i++) {
       const { albert, betty } = actors;
       const { network, deployment } = world.deploymentManager;
       const flashLoanPool = flashLoanPools[network][deployment];
+      const {
+        balancerVault,
+        uniswapRouter,
+        uniswapV3Factory,
+        sushiswapRouter,
+        stakedNativeToken,
+        weth9,
+        wrappedStakedNativeToken
+      } = addresses[network];
 
       const liquidator = await world.deploymentManager.deploy(
         'liquidator',
         'liquidator/OnChainLiquidator.sol',
         [
-          BALANCER_VAULT,
-          SUSHISWAP_ROUTER,
-          UNISWAP_ROUTER,
-          UNISWAP_V3_FACTORY,
-          ST_ETH,
-          WST_ETH,
-          WETH9
+          balancerVault,
+          sushiswapRouter,
+          uniswapRouter,
+          uniswapV3Factory,
+          stakedNativeToken,
+          wrappedStakedNativeToken,
+          weth9
         ]
       ) as OnChainLiquidator;
 
@@ -161,44 +209,68 @@ for (let i = 0; i < MAX_ASSETS; i++) {
 
 for (let i = 0; i < MAX_ASSETS; i++) {
   const assetAmounts = {
-    'usdc': [
-      // COMP
-      ' == 40000',
-      // WBTC
-      ' == 1200',
-      // WETH
-      ' == 10000',
-      // UNI
-      ' == 250000',
-      // LINK
-      ' == 500000',
-    ],
-    'weth': [
-      // CB_ETH
-      ' == 2000',
-      // WST_ETH
-      ' == 5000'
-    ]
+    'mainnet': {
+      'usdc': [
+        // COMP
+        ' == 40000',
+        // WBTC
+        ' == 1200',
+        // WETH
+        ' == 10000',
+        // UNI
+        ' == 250000',
+        // LINK
+        ' == 500000',
+      ],
+      'weth': [
+        // CB_ETH
+        ' == 2000',
+        // WST_ETH
+        ' == 5000'
+      ]
+    },
+    'polygon': {
+      'usdc': [
+        // WETH
+        ' == 1000',
+        // WBTC
+        ' == 100',
+        // WMATIC
+        ' == 2500000',
+      ]
+    }
   };
   const maxAmountsToPurchase = {
-    'usdc': [
-      // COMP
-      exp(500, 18),
-      // WBTC
-      exp(120, 8),
-      // WETH9
-      exp(5000, 18),
-      // UNI:
-      exp(150000, 18),
-      // LINK
-      exp(150000, 18)
-    ],
-    'weth': [
-      // CB_ETH
-      exp(1000, 18),
-      // WST_ETH
-      exp(2000, 18)
-    ]
+    'mainnet': {
+      'usdc': [
+        // COMP
+        exp(500, 18),
+        // WBTC
+        exp(120, 8),
+        // WETH9
+        exp(5000, 18),
+        // UNI:
+        exp(150000, 18),
+        // LINK
+        exp(150000, 18)
+      ],
+      'weth': [
+        // CB_ETH
+        exp(1000, 18),
+        // WST_ETH
+        exp(2000, 18)
+      ]
+    },
+    'polygon': {
+      'usdc': [
+        // WETH
+        exp(400, 18),
+        // WBTC
+        exp(40, 8),
+        // WMATIC
+        exp(5000, 18),
+      ]
+    }
   };
 
   scenario(
@@ -207,14 +279,14 @@ for (let i = 0; i < MAX_ASSETS; i++) {
       upgrade: {
         targetReserves: exp(20_000, 18)
       },
-      filter: async (ctx) => ctx.world.base.network === 'mainnet' && await isValidAssetIndex(ctx, i),
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && matchesDeployment(ctx, [{deployment: 'mainnet'}, {network: 'polygon'}]),
       tokenBalances: {
-        $comet: { $base: 10000 },
+        $comet: { $base: 3_000_000 },
       },
       cometBalances: async (ctx) => (
         {
           albert: {
-            [`$asset${i}`]: assetAmounts[ctx.world.base.deployment]?.[i] || 0
+            [`$asset${i}`]: assetAmounts[ctx.world.base.network]?.[ctx.world.base.deployment]?.[i] || 0
           },
         }
       ),
@@ -223,18 +295,27 @@ for (let i = 0; i < MAX_ASSETS; i++) {
       const { albert, betty } = actors;
       const { network, deployment } = world.deploymentManager;
       const flashLoanPool = flashLoanPools[network][deployment];
+      const {
+        balancerVault,
+        uniswapRouter,
+        uniswapV3Factory,
+        sushiswapRouter,
+        stakedNativeToken,
+        weth9,
+        wrappedStakedNativeToken
+      } = addresses[network];
 
       const liquidator = await world.deploymentManager.deploy(
         'liquidator',
         'liquidator/OnChainLiquidator.sol',
         [
-          BALANCER_VAULT,
-          SUSHISWAP_ROUTER,
-          UNISWAP_ROUTER,
-          UNISWAP_V3_FACTORY,
-          ST_ETH,
-          WST_ETH,
-          WETH9
+          balancerVault,
+          sushiswapRouter,
+          uniswapRouter,
+          uniswapV3Factory,
+          stakedNativeToken,
+          wrappedStakedNativeToken,
+          weth9
         ]
       ) as OnChainLiquidator;
 
@@ -270,7 +351,7 @@ for (let i = 0; i < MAX_ASSETS; i++) {
         [albert.address],
         [collateralAssetAddress],
         [getPoolConfig(collateralAssetAddress)],
-        [maxAmountsToPurchase[deployment][i]],
+        [maxAmountsToPurchase[network][deployment][i]],
         flashLoanPool.tokenAddress,
         flashLoanPool.poolFee,
         10e6
@@ -298,9 +379,9 @@ for (let i = 0; i < MAX_ASSETS; i++) {
 scenario(
   `LiquidationBot > absorbs, but does not attempt to purchase collateral when value is beneath liquidationThreshold`,
   {
-    filter: async (ctx) => ctx.world.base.network === 'mainnet',
+    filter: async (ctx) => matchesDeployment(ctx, [{deployment: 'mainnet'}, {network: 'polygon'}]),
     tokenBalances: {
-      $comet: { $base: 1000 },
+      $comet: { $base: 100000 },
     },
     cometBalances: {
       albert: {
@@ -313,18 +394,27 @@ scenario(
     const { albert, betty } = actors;
     const { network, deployment } = world.deploymentManager;
     const flashLoanPool = flashLoanPools[network][deployment];
+    const {
+      balancerVault,
+      uniswapRouter,
+      uniswapV3Factory,
+      sushiswapRouter,
+      stakedNativeToken,
+      weth9,
+      wrappedStakedNativeToken
+    } = addresses[network];
 
     const liquidator = await world.deploymentManager.deploy(
       'liquidator',
       'liquidator/OnChainLiquidator.sol',
       [
-        BALANCER_VAULT,
-        SUSHISWAP_ROUTER,
-        UNISWAP_ROUTER,
-        UNISWAP_V3_FACTORY,
-        ST_ETH,
-        WST_ETH,
-        WETH9
+        balancerVault,
+        sushiswapRouter,
+        uniswapRouter,
+        uniswapV3Factory,
+        stakedNativeToken,
+        wrappedStakedNativeToken,
+        weth9
       ]
     ) as OnChainLiquidator;
 
@@ -400,9 +490,9 @@ scenario(
 scenario(
   `LiquidationBot > absorbs, but does not attempt to purchase collateral when maxAmountToPurchase=0`,
   {
-    filter: async (ctx) => ctx.world.base.network === 'mainnet',
+    filter: async (ctx) => matchesDeployment(ctx, [{deployment: 'mainnet'}, {network: 'polygon'}]),
     tokenBalances: {
-      $comet: { $base: 1000 },
+      $comet: { $base: 100000 },
     },
     cometBalances: {
       albert: {
@@ -415,18 +505,27 @@ scenario(
     const { albert, betty } = actors;
     const { network, deployment } = world.deploymentManager;
     const flashLoanPool = flashLoanPools[network][deployment];
+    const {
+      balancerVault,
+      uniswapRouter,
+      uniswapV3Factory,
+      sushiswapRouter,
+      stakedNativeToken,
+      weth9,
+      wrappedStakedNativeToken
+    } = addresses[network];
 
     const liquidator = await world.deploymentManager.deploy(
       'liquidator',
       'liquidator/OnChainLiquidator.sol',
       [
-        BALANCER_VAULT,
-        SUSHISWAP_ROUTER,
-        UNISWAP_ROUTER,
-        UNISWAP_V3_FACTORY,
-        ST_ETH,
-        WST_ETH,
-        WETH9
+        balancerVault,
+        sushiswapRouter,
+        uniswapRouter,
+        uniswapV3Factory,
+        stakedNativeToken,
+        wrappedStakedNativeToken,
+        weth9
       ]
     ) as OnChainLiquidator;
 
@@ -502,7 +601,10 @@ scenario(
 scenario(
   `LiquidationBot > reverts when price slippage is too high`,
   {
-    filter: async (ctx) => ctx.world.base.network === 'mainnet',
+    upgrade: {
+      targetReserves: exp(20_000, 18)
+    },
+    filter: async (ctx) => matchesDeployment(ctx, [{deployment: 'mainnet'}]), // XXX enable for Polygon
     tokenBalances: {
       $comet: { $base: 10000 },
     },
@@ -517,18 +619,27 @@ scenario(
     const { albert, betty } = actors;
     const { network, deployment } = world.deploymentManager;
     const flashLoanPool = flashLoanPools[network][deployment];
+    const {
+      balancerVault,
+      uniswapRouter,
+      uniswapV3Factory,
+      sushiswapRouter,
+      stakedNativeToken,
+      weth9,
+      wrappedStakedNativeToken
+    } = addresses[network];
 
     const liquidator = await world.deploymentManager.deploy(
       'liquidator',
       'liquidator/OnChainLiquidator.sol',
       [
-        BALANCER_VAULT,
-        SUSHISWAP_ROUTER,
-        UNISWAP_ROUTER,
-        UNISWAP_V3_FACTORY,
-        ST_ETH,
-        WST_ETH,
-        WETH9
+        balancerVault,
+        sushiswapRouter,
+        uniswapRouter,
+        uniswapV3Factory,
+        stakedNativeToken,
+        wrappedStakedNativeToken,
+        weth9
       ]
     ) as OnChainLiquidator;
 

--- a/scripts/liquidation_bot/deploy.ts
+++ b/scripts/liquidation_bot/deploy.ts
@@ -1,19 +1,49 @@
 import hre from 'hardhat';
+import { ethers } from 'ethers';
 import { DeploymentManager } from '../../plugins/deployment_manager/DeploymentManager';
 import { OnChainLiquidator } from '../../build/types';
 
-const BALANCER_VAULT = '0xBA12222222228d8Ba445958a75a0704d566BF2C8';
-const SUSHISWAP_ROUTER = '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F';
-const UNISWAP_ROUTER = '0xE592427A0AEce92De3Edee1F18E0157C05861564';
-const UNISWAP_V3_FACTORY = '0x1F98431c8aD98523631AE4a59f267346ea31F984';
+interface LiquidationAddresses {
+  balancerVault: string;
+  uniswapRouter: string;
+  uniswapV3Factory: string;
+  sushiswapRouter: string;
+  stakedNativeToken: string;
+  weth9: string;
+  wrappedStakedNativeToken: string;
+}
 
-const ST_ETH = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84';
-const WETH9 = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-const WST_ETH = '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0';
+const sharedAddresses = {
+  balancerVault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+  uniswapRouter: '0xE592427A0AEce92De3Edee1F18E0157C05861564',
+  uniswapV3Factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
+};
+
+const addresses: {[network: string]: LiquidationAddresses} = {
+  'mainnet': {
+    ...sharedAddresses,
+    sushiswapRouter: '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F',
+    stakedNativeToken: '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84',
+    weth9: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+    wrappedStakedNativeToken: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0'
+
+  },
+  'polygon': {
+    ...sharedAddresses,
+    sushiswapRouter: '0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506',
+    stakedNativeToken: '0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4',
+    weth9: '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619',
+    wrappedStakedNativeToken: ethers.constants.AddressZero // wstMatic does not exist
+  }
+};
 
 async function main() {
   const network = hre.network.name;
   const deployment = 'abc'; // doesn't matter; just need a value to instantiate DeploymentManager
+
+  if (!['mainnet', 'polygon'].includes(network)) {
+    throw new Error(`unable to deploy Liquidator to network: ${network}`);
+  }
 
   const dm = new DeploymentManager(
     network,
@@ -26,17 +56,27 @@ async function main() {
   );
   await dm.spider();
 
+  const {
+    balancerVault,
+    uniswapRouter,
+    uniswapV3Factory,
+    sushiswapRouter,
+    stakedNativeToken,
+    weth9,
+    wrappedStakedNativeToken
+  } = addresses[network];
+
   const liquidator = await dm.deploy(
     'liquidator',
     'liquidator/OnChainLiquidator.sol',
     [
-      BALANCER_VAULT,
-      SUSHISWAP_ROUTER,
-      UNISWAP_ROUTER,
-      UNISWAP_V3_FACTORY,
-      ST_ETH,
-      WST_ETH,
-      WETH9
+      balancerVault,
+      sushiswapRouter,
+      uniswapRouter,
+      uniswapV3Factory,
+      stakedNativeToken,
+      wrappedStakedNativeToken,
+      weth9
     ]
   ) as OnChainLiquidator;
 

--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -37,6 +37,9 @@ const WBTC = '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599';
 const WETH9 = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
 const CB_ETH = '0xBe9895146f7AF43049ca1c1AE358B0541Ea49704';
 const WST_ETH = '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0';
+const POLYGON_WBTC = '0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6';
+const POLYGON_WETH = '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619';
+const WMATIC = '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270';
 
 const liquidationThresholds = {
   'mainnet': {
@@ -60,9 +63,17 @@ export const flashLoanPools = {
     }
   },
   'goerli': {
-    // WETH pool
-    tokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
-    poolFee: 3000
+    'usdc': {
+      // WETH pool
+      tokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
+      poolFee: 3000
+    }
+  },
+  'polygon': {
+    'usdc': {
+      tokenAddress: '0xc2132d05d31c914a87c6611c10748aeb04b58e8f', // USDT
+      poolFee: 100
+    }
   }
 };
 
@@ -129,7 +140,31 @@ export function getPoolConfig(tokenAddress: string) {
         exchange: Exchange.Balancer,
         balancerPoolId: '0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080'
       }
-    }
+    },
+    [WMATIC.toLowerCase()]: {
+      ...defaultPoolConfig,
+      ...{
+        exchange: Exchange.Uniswap,
+        swapViaWeth: false,
+        uniswapPoolFee: 500
+      }
+    },
+    [POLYGON_WBTC.toLowerCase()]: {
+      ...defaultPoolConfig,
+      ...{
+        exchange: Exchange.Uniswap,
+        swapViaWeth: true,
+        uniswapPoolFee: 500
+      }
+    },
+    [POLYGON_WETH.toLowerCase()]: {
+      ...defaultPoolConfig,
+      ...{
+        exchange: Exchange.Uniswap,
+        swapViaWeth: false,
+        uniswapPoolFee: 500
+      }
+    },
   };
 
   const poolConfig = poolConfigs[tokenAddress.toLowerCase()];


### PR DESCRIPTION
This PR does the following:

- adds Forge tests for Polygon liquidation
- updates scenarios to run for Polygon
- updates the Liquidation Bot deploy script.

The existing Liquidation contract works for Polygon. Using Uniswap, we are currently able to swap

- 500 WETH (~$750K)
- 30 WBTC (~$600K)
- 500,000 WMATIC (~$600K)

Swap liquidity is the limiting factor for the Liquidation Bot (how much of a given asset can you swap before the price slippage exceeds the discount that the protocol has sold the collateral for, making the swap unprofitable).

But there is an additional challenge for Polygon: flash loan liquidity.

When taking out a flash loan, we have to find a Uniswap pool where 1) one of the paired tokens is the base token of the protocol, and 2) the other token is not one of the collateral assets.

(The second token cannot be a collateral asset because if you take out a flash loan from a pool and then later attempt to swap via that same pool, you will exit with an error from the Uniswap's contracts reentrancy guard.)

Finding a pool that fits this criteria is easy on mainnet (we currently use USDC/DAI), but harder on Polygon since there are fewer pools and they are smaller.

On Polygon, the largest `[TOKEN]/USDC` pools that do not involve WETH, WBTC or WMATIC are `METADEX/USDC` and `USDC/USDT`. The METADEX pool currently has ~$3M worth of USDC to take out as a flash loan; the USDT pool has ~$1M USDC.

Those amounts are probably enough for now, but the risk of running out of sufficient flash loan liquidity is another issue to be aware of on L2s.