### PR TITLE
Create custom price feed for WBTC

### DIFF
--- a/contracts/pricefeeds/ConstantPriceFeed.sol
+++ b/contracts/pricefeeds/ConstantPriceFeed.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.15;
 
-import "./IPriceFeed.sol";
+import "../IPriceFeed.sol";
 
 /**
  * @title Constant price feed

--- a/contracts/pricefeeds/ScalingPriceFeed.sol
+++ b/contracts/pricefeeds/ScalingPriceFeed.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.15;
 
-import "./vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
-import "./IPriceFeed.sol";
+import "../vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import "../IPriceFeed.sol";
 
 /**
  * @title Scaling price feed

--- a/contracts/pricefeeds/WBTCPriceFeed.sol
+++ b/contracts/pricefeeds/WBTCPriceFeed.sol
@@ -68,13 +68,13 @@ contract WBTCPriceFeed is IPriceFeed {
         uint256 updatedAt,
         uint80 answeredInRound
     ) {
-        (uint80 roundIdA, int256 WBTCToBTCPrice, uint256 startedAtA, uint256 updatedAtA, uint80 answeredInRoundA) = AggregatorV3Interface(WBTCToBTCPriceFeed).latestRoundData();
-        (uint80 roundIdB, int256 BTCToUSDPrice, uint256 startedAtB, uint256 updatedAtB, uint80 answeredInRoundB) = AggregatorV3Interface(BTCToUSDPriceFeed).latestRoundData();
+        (, int256 WBTCToBTCPrice, , , ) = AggregatorV3Interface(WBTCToBTCPriceFeed).latestRoundData();
+        (uint80 roundId_, int256 BTCToUSDPrice, uint256 startedAt_, uint256 updatedAt_, uint80 answeredInRound_) = AggregatorV3Interface(BTCToUSDPriceFeed).latestRoundData();
 
         // We use return the round data of the BTC / USD price feed because of its shorter heartbeat (1hr vs 24hr)
-        if (WBTCToBTCPrice <= 0 || BTCToUSDPrice <= 0) return (roundIdB, 0, startedAtB, updatedAtB, answeredInRoundB);
+        if (WBTCToBTCPrice <= 0 || BTCToUSDPrice <= 0) return (roundId_, 0, startedAt_, updatedAt_, answeredInRound_);
 
         int256 price = WBTCToBTCPrice * BTCToUSDPrice * priceFeedScale / combinedScale;
-        return (roundIdB, price, startedAtB, updatedAtB, answeredInRoundB);
+        return (roundId_, price, startedAt_, updatedAt_, answeredInRound_);
     }
 }

--- a/contracts/pricefeeds/WBTCPriceFeed.sol
+++ b/contracts/pricefeeds/WBTCPriceFeed.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.15;
+
+import "../vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import "../IPriceFeed.sol";
+
+/**
+ * @title WBTC price feed
+ * @notice A custom price feed that calculates the price for WBTC / USD
+ * @author Compound
+ */
+contract WBTCPriceFeed is IPriceFeed {
+    /** Custom errors **/
+    error BadDecimals();
+    error InvalidInt256();
+
+    /// @notice Version of the price feed
+    uint public constant override version = 1;
+
+    /// @notice Description of the price feed
+    string public constant override description = "Custom price feed for WBTC / USD";
+
+    /// @notice Number of decimals for returned prices
+    uint8 public immutable override decimals;
+
+    /// @notice Chainlink WBTC / BTC price feed
+    address public immutable WBTCToBTCPriceFeed;
+
+    /// @notice Chainlink BTC / USD price feed
+    address public immutable BTCToUSDPriceFeed;
+
+    /// @notice Combined scale of the two underlying Chainlink price feeds
+    int public immutable combinedScale;
+
+    /// @notice Scale of this price feed
+    int public immutable priceFeedScale;
+
+    constructor(address WBTCToBTCPriceFeed_, address BTCToUSDPriceFeed_, uint8 decimals_) {
+        WBTCToBTCPriceFeed = WBTCToBTCPriceFeed_;
+        BTCToUSDPriceFeed = BTCToUSDPriceFeed_;
+        uint8 WBTCToBTCPriceFeedDecimals = AggregatorV3Interface(WBTCToBTCPriceFeed_).decimals();
+        uint8 BTCToUSDPriceFeedDecimals = AggregatorV3Interface(BTCToUSDPriceFeed_).decimals();
+
+        combinedScale = signed256(10 ** (WBTCToBTCPriceFeedDecimals + BTCToUSDPriceFeedDecimals));
+
+        if (decimals_ > 18) revert BadDecimals();
+        decimals = decimals_;
+        priceFeedScale = int256(10 ** decimals);
+    }
+
+    function signed256(uint256 n) internal pure returns (int256) {
+        if (n > uint256(type(int256).max)) revert InvalidInt256();
+        return int256(n);
+    }
+
+    /**
+     * @notice WBTC price for the latest round
+     * @return roundId Round id from the WBTC price feed
+     * @return answer Latest price for WBTC / USD
+     * @return startedAt Timestamp when the round was started; passed on from WBTC price feed
+     * @return updatedAt Timestamp when the round was last updated; passed on from WBTC price feed
+     * @return answeredInRound Round id in which the answer was computed; passed on from WBTC price feed
+     **/
+    function latestRoundData() override external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        (uint80 roundIdA, int256 WBTCToBTCPrice, uint256 startedAtA, uint256 updatedAtA, uint80 answeredInRoundA) = AggregatorV3Interface(WBTCToBTCPriceFeed).latestRoundData();
+        (uint80 roundIdB, int256 BTCToUSDPrice, uint256 startedAtB, uint256 updatedAtB, uint80 answeredInRoundB) = AggregatorV3Interface(BTCToUSDPriceFeed).latestRoundData();
+
+        // We use return the round data of the BTC / USD price feed because of its shorter heartbeat (1hr vs 24hr)
+        if (WBTCToBTCPrice <= 0 || BTCToUSDPrice <= 0) return (roundIdB, 0, startedAtB, updatedAtB, answeredInRoundB);
+
+        int256 price = WBTCToBTCPrice * BTCToUSDPrice * priceFeedScale / combinedScale;
+        return (roundIdB, price, startedAtB, updatedAtB, answeredInRoundB);
+    }
+}

--- a/contracts/pricefeeds/WBTCPriceFeed.sol
+++ b/contracts/pricefeeds/WBTCPriceFeed.sol
@@ -61,13 +61,7 @@ contract WBTCPriceFeed is IPriceFeed {
      * @return updatedAt Timestamp when the round was last updated; passed on from the BTC / USD price feed
      * @return answeredInRound Round id in which the answer was computed; passed on from the BTC / USD price feed
      **/
-    function latestRoundData() override external view returns (
-        uint80 roundId,
-        int256 answer,
-        uint256 startedAt,
-        uint256 updatedAt,
-        uint80 answeredInRound
-    ) {
+    function latestRoundData() override external view returns (uint80, int256, uint256, uint256, uint80) {
         (, int256 WBTCToBTCPrice, , , ) = AggregatorV3Interface(WBTCToBTCPriceFeed).latestRoundData();
         (uint80 roundId_, int256 BTCToUSDPrice, uint256 startedAt_, uint256 updatedAt_, uint80 answeredInRound_) = AggregatorV3Interface(BTCToUSDPriceFeed).latestRoundData();
 

--- a/contracts/pricefeeds/WBTCPriceFeed.sol
+++ b/contracts/pricefeeds/WBTCPriceFeed.sol
@@ -35,12 +35,17 @@ contract WBTCPriceFeed is IPriceFeed {
     /// @notice Scale of this price feed
     int public immutable priceFeedScale;
 
+    /**
+     * @notice Construct a new WBTC / USD price feed
+     * @param WBTCToBTCPriceFeed_ The address of the WBTC / BTC price feed to fetch prices from
+     * @param BTCToUSDPriceFeed_ The address of the BTC / USD price feed to fetch prices from
+     * @param decimals_ The number of decimals for the returned prices
+     **/
     constructor(address WBTCToBTCPriceFeed_, address BTCToUSDPriceFeed_, uint8 decimals_) {
         WBTCToBTCPriceFeed = WBTCToBTCPriceFeed_;
         BTCToUSDPriceFeed = BTCToUSDPriceFeed_;
         uint8 WBTCToBTCPriceFeedDecimals = AggregatorV3Interface(WBTCToBTCPriceFeed_).decimals();
         uint8 BTCToUSDPriceFeedDecimals = AggregatorV3Interface(BTCToUSDPriceFeed_).decimals();
-
         combinedScale = signed256(10 ** (WBTCToBTCPriceFeedDecimals + BTCToUSDPriceFeedDecimals));
 
         if (decimals_ > 18) revert BadDecimals();
@@ -48,18 +53,13 @@ contract WBTCPriceFeed is IPriceFeed {
         priceFeedScale = int256(10 ** decimals);
     }
 
-    function signed256(uint256 n) internal pure returns (int256) {
-        if (n > uint256(type(int256).max)) revert InvalidInt256();
-        return int256(n);
-    }
-
     /**
      * @notice WBTC price for the latest round
-     * @return roundId Round id from the WBTC price feed
+     * @return roundId Round id from the BTC / USD price feed
      * @return answer Latest price for WBTC / USD
-     * @return startedAt Timestamp when the round was started; passed on from WBTC price feed
-     * @return updatedAt Timestamp when the round was last updated; passed on from WBTC price feed
-     * @return answeredInRound Round id in which the answer was computed; passed on from WBTC price feed
+     * @return startedAt Timestamp when the round was started; passed on from the BTC / USD price feed
+     * @return updatedAt Timestamp when the round was last updated; passed on from the BTC / USD price feed
+     * @return answeredInRound Round id in which the answer was computed; passed on from the BTC / USD price feed
      **/
     function latestRoundData() override external view returns (
         uint80 roundId,
@@ -71,10 +71,15 @@ contract WBTCPriceFeed is IPriceFeed {
         (, int256 WBTCToBTCPrice, , , ) = AggregatorV3Interface(WBTCToBTCPriceFeed).latestRoundData();
         (uint80 roundId_, int256 BTCToUSDPrice, uint256 startedAt_, uint256 updatedAt_, uint80 answeredInRound_) = AggregatorV3Interface(BTCToUSDPriceFeed).latestRoundData();
 
-        // We use return the round data of the BTC / USD price feed because of its shorter heartbeat (1hr vs 24hr)
+        // We return the round data of the BTC / USD price feed because of its shorter heartbeat (1hr vs 24hr)
         if (WBTCToBTCPrice <= 0 || BTCToUSDPrice <= 0) return (roundId_, 0, startedAt_, updatedAt_, answeredInRound_);
 
         int256 price = WBTCToBTCPrice * BTCToUSDPrice * priceFeedScale / combinedScale;
         return (roundId_, price, startedAt_, updatedAt_, answeredInRound_);
+    }
+
+    function signed256(uint256 n) internal pure returns (int256) {
+        if (n > uint256(type(int256).max)) revert InvalidInt256();
+        return int256(n);
     }
 }

--- a/contracts/pricefeeds/WstETHPriceFeed.sol
+++ b/contracts/pricefeeds/WstETHPriceFeed.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.15;
 
-import "./vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
-import "./IPriceFeed.sol";
-import "./IWstETH.sol";
+import "../vendor/@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import "../IPriceFeed.sol";
+import "../IWstETH.sol";
 
 /**
  * @title wstETH price feed

--- a/test/wbtc-price-feed.ts
+++ b/test/wbtc-price-feed.ts
@@ -1,0 +1,134 @@
+import { ethers, exp, expect } from './helpers';
+import {
+  SimplePriceFeed__factory,
+  WBTCPriceFeed__factory
+} from '../build/types';
+
+export async function makeWBTCPriceFeed({ WBTCToBTCPrice, BTCToUSDPrice }) {
+  const SimplePriceFeedFactory = (await ethers.getContractFactory('SimplePriceFeed')) as SimplePriceFeed__factory;
+  const WBTCToBTCPriceFeed = await SimplePriceFeedFactory.deploy(WBTCToBTCPrice, 8);
+  await WBTCToBTCPriceFeed.deployed();
+  
+  const BTCToUSDPriceFeed = await SimplePriceFeedFactory.deploy(BTCToUSDPrice, 8);
+  await BTCToUSDPriceFeed.deployed();
+
+  const WBTCPriceFeedFactory = (await ethers.getContractFactory('WBTCPriceFeed')) as WBTCPriceFeed__factory;
+  const WBTCPriceFeed = await WBTCPriceFeedFactory.deploy(WBTCToBTCPriceFeed.address, BTCToUSDPriceFeed.address, 8);
+  await WBTCPriceFeed.deployed();
+
+  return {
+    WBTCToBTCPriceFeed,
+    BTCToUSDPriceFeed,
+    WBTCPriceFeed
+  };
+}
+
+const testCases = [
+  {
+    WBTCToBTCPrice: exp(1, 8),
+    BTCToUSDPrice: exp(30_000, 8),
+    result: exp(30_000, 8)
+  },
+  {
+    WBTCToBTCPrice: exp(2.123456, 8),
+    BTCToUSDPrice: exp(31_333.123, 8),
+    result: 6653450803308n
+  },
+  {
+    WBTCToBTCPrice: exp(100, 8),
+    BTCToUSDPrice: exp(30_000, 8),
+    result: exp(3_000_000, 8)
+  },
+  {
+    WBTCToBTCPrice: exp(0.9999, 8),
+    BTCToUSDPrice: exp(30_000, 8),
+    result: exp(29_997, 8)
+  },
+  {
+    WBTCToBTCPrice: exp(0.987937, 8),
+    BTCToUSDPrice: exp(31_947.71623, 8),
+    result: 3156233092911n
+  },
+  {
+    WBTCToBTCPrice: exp(0.5, 8),
+    BTCToUSDPrice: exp(30_000, 8),
+    result: exp(15_000, 8)
+  },
+  {
+    WBTCToBTCPrice: exp(0.00555, 8),
+    BTCToUSDPrice: exp(30_000, 8),
+    result: exp(166.5, 8)
+  },
+  {
+    WBTCToBTCPrice: exp(0, 8),
+    BTCToUSDPrice: exp(30_000, 8),
+    result: exp(0, 8)
+  },
+  {
+    WBTCToBTCPrice: exp(1, 8),
+    BTCToUSDPrice: exp(0, 8),
+    result: exp(0, 8)
+  },
+  {
+    WBTCToBTCPrice: exp(0, 8),
+    BTCToUSDPrice: exp(0, 8),
+    result: exp(0, 8)
+  },
+];
+
+describe('WBTC price feed', function () {
+  it('reverts if constructed with bad decimals', async () => {
+    const SimplePriceFeedFactory = (await ethers.getContractFactory('SimplePriceFeed')) as SimplePriceFeed__factory;
+    const WBTCToBTCPriceFeed = await SimplePriceFeedFactory.deploy(exp(1, 8), 8);
+    await WBTCToBTCPriceFeed.deployed();
+    
+    const BTCToUSDPriceFeed = await SimplePriceFeedFactory.deploy(exp(30_000), 8);
+    await BTCToUSDPriceFeed.deployed();
+  
+    const WBTCPriceFeedFactory = (await ethers.getContractFactory('WBTCPriceFeed')) as WBTCPriceFeed__factory;
+    await expect(WBTCPriceFeedFactory.deploy(
+      WBTCToBTCPriceFeed.address,
+      BTCToUSDPriceFeed.address,
+      20 // decimals_ is too high
+    )).to.be.revertedWith("custom error 'BadDecimals()'");
+  });
+
+  describe('latestRoundData', function () {
+    for (const { WBTCToBTCPrice, BTCToUSDPrice, result } of testCases) {
+      it(`WBTCToBTCPrice (${WBTCToBTCPrice}), BTCToUSDPrice (${BTCToUSDPrice}) -> ${result}`, async () => {
+        const { WBTCPriceFeed } = await makeWBTCPriceFeed({ WBTCToBTCPrice, BTCToUSDPrice });
+        const latestRoundData = await WBTCPriceFeed.latestRoundData();
+        const price = latestRoundData.answer.toBigInt();
+
+        expect(price).to.eq(result);
+      });
+    }
+
+    it('passes along roundId, startedAt, updatedAt and answeredInRound values from BTC / USD price feed', async () => {
+      const { BTCToUSDPriceFeed, WBTCPriceFeed } = await makeWBTCPriceFeed({
+        WBTCToBTCPrice: exp(1, 18),
+        BTCToUSDPrice: exp(30_000, 18),
+      });
+
+      await BTCToUSDPriceFeed.setRoundData(
+        exp(15, 18), // roundId_,
+        1,           // answer_,
+        exp(16, 8),  // startedAt_,
+        exp(17, 8),  // updatedAt_,
+        exp(18, 18)  // answeredInRound_
+      );
+
+      const {
+        roundId,
+        startedAt,
+        updatedAt,
+        answeredInRound
+      } = await WBTCPriceFeed.latestRoundData();
+
+      expect(roundId.toBigInt()).to.eq(exp(15, 18));
+      expect(startedAt.toBigInt()).to.eq(exp(16, 8));
+      expect(updatedAt.toBigInt()).to.eq(exp(17, 8));
+      expect(answeredInRound.toBigInt()).to.eq(exp(18, 18));
+    });
+  });
+});


### PR DESCRIPTION
This PR creates a custom price feed for WBTC / USD by reading from both the WBTC / BTC and BTC / USD price feeds. This will allow the cUSDCv3 market to get a more accurate price for WBTC.

We also organize the contracts repo by moving all the custom price feed contracts into a separate `pricefeeds` subdirectory.