### PR TITLE
Remove Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,0 @@
-artifacts
-build
-cache
-coverage
-deployments/*/.contracts
-deployments/*/*/*.json
-dist
-SPEC.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,0 @@
-{
-  "singleQuote": true,
-  "printWidth": 100
-}


### PR DESCRIPTION
The Comet repo currently has rules set up for both Prettier and ESLint, even though we only enforce the rules for ESLint. The move from Prettier to ESLint was decided in https://github.com/compound-finance/comet/pull/321. 

Keeping the Prettier configs in the repo while not enforcing them is arguably worse than just not having the configs in the first place, since contributors may end up running the Prettier (e.g. via VSCode auto-format) for some files and introduce very large diffs. Removing Prettier should help reduce the formatting diffs introduced by contributors.

