### PR TITLE
Add ability to pre-populate rewards claimed for users in CometRewards

### DIFF
--- a/contracts/CometRewards.sol
+++ b/contracts/CometRewards.sol
@@ -42,6 +42,7 @@ contract CometRewards {
     /** Custom errors **/
 
     error AlreadyConfigured(address);
+    error BadData();
     error InvalidUInt64(uint);
     error NotPermitted(address);
     error NotSupported(address);
@@ -110,6 +111,22 @@ contract CometRewards {
      */
     function setRewardConfig(address comet, address token) external {
         setRewardConfigWithMultiplier(comet, token, FACTOR_SCALE);
+    }
+
+    /**
+     * @notice Set the rewards claimed for a list of users
+     * @param comet The protocol instance to populate the data for
+     * @param users The list of users to populate the data for
+     * @param claimedAmounts The list of claimed amounts to populate the data with
+     */
+    function setRewardsClaimed(address comet, address[] calldata users, uint[] calldata claimedAmounts) external {
+        if (msg.sender != governor) revert NotPermitted(msg.sender);
+        if (users.length != claimedAmounts.length) revert BadData();
+
+        for (uint i = 0; i < users.length; ) {
+            rewardsClaimed[comet][users[i]] = claimedAmounts[i];
+            unchecked { i++; }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR introduces a `setRewardsClaimed` function that gives the admin the ability to set rewards claimed for any user. This gives us the ability to initialize a new reward distribution that doesn't necessarily have to retroactively reward all past usage of Comet. 

We would have to compute off-chain the amount that each user would be able to claim at a specific block number `x` and write it on-chain via the `setRewardsClaimed` function. This allows us to essentially set the start time of the rewards accrual to be after that specific block number `x`.