### PR TITLE
Fix Liquidation Bot scenarios

### DIFF
--- a/scenario/LiquidationBotScenario.ts
+++ b/scenario/LiquidationBotScenario.ts
@@ -63,6 +63,15 @@ async function borrowCapacityForAsset(comet: CometInterface, actor: CometActor, 
 }
 
 for (let i = 0; i < MAX_ASSETS; i++) {
+  const baseTokenBalances = {
+    'mainnet': {
+      'usdc': 2250000,
+      'weth': 20
+    },
+    'polygon': {
+      'usdc': 2250000
+    }
+  };
   const assetAmounts = {
     'mainnet': {
       'usdc': [
@@ -79,7 +88,7 @@ for (let i = 0; i < MAX_ASSETS; i++) {
       ],
       'weth': [
         // CB_ETH
-        ' == 1000',
+        ' == 750',
         // WST_ETH
         ' == 2000'
       ]
@@ -95,19 +104,20 @@ for (let i = 0; i < MAX_ASSETS; i++) {
       ],
     }
   };
-  // XXX enable for mainnet WETH
   scenario(
     `LiquidationBot > liquidates an underwater position of $asset${i} with no maxAmountToPurchase`,
     {
       upgrade: {
         targetReserves: exp(20_000, 18)
       },
-      filter: async (ctx) => await isValidAssetIndex(ctx, i) && matchesDeployment(ctx, [{network: 'mainnet', deployment: 'usdc'}, {network: 'polygon'}]),
-      tokenBalances: {
-        $comet: {
-          $base: 2250000,
-        },
-      },
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && matchesDeployment(ctx, [{network: 'mainnet'}, {network: 'polygon'}]),
+      tokenBalances: async (ctx) => (
+        {
+          $comet: {
+            $base: baseTokenBalances[ctx.world.base.network]?.[ctx.world.base.deployment] || 0,
+          },
+        }
+      ),
       cometBalances: async (ctx) => (
         {
           albert: {
@@ -209,6 +219,15 @@ for (let i = 0; i < MAX_ASSETS; i++) {
 }
 
 for (let i = 0; i < MAX_ASSETS; i++) {
+  const baseTokenBalances = {
+    'mainnet': {
+      'usdc': 2250000,
+      'weth': 20
+    },
+    'polygon': {
+      'usdc': 3000000
+    }
+  };
   const assetAmounts = {
     'mainnet': {
       'usdc': [
@@ -257,7 +276,7 @@ for (let i = 0; i < MAX_ASSETS; i++) {
       ],
       'weth': [
         // CB_ETH
-        exp(1000, 18),
+        exp(750, 18),
         // WST_ETH
         exp(2000, 18)
       ]
@@ -273,17 +292,20 @@ for (let i = 0; i < MAX_ASSETS; i++) {
       ]
     }
   };
-  // XXX enable for mainnet WETH
   scenario(
     `LiquidationBot > partially liquidates large position of $asset${i}, by setting maxAmountToPurchase`,
     {
       upgrade: {
         targetReserves: exp(20_000, 18)
       },
-      filter: async (ctx) => await isValidAssetIndex(ctx, i) && matchesDeployment(ctx, [{network: 'mainnet', deployment: 'usdc'}, {network: 'polygon'}]),
-      tokenBalances: {
-        $comet: { $base: 3_000_000 },
-      },
+      filter: async (ctx) => await isValidAssetIndex(ctx, i) && matchesDeployment(ctx, [{network: 'mainnet'}, {network: 'polygon'}]),
+      tokenBalances: async (ctx) => (
+        {
+          $comet: {
+            $base: baseTokenBalances[ctx.world.base.network]?.[ctx.world.base.deployment] || 0,
+          },
+        }
+      ),
       cometBalances: async (ctx) => (
         {
           albert: {
@@ -605,7 +627,7 @@ scenario(
     upgrade: {
       targetReserves: exp(20_000, 18)
     },
-    filter: async (ctx) => ctx.world.base.network === 'mainnet',
+    filter: async (ctx) => matchesDeployment(ctx, [{network: 'mainnet'}]), // XXX enable for Polygon
     tokenBalances: {
       $comet: { $base: 10000 },
     },

--- a/scenario/LiquidationBotScenario.ts
+++ b/scenario/LiquidationBotScenario.ts
@@ -222,7 +222,7 @@ for (let i = 0; i < MAX_ASSETS; i++) {
   const baseTokenBalances = {
     'mainnet': {
       'usdc': 2250000,
-      'weth': 20
+      'weth': 5000
     },
     'polygon': {
       'usdc': 3000000
@@ -246,7 +246,7 @@ for (let i = 0; i < MAX_ASSETS; i++) {
         // CB_ETH
         ' == 2000',
         // WST_ETH
-        ' == 5000'
+        ' == 3000'
       ]
     },
     'polygon': {

--- a/scenario/constraints/TokenBalanceConstraint.ts
+++ b/scenario/constraints/TokenBalanceConstraint.ts
@@ -7,8 +7,11 @@ import { exp } from '../../test/helpers';
 import { ComparativeAmount, ComparisonOp, getActorAddressFromName, getAssetFromName, parseAmount, getToTransferAmount } from '../utils';
 
 export class TokenBalanceConstraint<T extends CometContext, R extends Requirements> implements Constraint<T, R> {
-  async solve(requirements: R, _initialContext: T) {
-    const assetsByActor = requirements.tokenBalances;
+  async solve(requirements: R, initialContext: T) {
+    let assetsByActor = requirements.tokenBalances;
+    if (typeof assetsByActor === 'function') {
+      assetsByActor = await assetsByActor(initialContext);
+    }
     if (assetsByActor) {
       const actorsByAsset = Object.entries(assetsByActor).reduce((a, [actor, assets]) => {
         return Object.entries(assets).reduce((a, [asset, rawAmount]) => {


### PR DESCRIPTION
- add the fix for issue that ⛑️ found (`deployment` keys that should be `network` keys)
- reduce `cbETH` swap amounts from 1000 to 750 (due to shrinking liquidity)
- add deployment-specific base token amounts, so that we don't try to source 3M WETH for the `mainnet-weth` deployment