### PR TITLE
Support multiple connections to Seacrest in Enact

### DIFF
--- a/.github/workflows/enact-migration.yaml
+++ b/.github/workflows/enact-migration.yaml
@@ -12,9 +12,6 @@ on:
           - goerli
           - mumbai
           - polygon
-      different_enact_network:
-        type: boolean
-        description: Use a different network to enact the migration (e.g. used for cross-chain proposals that need to be made on mainnet)
       deployment:
         description: Deployment Name (e.g. "usdc")
         required: true
@@ -42,7 +39,6 @@ jobs:
       POLYGONSCAN_KEY: ${{ secrets.POLYGONSCAN_KEY }}
     steps:
       - name: Get governance network
-        if: ${{ github.event.inputs.different_enact_network == 'true' }}
         run: |
           case ${{ github.event.inputs.network }} in
             polygon)
@@ -50,7 +46,7 @@ jobs:
             mumbai)
                 echo "GOV_NETWORK=goerli" >> $GITHUB_ENV ;;
             *)
-              echo "No governance network for selected network" && exit 1 ;;
+                echo "No governance network for selected network" ;;
           esac
 
       - name: Seacrest
@@ -65,7 +61,7 @@ jobs:
         with:
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"kovan\":\"https://kovan.infura.io/v3/$INFURA_KEY\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\"}')[env.GOV_NETWORK] }}"
           port: 8685
-        if: github.event.inputs.eth_pk == '' && github.event.inputs.different_enact_network == 'true'
+        if: github.event.inputs.eth_pk == '' && env.GOV_NETWORK != ''
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -98,7 +94,7 @@ jobs:
           DEBUG: true
           ETH_PK: "${{ inputs.eth_pk }}"
           NETWORK_PROVIDER: ${{ fromJSON('["", "http://localhost:8585"]')[github.event.inputs.eth_pk == ''] }}
-          GOV_NETWORK_PROVIDER: ${{ fromJSON('["", "http://localhost:8685"]')[github.event.inputs.eth_pk == '' && github.event.inputs.different_enact_network == 'true'] }}
+          GOV_NETWORK_PROVIDER: ${{ fromJSON('["", "http://localhost:8685"]')[github.event.inputs.eth_pk == '' && env.GOV_NETWORK != ''] }}
           GOV_NETWORK: ${{ env.GOV_NETWORK }}
           REMOTE_ACCOUNTS: ${{ fromJSON('["", "true"]')[github.event.inputs.eth_pk == ''] }}
 

--- a/.github/workflows/enact-migration.yaml
+++ b/.github/workflows/enact-migration.yaml
@@ -12,6 +12,9 @@ on:
           - goerli
           - mumbai
           - polygon
+      different_enact_network:
+        type: boolean
+        description: Use a different network for enacting the migration (e.g. proposals that need to be made on mainnet)
       deployment:
         description: Deployment Name (e.g. "usdc")
         required: true
@@ -38,11 +41,30 @@ jobs:
       INFURA_KEY: ${{ secrets.INFURA_KEY }}
       POLYGONSCAN_KEY: ${{ secrets.POLYGONSCAN_KEY }}
     steps:
+      - name: Get governance network
+        if: ${{ github.event.inputs.different_enact_network == 'true' }}
+        run: |
+          case ${{ github.event.inputs.network }} in
+            polygon)
+                echo "GOV_NETWORK=mainnet" >> $GITHUB_ENV ;;
+            mumbai)
+                echo "GOV_NETWORK=goerli" >> $GITHUB_ENV ;;
+            *)
+              echo "No governance network for selected network" && exit 1 ;;
+          esac
+
       - name: Seacrest
         uses: hayesgm/seacrest@v1
         with:
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"kovan\":\"https://kovan.infura.io/v3/$INFURA_KEY\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
+        if: github.event.inputs.eth_pk == ''
+
+      - name: Seacrest (governance network)
+        uses: hayesgm/seacrest@v1
+        with:
+          ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"kovan\":\"https://kovan.infura.io/v3/$INFURA_KEY\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\"}')[env.GOV_NETWORK] }}"
+          port: 8685
         if: github.event.inputs.eth_pk == ''
 
       - name: Checkout repository
@@ -76,6 +98,8 @@ jobs:
           DEBUG: true
           ETH_PK: "${{ inputs.eth_pk }}"
           NETWORK_PROVIDER: ${{ fromJSON('["", "http://localhost:8585"]')[github.event.inputs.eth_pk == ''] }}
+          GOV_NETWORK_PROVIDER: ${{ fromJSON('["", "http://localhost:8685"]')[github.event.inputs.eth_pk == ''] }}
+          GOV_NETWORK: ${{ env.GOV_NETWORK }}
           REMOTE_ACCOUNTS: ${{ fromJSON('["", "true"]')[github.event.inputs.eth_pk == ''] }}
 
       - name: Commit changes

--- a/.github/workflows/enact-migration.yaml
+++ b/.github/workflows/enact-migration.yaml
@@ -14,7 +14,7 @@ on:
           - polygon
       different_enact_network:
         type: boolean
-        description: Use a different network for enacting the migration (e.g. proposals that need to be made on mainnet)
+        description: Use a different network to enact the migration (e.g. used for cross-chain proposals that need to be made on mainnet)
       deployment:
         description: Deployment Name (e.g. "usdc")
         required: true
@@ -65,7 +65,7 @@ jobs:
         with:
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"kovan\":\"https://kovan.infura.io/v3/$INFURA_KEY\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\"}')[env.GOV_NETWORK] }}"
           port: 8685
-        if: github.event.inputs.eth_pk == ''
+        if: github.event.inputs.eth_pk == '' && github.event.inputs.different_enact_network == 'true'
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -98,7 +98,7 @@ jobs:
           DEBUG: true
           ETH_PK: "${{ inputs.eth_pk }}"
           NETWORK_PROVIDER: ${{ fromJSON('["", "http://localhost:8585"]')[github.event.inputs.eth_pk == ''] }}
-          GOV_NETWORK_PROVIDER: ${{ fromJSON('["", "http://localhost:8685"]')[github.event.inputs.eth_pk == ''] }}
+          GOV_NETWORK_PROVIDER: ${{ fromJSON('["", "http://localhost:8685"]')[github.event.inputs.eth_pk == '' && github.event.inputs.different_enact_network == 'true'] }}
           GOV_NETWORK: ${{ env.GOV_NETWORK }}
           REMOTE_ACCOUNTS: ${{ fromJSON('["", "true"]')[github.event.inputs.eth_pk == ''] }}
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -39,7 +39,9 @@ const {
   POLYGONSCAN_KEY,
   REPORT_GAS = 'false',
   NETWORK_PROVIDER = '',
-  REMOTE_ACCOUNTS = '',
+  GOV_NETWORK_PROVIDER = '',
+  GOV_NETWORK = '',
+  REMOTE_ACCOUNTS = ''
 } = process.env;
 
 function *deriveAccounts(pk: string, n: number = 10) {
@@ -108,7 +110,11 @@ function setupDefaultNetworkProviders(hardhatConfig: HardhatUserConfig) {
   for (const netConfig of networkConfigs) {
     hardhatConfig.networks[netConfig.network] = {
       chainId: netConfig.chainId,
-      url: NETWORK_PROVIDER || netConfig.url || getDefaultProviderURL(netConfig.network),
+      url:
+        (netConfig.network === GOV_NETWORK ? GOV_NETWORK_PROVIDER : undefined) ||
+        NETWORK_PROVIDER ||
+        netConfig.url ||
+        getDefaultProviderURL(netConfig.network),
       gas: netConfig.gas || 'auto',
       gasPrice: netConfig.gasPrice || 'auto',
       accounts: REMOTE_ACCOUNTS ? "remote" : ( ETH_PK ? [...deriveAccounts(ETH_PK)] : { mnemonic: MNEMONIC } ),


### PR DESCRIPTION
Currently, running `Enact` in CI using Seacrest will fail when multiple networks are used (e.g. for cross-chain governance proposals that read from Polygon and write to mainnet). This is because Seacrest's connection with WalletConnect is for a specific chain, so trying to access a different chain will result in a `could not detect network` error.

This change supports making multiple connections to Seacrest/WalletConnect, all from a single phone. We introduce optional `GOV_NETWORK` and `GOV_NETWORK_PROVIDER` env variables to override the provider for a specific chain when creating the HREs. The `Enact` CI job determines the `GOV_NETWORK` based on what the original selected network is. 