### PR TITLE
`hasPurchasableCollateral` fixes for liquidation bot

### DIFF
--- a/scripts/liquidation_bot/index.ts
+++ b/scripts/liquidation_bot/index.ts
@@ -99,7 +99,7 @@ async function main() {
   let lastBlockNumber: number;
   let loops = 0;
   while (true) {
-    if (loops >= loopsUntilUpdateAssets) {
+    if (assets.length == 0 || loops >= loopsUntilUpdateAssets) {
       googleCloudLog(LogSeverity.INFO, 'Updating assets');
       assets = await getAssets(comet);
       loops = 0;

--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -292,8 +292,8 @@ async function getUniqueAddresses(comet: CometInterface): Promise<Set<string>> {
 }
 
 export async function hasPurchaseableCollateral(comet: CometInterface, assets: Asset[], minBaseValue: number): Promise<boolean> {
-  const baseReserves = await comet.getReserves();
-  const targetReserves = await comet.targetReserves();
+  const baseReserves = (await comet.getReserves()).toBigInt();
+  const targetReserves = (await comet.targetReserves()).toBigInt();
 
   if (baseReserves >= targetReserves) {
     return false;
@@ -364,6 +364,8 @@ export async function arbitragePurchaseableCollateral(
       network,
       deployment
     );
+  } else {
+    googleCloudLog(LogSeverity.INFO, `No purchasable collateral found`);
   }
 }
 

--- a/test/liquidation/liquidation-bot-script.ts
+++ b/test/liquidation/liquidation-bot-script.ts
@@ -51,7 +51,12 @@ describe('Liquidation Bot', function () {
         expect(await comet.isLiquidatable(underwater.address)).to.be.false;
 
         const assetAddresses = await getAssets(comet);
-        expect(await hasPurchaseableCollateral(comet, assetAddresses, 1)).to.be.false;
+        expect(await hasPurchaseableCollateral(comet, assetAddresses, 1e6)).to.be.false;
+        // make sure that hasPurchaseableCollateral is false not because the
+        // protocol has exceeded target reserves
+        expect(
+          (await comet.getReserves()).lt(await comet.targetReserves())
+        ).to.be.true;
       });
     }
   });
@@ -84,7 +89,12 @@ describe('Liquidation Bot', function () {
       );
 
       // There will be some dust to purchase, but we expect it to be less than $1 of worth
-      expect(await hasPurchaseableCollateral(comet, assetAddresses, 1)).to.be.false;
+      expect(await hasPurchaseableCollateral(comet, assetAddresses, 1e6)).to.be.false;
+      // make sure that hasPurchaseableCollateral is false not because the
+      // protocol has exceeded target reserves
+      expect(
+        (await comet.getReserves()).lt(await comet.targetReserves())
+      ).to.be.true;
     });
 
     it('buys all collateral when available', async function () {
@@ -117,7 +127,12 @@ describe('Liquidation Bot', function () {
       );
 
       // There will be some dust to purchase, but we expect it to be less than $1 of worth
-      expect(await hasPurchaseableCollateral(comet, assetAddresses, 1)).to.be.false;
+      expect(await hasPurchaseableCollateral(comet, assetAddresses, 1e6)).to.be.false;
+      // make sure that hasPurchaseableCollateral is false not because the
+      // protocol has exceeded target reserves
+      expect(
+        (await comet.getReserves()).lt(await comet.targetReserves())
+      ).to.be.true;
     });
 
     it('hasPurchaseableCollateral ignores dust collateral', async function () {
@@ -137,6 +152,11 @@ describe('Liquidation Bot', function () {
       expect(await hasPurchaseableCollateral(comet, assetAddresses, 0)).to.be.true;
       // There will be some dust to purchase, but we expect it to be less than $1 of worth
       expect(await hasPurchaseableCollateral(comet, assetAddresses, 1e6)).to.be.false;
+      // make sure that hasPurchaseableCollateral is false not because the
+      // protocol has exceeded target reserves
+      expect(
+        (await comet.getReserves()).lt(await comet.targetReserves())
+      ).to.be.true;
     });
 
     // XXX hasPurchaseableCollateral returns false when reserves are above target reserves

--- a/test/liquidation/makeLiquidatableProtocol.ts
+++ b/test/liquidation/makeLiquidatableProtocol.ts
@@ -79,7 +79,7 @@ export async function makeProtocol() {
     baseTrackingBorrowSpeed: exp(1, 15),
     baseMinForRewards: exp(1, 6),
     baseBorrowMin: exp(1, 6),
-    targetReserves: exp(1, 18),
+    targetReserves: exp(5_000_000, 6),
     assetConfigs: [
       {
         asset: COMP,
@@ -235,8 +235,8 @@ export async function makeLiquidatableProtocol() {
   await setTotalsBasic(comet, {
     baseBorrowIndex: 2e15,
     baseSupplyIndex: 2e15,
-    totalSupplyBase: 2e13,
-    totalBorrowBase: 2e13
+    totalSupplyBase: 2e11,
+    totalBorrowBase: 2e11
   });
 
   // create underwater user


### PR DESCRIPTION
After checking all addresses, the Liquidation Bot does a check for any purchasable collateral left in the protocol.

It checks the value of `baseReserves` against the value of `targetReserves` before checking for each asset.

`baseReserves` and `targetReserves` are both BigNumbers however, and they have their own comparison functions:

```
> BigNumber.from("10") > BigNumber.from("5")
false
> BigNumber.from("10").gt(BigNumber.from("5"))
true
```

Converting those values to BigInts first should get us the comparisons we expect.