### PR TITLE
Adding the Semgrep worflow by Decurity

### DIFF
--- a/.github/workflows/run-semgrep.yaml
+++ b/.github/workflows/run-semgrep.yaml
@@ -24,17 +24,23 @@ jobs:
     steps:
       # Fetch project source with GitHub Actions Checkout.
       - uses: actions/checkout@v3
-      # Fetch rules
-      - name: Fetch semgrep rules
-        uses: actions/checkout@v2
+      # Fetch generic rules
+      - name: Fetch generic semgrep rules
+        uses: actions/checkout@v3
         with:
           repository: decurity/semgrep-smart-contracts
           path: rules
-      # Run security & performance rules
+      # Fetch Compound rules
+      - name: Fetch Compound semgrep rules
+        uses: actions/checkout@v3
+        with:
+          repository: decurity/compound-semgrep-rules
+          path: compound
+      # Run security, performance & Compound specific rules
       - run: semgrep ci --sarif --output=semgrep.sarif || true
         env:
-           SEMGREP_RULES: rules/solidity/security rules/solidity/performance
-
+           SEMGREP_RULES: rules/solidity/security rules/solidity/performance compound/solidity
+      # Upload findings to GitHub Advanced Security Dashboard
       - name: Upload findings to GitHub Advanced Security Dashboard
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/.github/workflows/run-semgrep.yaml
+++ b/.github/workflows/run-semgrep.yaml
@@ -1,0 +1,42 @@
+# Name of this GitHub Actions workflow.
+name: Run Semgrep
+
+on:
+  # Scan changed files in PRs (diff-aware scanning):
+  pull_request: {}
+  # On-demand 
+  workflow_dispatch: {}
+
+jobs:
+  semgrep:
+    # User-definable name of this GitHub Actions job:
+    name: Scan
+    # If you are self-hosting, change the following `runs-on` value: 
+    runs-on: ubuntu-latest
+
+    container:
+      # A Docker image with Semgrep installed. Do not change this.
+      image: returntocorp/semgrep
+
+    # Skip any PR created by dependabot to avoid permission issues:
+    if: (github.actor != 'dependabot[bot]')
+
+    steps:
+      # Fetch project source with GitHub Actions Checkout.
+      - uses: actions/checkout@v3
+      # Fetch rules
+      - name: Fetch semgrep rules
+        uses: actions/checkout@v2
+        with:
+          repository: decurity/semgrep-smart-contracts
+          path: rules
+      # Run security & performance rules
+      - run: semgrep ci --sarif --output=semgrep.sarif || true
+        env:
+           SEMGREP_RULES: rules/solidity/security rules/solidity/performance
+
+      - name: Upload findings to GitHub Advanced Security Dashboard
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: semgrep.sarif
+        if: always()

--- a/.github/workflows/run-semgrep.yaml
+++ b/.github/workflows/run-semgrep.yaml
@@ -13,7 +13,11 @@ jobs:
     name: Scan
     # If you are self-hosting, change the following `runs-on` value: 
     runs-on: ubuntu-latest
-
+    env:
+      ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_KEY }}
+      SNOWTRACE_KEY: ${{ secrets.SNOWTRACE_KEY }}
+      INFURA_KEY: ${{ secrets.INFURA_KEY }}
+      POLYGONSCAN_KEY: ${{ secrets.POLYGONSCAN_KEY }}
     container:
       # A Docker image with Semgrep installed. Do not change this.
       image: returntocorp/semgrep


### PR DESCRIPTION
This Semgrep workflow runs 2 rule sets over all the pull requests.
The rule sets include both generic Solidity security detections and the comet-specific ones.
We've reviewed the comet repository issues, pull requests and commits and created a few rules according to the fixes that were proposed by OZ/ChainSecurity/Certora and have been accepted by Compound.
Most of the issues have been closed without fixes, and some of others are unfeasible to detect with Semgrep.

You can see it in action here: https://github.com/Decurity/comet/pull/2

Right now if you run these rules over the whole comet codebase, the stats is as follows:
Ran 9 rules on 36 files: 32 findings.

23 of these are missing sanity checks on constructor arguments (each argument = 1 finding). Of course many of them might not require the sanity checks so this rule can spam the alerts if run over the whole codebase but can be useful if run over the new contracts (there's only one constructor, so there won't be overwhelmingly many findings)

Also there's a couple of "A constant name is not in UPPER_CASE like other constant variables." and "Event parameters with type 'address' should be indexed" findings.
