### PR TITLE
Add token sweeping functions to Arbitrum Bridge Receiver

### DIFF
--- a/contracts/bridges/SweepableBridgeReceiver.sol
+++ b/contracts/bridges/SweepableBridgeReceiver.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.15;
+
+import "../IERC20NonStandard.sol";
+import "./BaseBridgeReceiver.sol";
+
+contract SweepableBridgeReceiver is BaseBridgeReceiver {
+    error FailedToSendNativeToken();
+    error TransferOutFailed();
+
+    /**
+     * @notice A public function to sweep accidental ERC-20 transfers to this contract
+     * @dev Note: Make sure to check that the asset being swept out is not malicious
+     * @param recipient The address that will receive the swept funds
+     * @param asset The address of the ERC-20 token to sweep
+     */
+    function sweepToken(address recipient, address asset) external {
+        if (msg.sender != localTimelock) revert Unauthorized();
+
+        uint256 balance = IERC20NonStandard(asset).balanceOf(address(this));
+        doTransferOut(asset, recipient, balance);
+    }
+
+    /**
+     * @notice A public function to sweep accidental native token transfers to this contract
+     * @param recipient The address that will receive the swept funds
+     */
+    function sweepNativeToken(address recipient) external {
+        if (msg.sender != localTimelock) revert Unauthorized();
+
+        uint256 balance = address(this).balance;
+        (bool success, ) = recipient.call{ value: balance }("");
+        if (!success) revert FailedToSendNativeToken();
+    }
+
+    /**
+     * @notice Similar to ERC-20 transfer, except it properly handles `transfer` from non-standard ERC-20 tokens
+     * @param asset The ERC-20 token to transfer out
+     * @param to The recipient of the token transfer
+     * @param amount The amount of the token to transfer
+     * @dev Note: This wrapper safely handles non-standard ERC-20 tokens that do not return a value. See here: https://medium.com/coinmonks/missing-return-value-bug-at-least-130-tokens-affected-d67bf08521ca
+     */
+    function doTransferOut(address asset, address to, uint amount) internal {
+        IERC20NonStandard(asset).transfer(to, amount);
+
+        bool success;
+        assembly {
+            switch returndatasize()
+                case 0 {                      // This is a non-standard ERC-20
+                    success := not(0)         // set success to true
+                }
+                case 32 {                     // This is a compliant ERC-20
+                    returndatacopy(0, 0, 32)
+                    success := mload(0)       // Set `success = returndata` of override external call
+                }
+                default {                     // This is an excessively non-compliant ERC-20, revert.
+                    revert(0, 0)
+                }
+        }
+        if (!success) revert TransferOutFailed();
+    }
+}

--- a/contracts/bridges/arbitrum/ArbitrumBridgeReceiver.sol
+++ b/contracts/bridges/arbitrum/ArbitrumBridgeReceiver.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.15;
 
-import "../BaseBridgeReceiver.sol";
+import "../SweepableBridgeReceiver.sol";
 import "./AddressAliasHelper.sol";
 
-contract ArbitrumBridgeReceiver is BaseBridgeReceiver {
+contract ArbitrumBridgeReceiver is SweepableBridgeReceiver {
     fallback() external payable {
         processMessage(AddressAliasHelper.undoL1ToL2Alias(msg.sender), msg.data);
     }

--- a/contracts/bridges/test/SweepableBridgeReceiverHarness.sol
+++ b/contracts/bridges/test/SweepableBridgeReceiverHarness.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.15;
+
+import "../SweepableBridgeReceiver.sol";
+
+contract SweepableBridgeReceiverHarness is SweepableBridgeReceiver {
+    function processMessageExternal(
+        address rootMessageSender,
+        bytes calldata data
+    ) external {
+        processMessage(rootMessageSender, data);
+    }
+
+    fallback() external payable { }
+}

--- a/test/bridges/base-bridge-receiver-test.ts
+++ b/test/bridges/base-bridge-receiver-test.ts
@@ -13,7 +13,7 @@ enum ProposalState {
   Executed = 2
 }
 
-async function makeTimelock({ admin }: { admin: string }) {
+export async function makeTimelock({ admin }: { admin: string }) {
   const TimelockFactory = (await ethers.getContractFactory('Timelock')) as Timelock__factory;
   const timelock = await TimelockFactory.deploy(
     admin,              // admin
@@ -51,7 +51,7 @@ async function makeBridgeReceiver({ initialize } = { initialize: true }) {
   };
 }
 
-function encodeBridgeReceiverCalldata({ targets, values, signatures, calldatas }) {
+export function encodeBridgeReceiverCalldata({ targets, values, signatures, calldatas }) {
   return utils.defaultAbiCoder.encode(BRIDGE_RECEIVER_CALLDATA_ABI, [targets, values, signatures, calldatas]);
 }
 

--- a/test/bridges/sweepable-bridge-receiver-test.ts
+++ b/test/bridges/sweepable-bridge-receiver-test.ts
@@ -1,0 +1,181 @@
+import { ethers, exp, expect, wait } from './../helpers';
+import { utils } from 'ethers';
+import {
+  SweepableBridgeReceiverHarness__factory,
+  FaucetToken__factory,
+  NonStandardFaucetToken__factory,
+} from '../../build/types';
+import { encodeBridgeReceiverCalldata, makeTimelock } from './base-bridge-receiver-test';
+
+async function makeSweepableBridgeReceiver({ initialize } = { initialize: true }) {
+  const [_defaultSigner, govTimelockAdmin, ...signers] = await ethers.getSigners();
+
+  const SweepableBridgeReceiverFactory = (await ethers.getContractFactory('SweepableBridgeReceiverHarness')) as SweepableBridgeReceiverHarness__factory;
+  const sweepableBridgeReceiver = await SweepableBridgeReceiverFactory.deploy();
+  await sweepableBridgeReceiver.deployed();
+
+  const govTimelock = await makeTimelock({ admin: govTimelockAdmin.address });
+  const localTimelock = await makeTimelock({ admin: sweepableBridgeReceiver.address });
+
+  if (initialize) {
+    await sweepableBridgeReceiver.initialize(
+      govTimelock.address,   // govTimelock
+      localTimelock.address  // localTimelock
+    );
+  }
+
+  return {
+    sweepableBridgeReceiver,
+    govTimelock,
+    localTimelock,
+    signers
+  };
+}
+
+async function makeFaucetToken(initialAmount: number, name: string, decimals: number, symbol: string) {
+  const FaucetFactory = (await ethers.getContractFactory('FaucetToken')) as FaucetToken__factory;
+  const token = await FaucetFactory.deploy(initialAmount, name, decimals, symbol);
+  await token.deployed();
+
+  return token;
+}
+
+async function proposeAndExecute(sweepableBridgeReceiver, govTimelock, { targets, values, signatures, calldatas }) {
+  // enqueue proposal to sweep tokens
+  const calldata = encodeBridgeReceiverCalldata({
+    targets,
+    values,
+    signatures,
+    calldatas
+  });
+  await sweepableBridgeReceiver.processMessageExternal(govTimelock.address, calldata);
+
+  // execute proposal to sweep tokens
+  const { eta } = await sweepableBridgeReceiver.proposals(1);
+  await ethers.provider.send('evm_setNextBlockTimestamp', [eta.toNumber()]);
+  await wait(sweepableBridgeReceiver.executeProposal(1));
+}
+
+describe('SweepableBridgeReceiver', async() => {
+  it('sweeps standard ERC20 token', async () => {
+    const { sweepableBridgeReceiver, localTimelock, govTimelock, signers } = await makeSweepableBridgeReceiver();
+    const [alice] = signers;
+
+    const USDC = await makeFaucetToken(1e6, 'USDC', 6, 'USDC');
+
+    // Alice "accidentally" sends 10 USDC to the SweepableBridgeReceiver
+    const transferAmount = exp(10, 6);
+    await USDC.allocateTo(alice.address, transferAmount);
+    await USDC.connect(alice).transfer(sweepableBridgeReceiver.address, transferAmount);
+
+    const oldBridgeReceiverBalance = await USDC.balanceOf(sweepableBridgeReceiver.address);
+    const oldTimelockBalance = await USDC.balanceOf(localTimelock.address);
+
+    await proposeAndExecute(
+      sweepableBridgeReceiver,
+      govTimelock,
+      {
+        targets: [sweepableBridgeReceiver.address],
+        values: [0],
+        signatures: ['sweepToken(address,address)'],
+        calldatas: [
+          utils.defaultAbiCoder.encode(['address', 'address'], [localTimelock.address, USDC.address]),
+        ]
+      }
+    );
+
+    const newBridgeReceiverBalance = await USDC.balanceOf(sweepableBridgeReceiver.address);
+    const newTimelockBalance = await USDC.balanceOf(localTimelock.address);
+
+    expect(newBridgeReceiverBalance.sub(oldBridgeReceiverBalance)).to.be.equal(-transferAmount);
+    expect(newTimelockBalance.sub(oldTimelockBalance)).to.be.equal(transferAmount);
+  });
+
+  it('sweeps non-standard ERC20 token', async () => {
+    const { sweepableBridgeReceiver, localTimelock, govTimelock, signers } = await makeSweepableBridgeReceiver();
+    const [alice] = signers;
+
+    // Deploy non-standard token
+    const NonStandardFaucetFactory = (await ethers.getContractFactory('NonStandardFaucetToken')) as NonStandardFaucetToken__factory;
+    const nonStandardToken = await NonStandardFaucetFactory.deploy(1000e6, 'Tether', 6, 'USDT');
+    await nonStandardToken.deployed();
+
+    // Alice "accidentally" sends 10 non-standard tokens to the Bulker
+    const transferAmount = exp(10, 6);
+    await nonStandardToken.allocateTo(alice.address, transferAmount);
+    await nonStandardToken.connect(alice).transfer(sweepableBridgeReceiver.address, transferAmount);
+
+    const oldBridgeReceiverBalance = await nonStandardToken.balanceOf(sweepableBridgeReceiver.address);
+    const oldTimelockBalance = await nonStandardToken.balanceOf(localTimelock.address);
+
+    await proposeAndExecute(
+      sweepableBridgeReceiver,
+      govTimelock,
+      {
+        targets: [sweepableBridgeReceiver.address],
+        values: [0],
+        signatures: ['sweepToken(address,address)'],
+        calldatas: [
+          utils.defaultAbiCoder.encode(['address', 'address'], [localTimelock.address, nonStandardToken.address]),
+        ]
+      }
+    );
+
+    const newBridgeReceiverBalance = await nonStandardToken.balanceOf(sweepableBridgeReceiver.address);
+    const newTimelockBalance = await nonStandardToken.balanceOf(localTimelock.address);
+
+    expect(newBridgeReceiverBalance.sub(oldBridgeReceiverBalance)).to.be.equal(-transferAmount);
+    expect(newTimelockBalance.sub(oldTimelockBalance)).to.be.equal(transferAmount);
+  });
+
+  it('sweeps native token', async () => {
+    const { sweepableBridgeReceiver, localTimelock, govTimelock, signers } = await makeSweepableBridgeReceiver();
+    const [alice] = signers;
+
+    // Alice "accidentally" sends 1 ETH to the sweepableBridgeReceiver
+    const transferAmount = exp(1, 18);
+    await alice.sendTransaction({ to: sweepableBridgeReceiver.address, value: transferAmount });
+
+    const oldBridgeReceiverBalance = await ethers.provider.getBalance(sweepableBridgeReceiver.address);
+    const oldTimelockBalance = await ethers.provider.getBalance(localTimelock.address);
+
+    await proposeAndExecute(
+      sweepableBridgeReceiver,
+      govTimelock,
+      {
+        targets: [sweepableBridgeReceiver.address],
+        values: [0],
+        signatures: ['sweepNativeToken(address)'],
+        calldatas: [
+          utils.defaultAbiCoder.encode(['address'], [localTimelock.address]),
+        ]
+      }
+    );
+
+    const newBridgeReceiverBalance = await ethers.provider.getBalance(sweepableBridgeReceiver.address);
+    const newTimelockBalance = await ethers.provider.getBalance(localTimelock.address);
+
+    expect(newBridgeReceiverBalance.sub(oldBridgeReceiverBalance)).to.be.equal(-transferAmount);
+    expect(newTimelockBalance.sub(oldTimelockBalance)).to.be.equal(transferAmount);
+  });
+
+  it('reverts if sweepToken is called by address other than local timelock', async () => {
+    const { sweepableBridgeReceiver, signers } = await makeSweepableBridgeReceiver();
+    const [alice] = signers;
+
+    const USDC = await makeFaucetToken(1e6, 'USDC', 6, 'USDC');
+
+    // Alice sweeps tokens
+    await expect(sweepableBridgeReceiver.connect(alice).sweepToken(alice.address, USDC.address))
+      .to.be.revertedWith("custom error 'Unauthorized()'");
+  });
+
+  it('reverts if sweepNativeToken is called by non-admin', async () => {
+    const { sweepableBridgeReceiver, signers } = await makeSweepableBridgeReceiver();
+    const [alice] = signers;
+
+    // Alice sweeps ETH
+    await expect(sweepableBridgeReceiver.connect(alice).sweepNativeToken(alice.address))
+      .to.be.revertedWith("custom error 'Unauthorized()'");
+  });
+});


### PR DESCRIPTION
This PR adds native token and ERC20 sweeping functions to the Arbitrum bridge receiver per OpenZeppelin's recommendations.

Changes include:
- a `SweepableBridgeReceiver` contract, which exposes `sweepToken` and `sweepNativeToken` functions that can be called by the localTimelock (adapted from the Bulker contract
- ~~a`BridgeReceiverCore` contract that is shared by `BaseBridgeReceiver` and `SweepableBridgeReceiver` (to allow both to use the `localTimelock` variable and the `Unauthorized` custom error)~~
- unit tests, including a SweepableBridgeReceiver harness contract
