### PR TITLE
Upgrade git action to use new seacrest

### DIFF
--- a/.github/workflows/deploy-market.yaml
+++ b/.github/workflows/deploy-market.yaml
@@ -35,22 +35,11 @@ jobs:
       ARBISCAN_KEY: ${{ secrets.ARBISCAN_KEY }}
       LINEASCAN_KEY: ${{ secrets.LINEASCAN_KEY }}
     steps:
-      - name: Get governance network
-        run: |
-          case ${{ github.event.inputs.network }} in
-            polygon | arbitrum)
-                echo "GOV_NETWORK=mainnet" >> $GITHUB_ENV ;;
-            mumbai | arbitrum-goerli | base-goerli | linea-goerli)
-                echo "GOV_NETWORK=goerli" >> $GITHUB_ENV ;;
-            *)
-                echo "No governance network for selected network" ;;
-          esac
-
       - name: Seacrest
         uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
-          requested_network: "${{ env.GOV_NETWORK }}"
+          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[inputs.network] }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet-eth.compound.finance\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''

--- a/.github/workflows/deploy-market.yaml
+++ b/.github/workflows/deploy-market.yaml
@@ -36,10 +36,10 @@ jobs:
       LINEASCAN_KEY: ${{ secrets.LINEASCAN_KEY }}
     steps:
       - name: Seacrest
-        uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
+        uses: hayesgm/seacrest@v2
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
-          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[inputs.network] }}"
+          requested_network: "${{ inputs.network }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet-eth.compound.finance\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''

--- a/.github/workflows/deploy-market.yaml
+++ b/.github/workflows/deploy-market.yaml
@@ -36,8 +36,10 @@ jobs:
       LINEASCAN_KEY: ${{ secrets.LINEASCAN_KEY }}
     steps:
       - name: Seacrest
-        uses: hayesgm/seacrest@v1
+        uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
+          wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
+          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[inputs.network] }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet-eth.compound.finance\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''

--- a/.github/workflows/deploy-market.yaml
+++ b/.github/workflows/deploy-market.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
-          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[inputs.network] }}"
+          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[env.GOV_NETWORK] }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet-eth.compound.finance\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''

--- a/.github/workflows/deploy-market.yaml
+++ b/.github/workflows/deploy-market.yaml
@@ -35,11 +35,22 @@ jobs:
       ARBISCAN_KEY: ${{ secrets.ARBISCAN_KEY }}
       LINEASCAN_KEY: ${{ secrets.LINEASCAN_KEY }}
     steps:
+      - name: Get governance network
+        run: |
+          case ${{ github.event.inputs.network }} in
+            polygon | arbitrum)
+                echo "GOV_NETWORK=mainnet" >> $GITHUB_ENV ;;
+            mumbai | arbitrum-goerli | base-goerli | linea-goerli)
+                echo "GOV_NETWORK=goerli" >> $GITHUB_ENV ;;
+            *)
+                echo "No governance network for selected network" ;;
+          esac
+
       - name: Seacrest
         uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
-          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[env.GOV_NETWORK] }}"
+          requested_network: "${{ env.GOV_NETWORK }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet-eth.compound.finance\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''

--- a/.github/workflows/enact-migration.yaml
+++ b/.github/workflows/enact-migration.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
-          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[inputs.network] }}"
+          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[env.GOV_NETWORK] }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''
@@ -67,7 +67,7 @@ jobs:
         uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
-          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[inputs.network] }}"
+          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[env.GOV_NETWORK] }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\"}')[env.GOV_NETWORK] }}"
           port: 8685
         if: github.event.inputs.eth_pk == '' && env.GOV_NETWORK != ''

--- a/.github/workflows/enact-migration.yaml
+++ b/.github/workflows/enact-migration.yaml
@@ -55,16 +55,16 @@ jobs:
           esac
 
       - name: Seacrest
-        uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
+        uses: hayesgm/seacrest@v2
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
-          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[inputs.network] }}"
+          requested_network: "${{ inputs.network }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''
 
       - name: Seacrest (governance network)
-        uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
+        uses: hayesgm/seacrest@v2
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
           requested_network: "${{ env.GOV_NETWORK }}"

--- a/.github/workflows/enact-migration.yaml
+++ b/.github/workflows/enact-migration.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
-          requested_network: "${{ env.GOV_NETWORK }}"
+          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[inputs.network] }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''

--- a/.github/workflows/enact-migration.yaml
+++ b/.github/workflows/enact-migration.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
-          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[env.GOV_NETWORK] }}"
+          requested_network: "${{ env.GOV_NETWORK }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''
@@ -67,7 +67,7 @@ jobs:
         uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
-          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[env.GOV_NETWORK] }}"
+          requested_network: "${{ env.GOV_NETWORK }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\"}')[env.GOV_NETWORK] }}"
           port: 8685
         if: github.event.inputs.eth_pk == '' && env.GOV_NETWORK != ''

--- a/.github/workflows/enact-migration.yaml
+++ b/.github/workflows/enact-migration.yaml
@@ -55,15 +55,19 @@ jobs:
           esac
 
       - name: Seacrest
-        uses: hayesgm/seacrest@v1
+        uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
+          wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
+          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[inputs.network] }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''
 
       - name: Seacrest (governance network)
-        uses: hayesgm/seacrest@v1
+        uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
+          wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
+          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[inputs.network] }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\"}')[env.GOV_NETWORK] }}"
           port: 8685
         if: github.event.inputs.eth_pk == '' && env.GOV_NETWORK != ''

--- a/.github/workflows/prepare-migration.yaml
+++ b/.github/workflows/prepare-migration.yaml
@@ -37,11 +37,22 @@ jobs:
       ARBISCAN_KEY: ${{ secrets.ARBISCAN_KEY }}
       LINEASCAN_KEY: ${{ secrets.LINEASCAN_KEY }}
     steps:
+      - name: Get governance network
+        run: |
+          case ${{ github.event.inputs.network }} in
+            polygon | arbitrum)
+                echo "GOV_NETWORK=mainnet" >> $GITHUB_ENV ;;
+            mumbai | arbitrum-goerli | base-goerli | linea-goerli)
+                echo "GOV_NETWORK=goerli" >> $GITHUB_ENV ;;
+            *)
+                echo "No governance network for selected network" ;;
+          esac
+
       - name: Seacrest
         uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
-          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[env.GOV_NETWORK] }}"
+          requested_network: "${{ env.GOV_NETWORK }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''

--- a/.github/workflows/prepare-migration.yaml
+++ b/.github/workflows/prepare-migration.yaml
@@ -38,8 +38,10 @@ jobs:
       LINEASCAN_KEY: ${{ secrets.LINEASCAN_KEY }}
     steps:
       - name: Seacrest
-        uses: hayesgm/seacrest@v1
+        uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
+          wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
+          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[inputs.network] }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''

--- a/.github/workflows/prepare-migration.yaml
+++ b/.github/workflows/prepare-migration.yaml
@@ -37,22 +37,11 @@ jobs:
       ARBISCAN_KEY: ${{ secrets.ARBISCAN_KEY }}
       LINEASCAN_KEY: ${{ secrets.LINEASCAN_KEY }}
     steps:
-      - name: Get governance network
-        run: |
-          case ${{ github.event.inputs.network }} in
-            polygon | arbitrum)
-                echo "GOV_NETWORK=mainnet" >> $GITHUB_ENV ;;
-            mumbai | arbitrum-goerli | base-goerli | linea-goerli)
-                echo "GOV_NETWORK=goerli" >> $GITHUB_ENV ;;
-            *)
-                echo "No governance network for selected network" ;;
-          esac
-
       - name: Seacrest
         uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
-          requested_network: "${{ env.GOV_NETWORK }}"
+          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[inputs.network] }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''

--- a/.github/workflows/prepare-migration.yaml
+++ b/.github/workflows/prepare-migration.yaml
@@ -38,10 +38,10 @@ jobs:
       LINEASCAN_KEY: ${{ secrets.LINEASCAN_KEY }}
     steps:
       - name: Seacrest
-        uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
+        uses: hayesgm/seacrest@v2
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
-          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[inputs.network] }}"
+          requested_network: "${{ inputs.network }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''

--- a/.github/workflows/prepare-migration.yaml
+++ b/.github/workflows/prepare-migration.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: hayesgm/seacrest@c3eef919c8ac21cf077aad0513ad8a493885ce6d
         with:
           wallet_connect_project_id: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
-          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[inputs.network] }}"
+          requested_network: "${{ fromJSON('{\"fuji\":43113,\"mainnet\":1,\"goerli\":5,\"mumbai\":80001,\"polygon\":137,\"arbitrum-goerli\":421613,\"arbitrum\":42161,\"base-goerli\":84531,\"linea-goerli\":59140}')[env.GOV_NETWORK] }}"
           ethereum_url: "${{ fromJSON('{\"fuji\":\"https://api.avax-test.network/ext/bc/C/rpc\",\"mainnet\":\"https://mainnet.infura.io/v3/$INFURA_KEY\",\"goerli\":\"https://goerli.infura.io/v3/$INFURA_KEY\",\"mumbai\":\"https://polygon-mumbai.infura.io/v3/$INFURA_KEY\",\"polygon\":\"https://polygon-mainnet.infura.io/v3/$INFURA_KEY\",\"arbitrum-goerli\":\"https://arbitrum-goerli.infura.io/v3/$INFURA_KEY\",\"arbitrum\":\"https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY\",\"base-goerli\":\"https://base-goerli.infura.io/v3/$INFURA_KEY\",\"linea-goerli\":\"https://linea-goerli.infura.io/v3/$INFURA_KEY\"}')[inputs.network] }}"
           port: 8585
         if: github.event.inputs.eth_pk == ''


### PR DESCRIPTION
Per: https://github.com/hayesgm/seacrest/releases/tag/v2
This PR will update /comet git actions to use the latest version of seacrest. 
So can unblock from failing seacrest@v1 due to WalletConnect's breaking changes.


Test run: https://github.com/compound-finance/comet/actions/runs/5548176565