### PR TITLE
add Polygon liquidation threshold

### DIFF
--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -48,6 +48,9 @@ const liquidationThresholds = {
   },
   'goerli': {
     'usdc': 10e6
+  },
+  'polygon': {
+    'usdc': 10e6
   }
 };
 


### PR DESCRIPTION
The Polygon Liquidation Bot was failing because we do not define a liquidation threshold (the smallest value that the Liquidation Bot will attempt to buy/sell) for Polygon/USDC.

~~Also, increasing the mainnet/USDC liquidation threshold so we get fewer liquidation attempts where the Bot will spend $90 in gas to earn $40.~~ Bumping USDC involves updating some tests, unexpectedly. Going to keep this change simple and just fix the Polygon issue for now.