### PR TITLE
Set rewards token address in Polygon configuration

### DIFF
--- a/deployments/polygon/usdc/configuration.json
+++ b/deployments/polygon/usdc/configuration.json
@@ -23,6 +23,7 @@
     "baseBorrowSpeed": "0e15",
     "baseMinForRewards": "1000000e6"
   },
+  "rewardTokenAddress": "0x8505b9d2254A7Ae468c0E9dd10Ccea3A837aef5c",
   "assets": {
     "WETH": {
       "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",


### PR DESCRIPTION
This is so the rewards config can be set on deploy. The alternative is to set the reward config in the cross-chain proposal to initialize the Polygon market.