### PR TITLE
Set entire Comet configuration for Polygon proposal

### DIFF
--- a/deployments/polygon/usdc/configuration.json
+++ b/deployments/polygon/usdc/configuration.json
@@ -31,7 +31,7 @@
       "borrowCF": 0.825,
       "liquidateCF": 0.895,
       "liquidationFactor": 0.95,
-      "supplyCap": "0e18"
+      "supplyCap": "10_000e18"
     },
     "WBTC": {
       "address": "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6",
@@ -40,7 +40,7 @@
       "borrowCF": 0.70,
       "liquidateCF": 0.77,
       "liquidationFactor": 0.95,
-      "supplyCap": "0e18"
+      "supplyCap": "10_000e8"
     },
     "WMATIC": {
       "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
@@ -49,7 +49,7 @@
       "borrowCF": 0.825,
       "liquidateCF": 0.895,
       "liquidationFactor": 0.95,
-      "supplyCap": "0e18"
+      "supplyCap": "10_000e18"
     }
   }
 }

--- a/deployments/polygon/usdc/migrations/1675200105_raise_polygon_supply_caps.ts
+++ b/deployments/polygon/usdc/migrations/1675200105_raise_polygon_supply_caps.ts
@@ -1,6 +1,6 @@
 import { DeploymentManager } from '../../../../plugins/deployment_manager/DeploymentManager';
 import { migration } from '../../../../plugins/deployment_manager/Migration';
-import { exp, proposal } from '../../../../src/deploy';
+import { calldata, exp, getConfigurationStruct, proposal } from '../../../../src/deploy';
 import { expect } from 'chai';
 
 export default migration('1675200105_raise_polygon_supply_caps', {
@@ -8,15 +8,15 @@ export default migration('1675200105_raise_polygon_supply_caps', {
     return {};
   },
 
-  enact: async (deploymentManager: DeploymentManager, governanceDeploymentManager: DeploymentManager) => {
+  enact: async (
+    deploymentManager: DeploymentManager,
+    governanceDeploymentManager: DeploymentManager
+  ) => {
     const trace = deploymentManager.tracer();
     const ethers = deploymentManager.hre.ethers;
     const { utils } = ethers;
 
-    const {
-      fxRoot,
-      governor
-    } = await governanceDeploymentManager.getContracts();
+    const { fxRoot, governor } = await governanceDeploymentManager.getContracts();
 
     const {
       bridgeReceiver,
@@ -28,17 +28,10 @@ export default migration('1675200105_raise_polygon_supply_caps', {
       WMATIC
     } = await deploymentManager.getContracts();
 
-    const wbtcCalldata = utils.defaultAbiCoder.encode(
-      ['address', 'address', 'uint128'],
-      [comet.address, WBTC.address, exp(10_000, 8)] // XXX add actual amount
-    );
-    const wethCalldata = utils.defaultAbiCoder.encode(
-      ['address', 'address', 'uint128'],
-      [comet.address, WETH.address, exp(10_000, 18)] // XXX add actual amount
-    );
-    const wmaticCalldata = utils.defaultAbiCoder.encode(
-      ['address', 'address', 'uint128'],
-      [comet.address, WMATIC.address, exp(10_000, 18)] // XXX add actual amount
+    const configuration = await getConfigurationStruct(deploymentManager);
+
+    const setConfigurationCalldata = await calldata(
+      configurator.populateTransaction.setConfiguration(comet.address, configuration)
     );
     const deployAndUpgradeToCalldata = utils.defaultAbiCoder.encode(
       ['address', 'address'],
@@ -48,25 +41,13 @@ export default migration('1675200105_raise_polygon_supply_caps', {
     const l2ProposalData = utils.defaultAbiCoder.encode(
       ['address[]', 'uint256[]', 'string[]', 'bytes[]'],
       [
+        [configurator.address, cometAdmin.address],
+        [0, 0],
         [
-          configurator.address,
-          configurator.address,
-          configurator.address,
-          cometAdmin.address
+          'setConfiguration(address,(address,address,address,address,address,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint104,uint104,uint104,(address,address,uint8,uint64,uint64,uint64,uint128)[]))',
+          'deployAndUpgradeTo(address,address)'
         ],
-        [0, 0, 0, 0],
-        [
-          "updateAssetSupplyCap(address,address,uint128)",
-          "updateAssetSupplyCap(address,address,uint128)",
-          "updateAssetSupplyCap(address,address,uint128)",
-          "deployAndUpgradeTo(address,address)",
-        ],
-        [
-          wbtcCalldata,
-          wethCalldata,
-          wmaticCalldata,
-          deployAndUpgradeToCalldata
-        ]
+        [setConfigurationCalldata, deployAndUpgradeToCalldata]
       ]
     );
 
@@ -74,13 +55,13 @@ export default migration('1675200105_raise_polygon_supply_caps', {
       {
         contract: fxRoot,
         signature: 'sendMessageToChild(address,bytes)',
-        args: [bridgeReceiver.address, l2ProposalData],
+        args: [bridgeReceiver.address, l2ProposalData]
       }
     ];
 
-    const description = ""; // XXX add description
-    const txn = await governanceDeploymentManager.retry(
-      async () => trace((await governor.propose(...await proposal(mainnetActions, description))))
+    const description = ''; // XXX add description
+    const txn = await governanceDeploymentManager.retry(async () =>
+      trace(await governor.propose(...(await proposal(mainnetActions, description))))
     );
 
     const event = txn.events.find(event => event.event === 'ProposalCreated');
@@ -90,12 +71,7 @@ export default migration('1675200105_raise_polygon_supply_caps', {
   },
 
   async verify(deploymentManager: DeploymentManager) {
-    const {
-      comet,
-      WBTC,
-      WETH,
-      WMATIC
-    } = await deploymentManager.getContracts();
+    const { comet, WBTC, WETH, WMATIC } = await deploymentManager.getContracts();
 
     const wbtcInfo = await comet.getAssetInfoByAddress(WBTC.address);
     const wethInfo = await comet.getAssetInfoByAddress(WETH.address);
@@ -104,5 +80,5 @@ export default migration('1675200105_raise_polygon_supply_caps', {
     expect(await wbtcInfo.supplyCap).to.be.eq(exp(10_000, 8));
     expect(await wethInfo.supplyCap).to.be.eq(exp(10_000, 18));
     expect(await wmaticInfo.supplyCap).to.be.eq(exp(10_000, 18));
-  },
+  }
 });


### PR DESCRIPTION
This allows us to update a variety of configs (e.g. CF, supply caps) more easily.