### PR TITLE
Make OptimismBridgeReceiver sweepable

### DIFF
--- a/contracts/bridges/optimism/OptimismBridgeReceiver.sol
+++ b/contracts/bridges/optimism/OptimismBridgeReceiver.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.15;
 
-import "../BaseBridgeReceiver.sol";
+import "../SweepableBridgeReceiver.sol";
 import "./IOvmL2CrossDomainMessengerInterface.sol";
 
-contract OptimismBridgeReceiver is BaseBridgeReceiver {
+contract OptimismBridgeReceiver is SweepableBridgeReceiver {
     error InvalidCrossDomainMessenger();
 
     event NewCrossDomainMessenger(address indexed oldCrossDomainMessenger, address indexed newCrossDomainMessenger);


### PR DESCRIPTION
This change should extend the `OptimismBridgeReceiver` with some functionality to sweep ERC20 and native tokens.