### PR TITLE
Do not attach signer to comet instance

### DIFF
--- a/scripts/liquidation_bot/index.ts
+++ b/scripts/liquidation_bot/index.ts
@@ -86,9 +86,6 @@ async function main() {
 
   const signerWithFlashbots = { signer, flashbotsProvider };
 
-  // connect Comet instance to the signer, so direct calls to Comet functions have a signer
-  comet = comet.connect(signer);
-
   if (!comet) {
     throw new Error(`no deployed Comet found for ${network}/${deployment}`);
   }

--- a/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
+++ b/scripts/liquidation_bot/liquidateUnderwaterBorrowers.ts
@@ -300,7 +300,7 @@ async function attemptLiquidation(
     // absorb addresses...
     if (targetAddresses.length > 0) {
       const signerAddress = await signerWithFlashbots.signer.getAddress();
-      await comet.absorb(signerAddress, targetAddresses);
+      await comet.connect(signerWithFlashbots.signer).absorb(signerAddress, targetAddresses);
     }
 
     // 3) buy smaller and smaller quantities of assets individually


### PR DESCRIPTION
In #748, we updated the Comet instance used in the liquidation bot to attach the signer before being passed around as an argument.

https://github.com/compound-finance/comet/pull/748/files#diff-985edbf80fe4c689f86ad3dcd779b4effe7ead300ec1f6dd5068f7b8d47e41eeR90

This approach doesn't work when `USE_FLASHBOTS` is set to `true`. In that case, we set the signer to be an Ethers Wallet, which has the side-effect of removing the Provider from the Comet instance. Subsequent attempts to read values via the provider fail.