### PR TITLE
Bump supply cap in Bulker scenario

### DIFF
--- a/scenario/BulkerScenario.ts
+++ b/scenario/BulkerScenario.ts
@@ -256,6 +256,9 @@ scenario(
   'Comet#bulker > (WETH base) all actions in one txn',
   {
     filter: async (ctx) => await isBulkerSupported(ctx) && await isRewardSupported(ctx) && matchesDeployment(ctx, [{deployment: 'weth'}]),
+    supplyCaps: {
+      $asset0: 10,
+    },
     tokenBalances: {
       albert: { $base: '== 10', $asset0: 10 },
       $comet: { $base: 5000 },


### PR DESCRIPTION
The Bulker scenario for the WETH market will fail whenever the supply cap is hit. This change ensures there is always ample supply cap before running the scenario.