### PR TITLE
remove (Polygon) from name

### DIFF
--- a/deployments/polygon/usdc/configuration.json
+++ b/deployments/polygon/usdc/configuration.json
@@ -1,5 +1,5 @@
 {
-  "name": "Compound USDC (Polygon)",
+  "name": "Compound USDC",
   "symbol": "cUSDCv3",
   "baseToken": "USDC",
   "baseTokenAddress": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",


### PR DESCRIPTION
removing `(Polygon)` from the contract name.

as reference, some other contracts incorporate `(PoS)` into their name, but there doesn't seem to be a solid convention around this.

USDC: `USD Coin (PoS)`
WBTC: `(PoS) Wrapped BTC`
WETH: `Wrapped Ether`
WMATIC: `Wrapped Matic`