### PR TITLE
Proposal to upgrade Goerli governor to allow sending ETH from the Timelock

### DIFF
--- a/deployments/goerli/usdc/migrations/1681942579_upgrade_governor_bravo.ts
+++ b/deployments/goerli/usdc/migrations/1681942579_upgrade_governor_bravo.ts
@@ -48,6 +48,10 @@ export default migration('1681942579_upgrade_governor_bravo', {
     trace(`Created proposal ${proposalId}.`);
   },
 
+  async enacted(deploymentManager: DeploymentManager): Promise<boolean> {
+    return true;
+  },
+
   async verify(deploymentManager: DeploymentManager) {
     await deploymentManager.spider(); // We spider here to pull in the updated governor impl address
     const { 'governor:implementation': governorImpl } = await deploymentManager.getContracts();

--- a/deployments/goerli/usdc/migrations/1681942579_upgrade_governor_bravo.ts
+++ b/deployments/goerli/usdc/migrations/1681942579_upgrade_governor_bravo.ts
@@ -1,0 +1,47 @@
+import { DeploymentManager } from '../../../../plugins/deployment_manager/DeploymentManager';
+import { migration } from '../../../../plugins/deployment_manager/Migration';
+import { proposal } from '../../../../src/deploy';
+
+const clone = {
+  governorImpl: '0xeF3B6E9e13706A8F01fe98fdCf66335dc5CfdEED'
+};
+
+export default migration('1681942579_upgrade_governor_bravo', {
+  prepare: async (deploymentManager: DeploymentManager) => {
+    return {};
+  },
+
+  enact: async (deploymentManager: DeploymentManager, govDeploymentManager: DeploymentManager) => {
+    const trace = deploymentManager.tracer();
+
+    const {
+      governor,
+    } = await deploymentManager.getContracts();
+
+    // Deploy new governor implementation (cloned from mainnet)
+    const newGovernorImpl = await deploymentManager.clone(
+      'governor:implementation',
+      clone.governorImpl,
+      [],
+      'mainnet'
+    );
+
+    const actions = [
+      // 1. Set implementation of the governor to the new governor implementation
+      {
+        contract: governor,
+        signature: '_setImplementation(address)',
+        args: [newGovernorImpl.address],
+      },
+    ];
+    const description = "# Update governor implementation\n\n## Explanation\n\nUpdates the governor implementation to allow for sending ETH from the Timelock. \n";
+    const txn = await deploymentManager.retry(
+      async () => governor.propose(...await proposal(actions, description))
+    );
+    trace(txn);
+
+    const event = (await txn.wait()).events.find(event => event.event === 'ProposalCreated');
+    const [proposalId] = event.args;
+    trace(`Created proposal ${proposalId}.`);
+  },
+});

--- a/tasks/deployment_manager/task.ts
+++ b/tasks/deployment_manager/task.ts
@@ -178,7 +178,7 @@ task('migrate', 'Runs migration')
         maybeForkEnv,
         {
           writeCacheToDisk: !simulate || overwrite, // Don't write to disk when simulating, unless overwrite is set
-          verificationStrategy: 'lazy',
+          verificationStrategy: 'eager', // We use eager here to verify contracts right after they are deployed
         }
       );
       await dm.spider();
@@ -196,7 +196,7 @@ task('migrate', 'Runs migration')
           governanceEnv,
           {
             writeCacheToDisk: !simulate || overwrite, // Don't write to disk when simulating, unless overwrite is set
-            verificationStrategy: 'lazy',
+            verificationStrategy: 'eager', // We use eager here to verify contracts right after they are deployed
           }
         );
         await governanceDm.spider();


### PR DESCRIPTION
This governor upgrade was made on mainnet last year in [proposal 115](https://compound.finance/governance/proposals/115), but never made to Goerli.

Migration job: https://github.com/compound-finance/comet/actions/runs/4758731465/jobs/8457147538
On-chain proposal: https://compound.finance/governance/proposals/73?target_network=goerli