### PR TITLE
Make updateBasePrincipal virtual to facilitate Comet extension

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -738,7 +738,7 @@ contract Comet is CometMainInterface {
     /**
      * @dev Write updated principal to store and tracking participation
      */
-    function updateBasePrincipal(address account, UserBasic memory basic, int104 principalNew) internal {
+    function updateBasePrincipal(address account, UserBasic memory basic, int104 principalNew) internal virtual {
         int104 principal = basic.principal;
         basic.principal = principalNew;
 


### PR DESCRIPTION
My team [received a grant](https://questbook.app/dashboard/?grantId=0xeb047900b28a9f90f3c0e65768b23e7542a65163&isRenderingProposalBody=true&proposalId=0x21b&chainId=10) from [CGP 2.0](https://docs.google.com/document/d/1PYYFazs9XxcidJn0Q0zl-XZEHWTaWZh_KX72Ym6qS0Y/edit) to add [Flexible Voting](https://github.com/ScopeLift/flexible-voting/) support to Compound V3. 

In order to implement our extension we need to be able to determine, for any given block:
1. how much principal a given account has supplied up to that time, and
1. how much total principal has been supplied to Comet up to that time

Our belief is that the easiest way to do this involves overriding the `Comet.updateBasePrincipal` function to store a couple checkpoints. You can see the PR for this work in https://github.com/ScopeLift/flexible-voting/pull/46, and the specific overrides we need to make [here](https://github.com/ScopeLift/flexible-voting/pull/46/files#diff-fb68bdd9eeee8debdaad8b1a3571bc1bdc5065576ebcd5e4c71e75f589f111dbR34-R41). Since `updateBasePrincipal` is the single way that principal balances are updated by the system, being able to add checkpointing to it greatly simplifies our task.

Thanks in advance!
