### PR TITLE
fix hasPurchasableCollateral price calculation

### DIFF
--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -332,6 +332,7 @@ async function getUniqueAddresses(comet: CometInterface): Promise<Set<string>> {
 export async function hasPurchaseableCollateral(comet: CometInterface, assets: Asset[], minBaseValue: number): Promise<boolean> {
   const baseReserves = (await comet.getReserves()).toBigInt();
   const targetReserves = (await comet.targetReserves()).toBigInt();
+  const baseScale = (await comet.baseScale()).toBigInt();
 
   if (baseReserves >= targetReserves) {
     return false;
@@ -340,7 +341,8 @@ export async function hasPurchaseableCollateral(comet: CometInterface, assets: A
   for (const asset of assets) {
     const collateralReserves = await comet.getCollateralReserves(asset.address);
     const price = await comet.getPrice(asset.priceFeed);
-    const value = collateralReserves.toBigInt() * price.toBigInt() / asset.scale;
+    const priceScale = exp(1, 8);
+    const value = collateralReserves.toBigInt() * price.toBigInt() * baseScale / asset.scale / priceScale;
     if (value >= minBaseValue) {
       return true;
     }


### PR DESCRIPTION
Currently, the protocol has a small amount of WETH for sale: 700000385672350.

The price from ChainLink for WETH is around 141226378000.

The bot calculates the price as `collateralReserves * price / assetScale`:

```
700000385672350 * 141226378000 / 1e18 = 98_858_519
``` 
So the price value we're using here is $98 USDC. That's off by two decimal places, it's actually ~$0.98:

![image](https://user-images.githubusercontent.com/2570291/224412160-86aa0025-2212-422f-8dfb-5d6ca21223b3.png)

So the bot thinks there is $98 of WETH for sale; it attempts to buy this purchasable collateral (passing in the 10e6 liquidation threshold as an argument). The contract receives the request, sees that there is less than 10e6 worth of collateral for sale, and emits an `AbsorbWithoutBuyingCollateral` event. The bot just spent $7 in gas, and nothing is changed.

I think this changed with the updates we made for the WETH deployment: https://github.com/compound-finance/comet/pull/587/files#diff-cf7a634160dd0cbfb8b9cbeb2fc76e6e132fd4abd055f0a46fdd28e728af8585R294

The function used to take a dollar amount as an argument, and multiply it by 1e8 to approximate the ChainLink price value for that much USD.

We later changed that argument to be an amount of the base asset (in the base asset's scale), but we didn't update the `value` calculation to account for the base asset's scale.

So the actual calculation should be `collateralReserves * price * baseScale / assetScale / priceScale`:

```
700000385672350 * 141226378000 * 1e6 / 1e18 / 1e8 = 988_585
```

aka $.98 USDC