### PR TITLE
QoL improvement for verifying contracts when deploying

### DIFF
--- a/.github/workflows/deploy-market.yaml
+++ b/.github/workflows/deploy-market.yaml
@@ -62,6 +62,12 @@ jobs:
           NETWORK_PROVIDER: ${{ fromJSON('["", "http://localhost:8585"]')[github.event.inputs.eth_pk == ''] }}
           REMOTE_ACCOUNTS: ${{ fromJSON('["", "true"]')[github.event.inputs.eth_pk == ''] }}
 
+      - uses: actions/upload-artifact@v2 # upload test results
+        if: success() || failure() # run this step even if previous step failed
+        with:
+          name: ${{ github.event.inputs.network }}-${{ github.event.inputs.deployment }}-verify-args
+          path: deployments/${{ github.event.inputs.network }}/${{ github.event.inputs.deployment }}/verify/args.json
+
       - name: Commit changes
         if: ${{ github.event.inputs.simulate == 'false' }}
         run: |

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -181,6 +181,17 @@ const config: HardhatUserConfig = {
       polygon: POLYGONSCAN_KEY,
       polygonMumbai: POLYGONSCAN_KEY,
     },
+    customChains: [
+      {
+        // Hardhat's Etherscan plugin calls the network `optimisticGoerli`, so we need to add an entry for our own network name
+        network: 'optimism-goerli',
+        chainId: 420,
+        urls: {
+          apiURL: 'https://api-goerli-optimistic.etherscan.io',
+          browserURL: 'goerli-optimism.etherscan.io'
+        }
+      }
+    ]
   },
 
   typechain: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -280,7 +280,7 @@ const config: HardhatUserConfig = {
         output: 'test-results.json',
       },
     },
-    timeout: 100_000
+    timeout: 150_000
   },
 
   paths: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -181,17 +181,6 @@ const config: HardhatUserConfig = {
       polygon: POLYGONSCAN_KEY,
       polygonMumbai: POLYGONSCAN_KEY,
     },
-    customChains: [
-      {
-        // Hardhat's Etherscan plugin calls the network `optimisticGoerli`, so we need to add an entry for our own network name
-        network: 'optimism-goerli',
-        chainId: 420,
-        urls: {
-          apiURL: 'https://api-goerli-optimistic.etherscan.io',
-          browserURL: 'goerli-optimism.etherscan.io'
-        }
-      }
-    ]
   },
 
   typechain: {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@compound-finance/hardhat-import": "^1.0.3",
     "@ethersproject/experimental": "^5.6.3",
     "@nomiclabs/hardhat-ethers": "^2.0.4",
-    "@nomiclabs/hardhat-etherscan": "3.0.0",
+    "@nomiclabs/hardhat-etherscan": "3.1.7",
     "@safe-global/safe-core-sdk": "^3.3.2",
     "@safe-global/safe-ethers-lib": "^1.9.2",
     "@typechain/ethers-v5": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "deep-object-diff": "^1.1.9",
-    "jest-diff": "^27.4.2"
+    "jest-diff": "^27.4.2",
+    "undici": "^5.21.0"
   },
   "devDependencies": {
     "@compound-finance/hardhat-import": "^1.0.3",

--- a/plugins/deployment_manager/DeploymentManager.ts
+++ b/plugins/deployment_manager/DeploymentManager.ts
@@ -272,9 +272,9 @@ export class DeploymentManager {
     const verifyArgsMap = await getVerifyArgs(this.cache);
     for (const [address, verifyArgs] of verifyArgsMap) {
       if (filter == undefined || await filter(address, verifyArgs)) {
-        await this.verifyContract(verifyArgs);
+        const success = await this.verifyContract(verifyArgs);
         // Clear from cache after successfully verifying
-        await deleteVerifyArgs(this.cache, address);
+        if (success) await deleteVerifyArgs(this.cache, address);
       }
     }
   }

--- a/plugins/deployment_manager/DeploymentManager.ts
+++ b/plugins/deployment_manager/DeploymentManager.ts
@@ -280,8 +280,8 @@ export class DeploymentManager {
   }
 
   /* Verifies a contract with the given args and deployment manager hre/opts */
-  async verifyContract(args: VerifyArgs) {
-    return verifyContract(args, this.hre, (await this.deployOpts()).raiseOnVerificationFailure);
+  async verifyContract(args: VerifyArgs): Promise<boolean> {
+    return await verifyContract(args, this.hre, (await this.deployOpts()).raiseOnVerificationFailure);
   }
 
   /* Loads contract configuration by tracing from roots outwards, based on relationConfig */

--- a/plugins/deployment_manager/ManualVerify.ts
+++ b/plugins/deployment_manager/ManualVerify.ts
@@ -31,7 +31,7 @@ export async function manualVerifyContract(
     'verify:get-etherscan-endpoint'
   );
 
-  const etherscanAPIKey = resolveEtherscanApiKey(hre.config.etherscan, verificationNetwork);
+  const etherscanAPIKey = resolveEtherscanApiKey(hre.config.etherscan.apiKey, verificationNetwork);
   const contractAddress = contract.address.toLowerCase();
   const sourceName = contractMetadata.source;
   const metadata = JSON.parse(contractMetadata.metadata);

--- a/plugins/deployment_manager/Verify.ts
+++ b/plugins/deployment_manager/Verify.ts
@@ -56,6 +56,6 @@ export async function verifyContract(
         success = false;
       }
     }
-    return success;
   }
+  return success;
 }

--- a/plugins/deployment_manager/Verify.ts
+++ b/plugins/deployment_manager/Verify.ts
@@ -16,8 +16,9 @@ export async function verifyContract(
   hre: HardhatRuntimeEnvironment,
   raise = false,
   retries = 10
-) {
+): Promise<boolean> {
   let address;
+  let success;
   try {
     if (verifyArgs.via === 'artifacts') {
       address = verifyArgs.address;
@@ -34,13 +35,14 @@ export async function verifyContract(
         hre
       );
     } else {
-      throw new Error(`Unknown verfication via`);
+      throw new Error(`Unknown verification via`);
     }
     debug('Contract at address ' + address + ' verified on Etherscan.');
+    success = true;
   } catch (e) {
     if (e.message.match(/Already Verified/i)) {
       debug('Contract at address ' + address + ' is already verified on Etherscan');
-      return;
+      success = true;
     } else if (e.message.match(/does not have bytecode/i) && retries > 0) {
       debug('Waiting for ' + address + ' to propagate to Etherscan');
       await new Promise((resolve) => setTimeout(resolve, 5000));
@@ -51,7 +53,9 @@ export async function verifyContract(
       } else {
         console.error(`Unable to verify contract at ${address}: ${e}`);
         console.error(`Continuing on anyway...`);
+        success = false;
       }
     }
+    return success;
   }
 }

--- a/plugins/deployment_manager/test/DeploymentManagerTest.ts
+++ b/plugins/deployment_manager/test/DeploymentManagerTest.ts
@@ -13,7 +13,7 @@ import { DeploymentManager } from '../DeploymentManager';
 import { fiatTokenBuildFile, mockImportSuccess } from './ImportTest';
 import { Migration } from '../Migration';
 import { expectedTemplate } from './MigrationTemplateTest';
-import { faucetTokenBuildFile, tokenArgs } from './DeployHelpers';
+import { buildToken, faucetTokenBuildFile, tokenArgs } from './DeployHelpers';
 import { tempDir } from './TestHelpers';
 import { VerifyArgs } from '../Verify';
 import { getVerifyArgs, putVerifyArgs } from '../VerifyArgs';
@@ -133,24 +133,26 @@ describe('DeploymentManager', () => {
   });
 
   describe('verifyContracts', () => {
-    it('should verify contracts succesfully', async () => {
+    it('should verify contracts successfully', async () => {
       let deploymentManager = new DeploymentManager('test-network', 'test-deployment', hre, {
         importRetries: 0,
         writeCacheToDisk: true,
         baseDir: tempDir(),
       });
+      // We have to deploy a contract because the Etherscan plugin checks the bytecode at the address
+      let token = await buildToken();
       let verifyArgs: VerifyArgs = {
         via: 'artifacts',
-        address: '0x0000000000000000000000000000000000000000',
-        constructorArguments: []
+        address: token.address,
+        constructorArguments: tokenArgs
       };
       await putVerifyArgs(
         deploymentManager.cache,
-        '0x0000000000000000000000000000000000000000',
+        token.address,
         verifyArgs
       );
       expect(objectFromMap(await getVerifyArgs(deploymentManager.cache))).to.eql({
-        '0x0000000000000000000000000000000000000000': verifyArgs
+        [token.address]: verifyArgs
       });
 
       mockVerifySuccess(hre);

--- a/tasks/deployment_manager/task.ts
+++ b/tasks/deployment_manager/task.ts
@@ -89,8 +89,6 @@ task('deploy', 'Deploys market')
         console.log(`[${tag}]\n${dm.diffDelta(delta)}`);
       } catch (e) {
         console.log(`[${tag}] Failed to deploy with error: ${e}`);
-        console.log(`[${tag}] VerifyArgs for deployed but unverified contracts will be uploaded if this is run in CI. VerifyArgs are:`);
-        console.log(await getVerifyArgs(dm.cache));
       }
     }
 

--- a/tasks/deployment_manager/task.ts
+++ b/tasks/deployment_manager/task.ts
@@ -5,7 +5,6 @@ import { HardhatRuntimeEnvironment, HardhatConfig } from 'hardhat/types';
 import { DeploymentManager, VerifyArgs } from '../../plugins/deployment_manager';
 import { impersonateAddress } from '../../plugins/scenario/utils';
 import hreForBase from '../../plugins/scenario/utils/hreForBase';
-import { getVerifyArgs } from '../../plugins/deployment_manager/VerifyArgs';
 
 // TODO: Don't depend on scenario's hreForBase
 function getForkEnv(env: HardhatRuntimeEnvironment): HardhatRuntimeEnvironment {

--- a/tasks/deployment_manager/task.ts
+++ b/tasks/deployment_manager/task.ts
@@ -5,6 +5,7 @@ import { HardhatRuntimeEnvironment, HardhatConfig } from 'hardhat/types';
 import { DeploymentManager, VerifyArgs } from '../../plugins/deployment_manager';
 import { impersonateAddress } from '../../plugins/scenario/utils';
 import hreForBase from '../../plugins/scenario/utils/hreForBase';
+import { getVerifyArgs } from '../../plugins/deployment_manager/VerifyArgs';
 
 // TODO: Don't depend on scenario's hreForBase
 function getForkEnv(env: HardhatRuntimeEnvironment): HardhatRuntimeEnvironment {
@@ -81,10 +82,16 @@ task('deploy', 'Deploys market')
     if (noDeploy) {
       // Don't run the deploy script
     } else {
-      const overrides = undefined; // TODO: pass through cli args
-      const delta = await dm.runDeployScript(overrides ?? { allMissing: true });
-      console.log(`[${tag}] Deployed ${dm.counter} contracts, spent ${dm.spent} Ξ`);
-      console.log(`[${tag}]\n${dm.diffDelta(delta)}`);
+      try {
+        const overrides = undefined; // TODO: pass through cli args
+        const delta = await dm.runDeployScript(overrides ?? { allMissing: true });
+        console.log(`[${tag}] Deployed ${dm.counter} contracts, spent ${dm.spent} Ξ`);
+        console.log(`[${tag}]\n${dm.diffDelta(delta)}`);
+      } catch (e) {
+        console.log(`[${tag}] Failed to deploy with error: ${e}`);
+        console.log(`[${tag}] Printing out VerifyArgs for already deployed but unverified contracts: `)
+        console.log(await getVerifyArgs(dm.cache));
+      }
     }
 
     const verify = noVerify ? false : !simulate;

--- a/tasks/deployment_manager/task.ts
+++ b/tasks/deployment_manager/task.ts
@@ -89,7 +89,7 @@ task('deploy', 'Deploys market')
         console.log(`[${tag}]\n${dm.diffDelta(delta)}`);
       } catch (e) {
         console.log(`[${tag}] Failed to deploy with error: ${e}`);
-        console.log(`[${tag}] Printing out VerifyArgs for already deployed but unverified contracts: `)
+        console.log(`[${tag}] VerifyArgs for deployed but unverified contracts will be uploaded if this is run in CI. VerifyArgs are:`);
         console.log(await getVerifyArgs(dm.cache));
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5224,7 +5224,7 @@ uglify-js@^3.1.4:
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.3.tgz#f0feedf019c4510f164099e8d7e72ff2d7304377"
   integrity sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==
 
-undici@^5.14.0:
+undici@^5.14.0, undici@^5.21.0:
   version "5.22.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.22.0.tgz#5e205d82a5aecc003fc4388ccd3d2c6e8674a0ad"
   integrity sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -740,18 +740,21 @@
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.0.tgz#f55ace2752d0effcf583e754960e9fa89fbe12cd"
   integrity sha512-kKCW7xawuD/lw69Yr1yqUUrF0IKmnLNGf+pTVbJ/ctHaRcPrwKI0EPkO1RNXBHlOOZkv6v4DK2PPvq0lL2ykig==
 
-"@nomiclabs/hardhat-etherscan@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.0.0.tgz#06e0d59787f01f1296d829e8d43fece50e7ffff1"
-  integrity sha512-E5s35dCHmzuY6pFqlgTdDGQr2xIyUJ3f91m6e7HYlPGz0FGzad9Nem/y0L7L3FHG4LPYg1UObkQVUzqBjtyAOA==
+"@nomiclabs/hardhat-etherscan@3.1.7":
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.7.tgz#72e3d5bd5d0ceb695e097a7f6f5ff6fcbf062b9a"
+  integrity sha512-tZ3TvSgpvsQ6B6OGmo1/Au6u8BrAkvs1mIC/eURA3xgIfznUZBhmpne8hv7BXUzw9xNL3fXdpOYgOQlVMTcoHQ==
   dependencies:
     "@ethersproject/abi" "^5.1.2"
     "@ethersproject/address" "^5.0.2"
-    cbor "^5.0.2"
+    cbor "^8.1.0"
+    chalk "^2.4.2"
     debug "^4.1.1"
     fs-extra "^7.0.1"
-    node-fetch "^2.6.0"
+    lodash "^4.17.11"
     semver "^6.3.0"
+    table "^6.8.0"
+    undici "^5.14.0"
 
 "@safe-global/safe-core-sdk-types@^1.9.0":
   version "1.9.0"
@@ -1219,6 +1222,16 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.6.1, ajv@^6.9.1:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^8.0.1:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
@@ -1367,6 +1380,11 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
 async-eventemitter@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/async-eventemitter/-/async-eventemitter-0.2.4.tgz#f5e7c8ca7d3e46aab9ec40a292baf686a0bafaca"
@@ -1463,11 +1481,6 @@ bignumber.js@^9.0.0:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.1.tgz#c4df7dc496bd849d4c9464344c1aa74228b4dac6"
   integrity sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==
-
-bignumber.js@^9.0.1:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.0.tgz#8d340146107fe3a6cb8d40699643c302e8773b62"
-  integrity sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -1641,13 +1654,12 @@ catering@^2.1.0, catering@^2.1.1:
   resolved "https://registry.yarnpkg.com/catering/-/catering-2.1.1.tgz#66acba06ed5ee28d5286133982a927de9a04b510"
   integrity sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==
 
-cbor@^5.0.2:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/cbor/-/cbor-5.2.0.tgz#4cca67783ccd6de7b50ab4ed62636712f287a67c"
-  integrity sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==
+cbor@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-8.1.0.tgz#cfc56437e770b73417a2ecbfc9caf6b771af60d5"
+  integrity sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==
   dependencies:
-    bignumber.js "^9.0.1"
-    nofilter "^1.0.4"
+    nofilter "^3.1.0"
 
 chai-as-promised@^7.1.1:
   version "7.1.1"
@@ -3565,6 +3577,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
@@ -3690,6 +3707,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
 lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
@@ -3973,7 +3995,7 @@ node-addon-api@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
-node-fetch@2, node-fetch@2.6.7, node-fetch@^2.6.0:
+node-fetch@2, node-fetch@2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -3985,10 +4007,10 @@ node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.5.0.tgz#7a64eefa0b21112f89f58379da128ac177f20e40"
   integrity sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==
 
-nofilter@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-1.0.4.tgz#78d6f4b6a613e7ced8b015cec534625f7667006e"
-  integrity sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==
+nofilter@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
+  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
 
 nopt@3.x:
   version "3.0.6"
@@ -4416,7 +4438,7 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
-require-from-string@^2.0.0:
+require-from-string@^2.0.0, require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
@@ -4684,6 +4706,15 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
+
 solc@0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/solc/-/solc-0.7.3.tgz#04646961bd867a744f63d2b4e3c0701ffdc7d78a"
@@ -4805,7 +4836,7 @@ string-width@^3.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.1.0, string-width@^4.2.0:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4929,6 +4960,17 @@ table@^5.2.3:
     lodash "^4.17.14"
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
+
+table@^6.8.0:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
+  integrity sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
 
 text-table@^0.2.0:
   version "0.2.0"
@@ -5181,6 +5223,13 @@ uglify-js@^3.1.4:
   version "3.17.3"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.3.tgz#f0feedf019c4510f164099e8d7e72ff2d7304377"
   integrity sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==
+
+undici@^5.14.0:
+  version "5.22.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.22.0.tgz#5e205d82a5aecc003fc4388ccd3d2c6e8674a0ad"
+  integrity sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==
+  dependencies:
+    busboy "^1.6.0"
 
 undici@^5.4.0:
   version "5.11.0"


### PR DESCRIPTION
This PR improves the deploy step by allowing us to recover the `VerifyArgs` if a deploy job fails mid-deploy. This allows us to easily resume verification of contracts that were deployed but not yet verified. We also upgrade `hardhat-etherscan` to support verifying contracts on L2s.

The changes in this PR are extracted from #728, which currently lives on the Optimism branch. I'm moving them to main since these are generic quality of life improvements that should be used on other branches as well, such as the Arbitrum one.