### PR TITLE
misc liquidation bot fixes

### DIFF
--- a/scripts/liquidation_bot/index.ts
+++ b/scripts/liquidation_bot/index.ts
@@ -49,7 +49,7 @@ async function main() {
   await dm.spider();
 
   const contracts = await dm.contracts();
-  const comet = contracts.get('comet') as CometInterface;
+  let comet = contracts.get('comet') as CometInterface;
 
   // Flashbots provider requires passing in a standard provider
   let flashbotsProvider: FlashbotsBundleProvider;
@@ -85,6 +85,9 @@ async function main() {
   }
 
   const signerWithFlashbots = { signer, flashbotsProvider };
+
+  // connect Comet instance to the signer, so direct calls to Comet functions have a signer
+  comet = comet.connect(signer);
 
   if (!comet) {
     throw new Error(`no deployed Comet found for ${network}/${deployment}`);

--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -299,13 +299,15 @@ async function attemptLiquidationViaOnChainLiquidator(
     const txn = await liquidator.populateTransaction.absorbAndArbitrage(
       ...args,
       {
-        gasLimit: Math.ceil(1.1 * (await liquidator.estimateGas.absorbAndArbitrage(...args)).toNumber()),
-        gasPrice: Math.ceil(1.1 * (await hre.ethers.provider.getGasPrice()).toNumber()),
+        gasLimit: Math.ceil(1.3 * (await liquidator.estimateGas.absorbAndArbitrage(...args)).toNumber()),
+        gasPrice: Math.ceil(1.3 * (await hre.ethers.provider.getGasPrice()).toNumber()),
       }
     );
 
     // ensure that .populateTransaction has not added a "from" key
     delete txn.from;
+
+    txn.chainId = hre.ethers.provider.network.chainId;
 
     const success = await sendTxn(txn, signerWithFlashbots);
 


### PR DESCRIPTION
Three fixes

- include a chainId in the transaction (Flashbots has begun validating this field and will reject transactions that fail to include it)
- increase the gas multiplier to be more competitive with our transactions
- connect the Comet instance to the signer so that direct calls on Comet (e.g. `await comet.absorb(signerAddress, targetAddresses)`) will succeed