### PR TITLE
Fix unverified Linea contract issue

### DIFF
--- a/deployments/goerli/usdc/relations.ts
+++ b/deployments/goerli/usdc/relations.ts
@@ -43,11 +43,12 @@ export default {
     }
   },
   lineaMessageService: {
-    delegates: {
-      field: {
-        slot: '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc'
-      }
-    }
+    artifact: 'contracts/bridges/linea/IMessageService.sol:IMessageService',
+    // delegates: {
+    //   field: {
+    //     slot: '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc'
+    //   }
+    // }
   },
   lineaL1TokenBridge: {
     delegates: {


### PR DESCRIPTION
Linea Goerli's `MessageService` contract just upgraded its implementation to an unverified contract, causing all testnet scenarios to fail when spidering Goerli. This should fix that.