### PR TITLE
Skip utilization scenarios for Goerli USDC

### DIFF
--- a/scenario/InterestRateScenario.ts
+++ b/scenario/InterestRateScenario.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { annualize, defactor, exp } from '../test/helpers';
 import { BigNumber } from 'ethers';
 import { FuzzType } from './constraints/Fuzzing';
+import { matchesDeployment } from './utils';
 
 function calculateInterestRate(
   utilization: BigNumber,
@@ -91,6 +92,9 @@ scenario(
       borrowPerYearInterestRateSlopeHigh: exp(0.3, 18),
     },
     utilization: 0.5,
+    // XXX this scenario fails for Goerli cUSDCv3 because someone supplied 100bn USDC and it's no longer
+    // possible to increase the utilization up to the target amount
+    filter: async (ctx) => !matchesDeployment(ctx, [{network: 'goerli', deployment: 'usdc'}])
   },
   async ({ comet }) => {
     const utilization = await comet.getUtilization();
@@ -114,6 +118,9 @@ scenario(
       borrowPerYearInterestRateSlopeHigh: exp(0.3, 18),
     },
     utilization: 0.85,
+    // XXX this scenario fails for Goerli cUSDCv3 because someone supplied 100bn USDC and it's no longer
+    // possible to increase the utilization up to the target amount
+    filter: async (ctx) => !matchesDeployment(ctx, [{network: 'goerli', deployment: 'usdc'}])
   },
   async ({ comet }) => {
     const utilization = await comet.getUtilization();


### PR DESCRIPTION
Someone supplied 100bn USDC to the Goerli USDC market, which caused 2 scenarios using the utilization constraint to fail because it became impossible to achieve a target utilization with so much supply in the market. This PR skips those 2 scenarios.

Another solution is to enhance the utilization constraint such that it can also withdraw base supplied by whales to achieve the target utilization.