### PR TITLE
OZ Monitoring Improvements 

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -56,7 +56,7 @@ const {
   LINEASCAN_KEY,
   OPTIMISMSCAN_KEY,
   INFURA_KEY,
-  QUICKNODE_KEY,
+  BASE_RPC_URL,
   MNEMONIC = 'myth like bonus scare over problem client lizard pioneer submit female collect',
   REPORT_GAS = 'false',
   NETWORK_PROVIDER = '',
@@ -117,7 +117,7 @@ const networkConfigs: NetworkConfig[] = [
   {
     network: 'base',
     chainId: 8453,
-    url: `https://clean-spring-wind.base-mainnet.discover.quiknode.pro/${QUICKNODE_KEY}`,
+    url: `${BASE_RPC_URL}`,
   },
   {
     network: 'arbitrum',

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -57,6 +57,7 @@ const {
   OPTIMISMSCAN_KEY,
   INFURA_KEY,
   BASE_RPC_URL,
+  SCROLL_RPC_URL,
   MNEMONIC = 'myth like bonus scare over problem client lizard pioneer submit female collect',
   REPORT_GAS = 'false',
   NETWORK_PROVIDER = '',
@@ -162,7 +163,7 @@ const networkConfigs: NetworkConfig[] = [
   {
     network: 'scroll',
     chainId: 534352,
-    url: 'https://rpc.scroll.io',
+    url: `${SCROLL_RPC_URL}`,
   }
 ];
 

--- a/plugins/import/etherscan.ts
+++ b/plugins/import/etherscan.ts
@@ -80,7 +80,7 @@ export function getEtherscanApiKey(network: string): string {
     'linea-goerli': process.env.LINEASCAN_KEY,
     optimism: process.env.OPTIMISMSCAN_KEY,
     'scroll-goerli': process.env.ETHERSCAN_KEY,
-    scroll: process.env.ETHERSCAN_KEY
+    scroll: process.env.SCROLLSCAN_KEY
   }[network];
 
   if (!apiKey) {

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -3,11 +3,11 @@ import {
   getEtherscanApiKey,
   getEtherscanApiUrl,
   getEtherscanUrl,
-} from "./etherscan";
+} from './etherscan';
 
 export function debug(...args: any[]) {
-  if (process.env["DEBUG"]) {
-    if (typeof args[0] === "function") {
+  if (process.env['DEBUG']) {
+    if (typeof args[0] === 'function') {
       console.log(...args[0]());
     } else {
       console.log(...args);
@@ -27,13 +27,13 @@ export async function loadContract(
   network: string,
   address: string
 ) {
-  if (address === "0x0000000000000000000000000000000000000000") {
+  if (address === '0x0000000000000000000000000000000000000000') {
     throw new Error(
       `Cannot load ${source} contract for address ${address} on network ${network}. Address invalid.`
     );
   }
   switch (source) {
-    case "etherscan":
+    case 'etherscan':
       return await loadEtherscanContract(network, address);
     default:
       throw new Error(
@@ -73,20 +73,20 @@ async function getEtherscanApiData(
   let apiUrl = await getEtherscanApiUrl(network);
 
   let result = await get(apiUrl, {
-    module: "contract",
-    action: "getsourcecode",
+    module: 'contract',
+    action: 'getsourcecode',
     address,
     apikey: apiKey,
   });
 
-  if (result.status !== "1") {
+  if (result.status !== '1') {
     throw new Error(`Etherscan Error: ${result.message} - ${result.result}`);
   }
 
   let s = <EtherscanSource>(<unknown>result.result[0]);
 
-  if (s.ABI === "Contract source code not verified") {
-    throw new Error("Contract source code not verified");
+  if (s.ABI === 'Contract source code not verified') {
+    throw new Error('Contract source code not verified');
   }
 
   return {
@@ -94,7 +94,7 @@ async function getEtherscanApiData(
     abi: JSON.parse(s.ABI),
     contract: s.ContractName,
     compiler: s.CompilerVersion,
-    optimized: s.OptimizationUsed !== "0",
+    optimized: s.OptimizationUsed !== '0',
     optimizationRuns: Number(s.Runs),
     constructorArgs: s.ConstructorArguments,
   };
@@ -105,15 +105,15 @@ async function scrapeContractCreationCodeFromEtherscanApi(
   address: string
 ) {
   const params = {
-    module: "proxy",
-    action: "eth_getCode",
+    module: 'proxy',
+    action: 'eth_getCode',
     address,
     apikey: getEtherscanApiKey(network),
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
   const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({
     ...params,
-    ...{ apikey: "[API_KEY]" },
+    ...{ apikey: '[API_KEY]' },
   })}`;
 
   debug(`Attempting to pull Contract Creation code from API at ${debugUrl}`);
@@ -163,7 +163,7 @@ async function scrapeContractCreationCodeFromEtherscan(
 function paramString(params: { [k: string]: string | number }) {
   return Object.entries(params)
     .map(([k, v]) => `${k}=${v}`)
-    .join("&");
+    .join('&');
 }
 
 async function pullFirstTransactionForContract(
@@ -173,20 +173,20 @@ async function pullFirstTransactionForContract(
   endblock = 99999999
 ) {
   const params = {
-    module: "account",
-    action: "txlist",
+    module: 'account',
+    action: 'txlist',
     address,
     startblock: startblock,
     endblock: endblock,
     page: 1,
     offset: 10,
-    sort: "asc",
+    sort: 'asc',
     apikey: getEtherscanApiKey(network),
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
   const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({
     ...params,
-    ...{ apikey: "[API_KEY]" },
+    ...{ apikey: '[API_KEY]' },
   })}`;
 
   debug(
@@ -208,26 +208,26 @@ async function pullFirstInternalTransactionForContract(
   endblock = 99999999
 ) {
   const params = {
-    module: "account",
-    action: "txlistinternal",
+    module: 'account',
+    action: 'txlistinternal',
     address,
     startblock: startblock,
     endblock: endblock,
     page: 1,
     offset: 10,
-    sort: "asc",
+    sort: 'asc',
     apikey: getEtherscanApiKey(network),
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
   const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({
     ...params,
-    ...{ apikey: "[API_KEY]" },
+    ...{ apikey: '[API_KEY]' },
   })}`;
   debug(
     `Attempting to pull Contract Creation code from first internal tx at ${debugUrl}`
   );
   const response = await get(url, {});
-  return response.result.find((tx) => tx.isError == "0").input;
+  return response.result.find((tx) => tx.isError == '0').input;
 }
 
 async function getContractCreationCode(network: string, address: string) {
@@ -245,7 +245,7 @@ async function getContractCreationCode(network: string, address: string) {
       errors.push(error);
     }
   }
-  throw new Error(errors.join("; "));
+  throw new Error(errors.join('; '));
 }
 
 function parseSources({
@@ -254,13 +254,13 @@ function parseSources({
   optimized,
   optimizationRuns,
 }: EtherscanData) {
-  if (source.startsWith("{") && source.endsWith("}")) {
+  if (source.startsWith('{') && source.endsWith('}')) {
     const sliced = source.slice(1, -1);
-    if (sliced.startsWith("{") && sliced.endsWith("}")) {
+    if (sliced.startsWith('{') && sliced.endsWith('}')) {
       return JSON.parse(sliced);
     } else {
       return {
-        language: "Solidity",
+        language: 'Solidity',
         settings: {
           optimizer: {
             enabled: optimized,
@@ -273,7 +273,7 @@ function parseSources({
   } else {
     // Note: legacy for tests, but is this even right?
     return {
-      language: "Solidity",
+      language: 'Solidity',
       settings: {
         optimizer: {
           enabled: optimized,
@@ -283,7 +283,7 @@ function parseSources({
       sources: {
         [`contracts/${contract}.sol`]: {
           content: source,
-          keccak256: "",
+          keccak256: '',
         },
       },
     };

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -91,7 +91,7 @@ async function scrapeContractCreationCodeFromEtherscanApi(network: string, addre
     apikey: getEtherscanApiKey(network)
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
-  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({ ...params, ...{ apikey: '[API_KEY]' }})}`;
+  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({ ...params, ...{ apikey: '[API_KEY]'}})}`;
 
   debug(`Attempting to pull Contract Creation code from API at ${debugUrl}`);
   const result = await get(url, {});
@@ -141,7 +141,7 @@ async function pullFirstTransactionForContract(network: string, address: string,
     apikey: getEtherscanApiKey(network)
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
-  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({ ...params, ...{ apikey: '[API_KEY]' }})}`;
+  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({ ...params, ...{ apikey: '[API_KEY]'}})}`;
 
   debug(`Attempting to pull Contract Creation code from first tx at ${debugUrl}`);
   const result = await get(url, {});

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -1,8 +1,8 @@
-import { get, getEtherscanApiKey, getEtherscanApiUrl, getEtherscanUrl } from "./etherscan";
+import { get, getEtherscanApiKey, getEtherscanApiUrl, getEtherscanUrl } from './etherscan';
 
 export function debug(...args: any[]) {
-  if (process.env["DEBUG"]) {
-    if (typeof args[0] === "function") {
+  if (process.env['DEBUG']) {
+    if (typeof args[0] === 'function') {
       console.log(...args[0]());
     } else {
       console.log(...args);
@@ -18,11 +18,11 @@ export function debug(...args: any[]) {
  */
 
 export async function loadContract(source: string, network: string, address: string) {
-  if (address === "0x0000000000000000000000000000000000000000") {
+  if (address === '0x0000000000000000000000000000000000000000') {
     throw new Error(`Cannot load ${source} contract for address ${address} on network ${network}. Address invalid.`);
   }
   switch (source) {
-    case "etherscan":
+    case 'etherscan':
       return await loadEtherscanContract(network, address);
     default:
       throw new Error(`Unknown source \`${source}\`, expected one of [etherscan]`);
@@ -56,20 +56,20 @@ async function getEtherscanApiData(network: string, address: string, apiKey: str
   let apiUrl = await getEtherscanApiUrl(network);
 
   let result = await get(apiUrl, {
-    module: "contract",
-    action: "getsourcecode",
+    module: 'contract',
+    action: 'getsourcecode',
     address,
     apikey: apiKey,
   });
 
-  if (result.status !== "1") {
+  if (result.status !== '1') {
     throw new Error(`Etherscan Error: ${result.message} - ${result.result}`);
   }
 
   let s = <EtherscanSource>(<unknown>result.result[0]);
 
-  if (s.ABI === "Contract source code not verified") {
-    throw new Error("Contract source code not verified");
+  if (s.ABI === 'Contract source code not verified') {
+    throw new Error('Contract source code not verified');
   }
 
   return {
@@ -77,7 +77,7 @@ async function getEtherscanApiData(network: string, address: string, apiKey: str
     abi: JSON.parse(s.ABI),
     contract: s.ContractName,
     compiler: s.CompilerVersion,
-    optimized: s.OptimizationUsed !== "0",
+    optimized: s.OptimizationUsed !== '0',
     optimizationRuns: Number(s.Runs),
     constructorArgs: s.ConstructorArguments,
   };
@@ -85,15 +85,15 @@ async function getEtherscanApiData(network: string, address: string, apiKey: str
 
 async function scrapeContractCreationCodeFromEtherscanApi(network: string, address: string) {
   const params = {
-    module: "proxy",
-    action: "eth_getCode",
+    module: 'proxy',
+    action: 'eth_getCode',
     address,
     apikey: getEtherscanApiKey(network),
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
   const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({
     ...params,
-    ...{ apikey: "[API_KEY]" },
+    ...{ apikey: '[API_KEY]' },
   })}`;
 
   debug(`Attempting to pull Contract Creation code from API at ${debugUrl}`);
@@ -130,25 +130,25 @@ async function scrapeContractCreationCodeFromEtherscan(network: string, address:
 function paramString(params: { [k: string]: string | number }) {
   return Object.entries(params)
     .map(([k, v]) => `${k}=${v}`)
-    .join("&");
+    .join('&');
 }
 
 async function pullFirstTransactionForContract(network: string, address: string, startblock = 0, endblock = 99999999) {
   const params = {
-    module: "account",
-    action: "txlist",
+    module: 'account',
+    action: 'txlist',
     address,
     startblock: startblock,
     endblock: endblock,
     page: 1,
     offset: 10,
-    sort: "asc",
+    sort: 'asc',
     apikey: getEtherscanApiKey(network),
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
   const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({
     ...params,
-    ...{ apikey: "[API_KEY]" },
+    ...{ apikey: '[API_KEY]' },
   })}`;
 
   debug(`Attempting to pull Contract Creation code from first tx at ${debugUrl}`);
@@ -168,24 +168,24 @@ async function pullFirstInternalTransactionForContract(
   endblock = 99999999
 ) {
   const params = {
-    module: "account",
-    action: "txlistinternal",
+    module: 'account',
+    action: 'txlistinternal',
     address,
     startblock: startblock,
     endblock: endblock,
     page: 1,
     offset: 10,
-    sort: "asc",
+    sort: 'asc',
     apikey: getEtherscanApiKey(network),
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
   const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({
     ...params,
-    ...{ apikey: "[API_KEY]" },
+    ...{ apikey: '[API_KEY]' },
   })}`;
   debug(`Attempting to pull Contract Creation code from first internal tx at ${debugUrl}`);
   const response = await get(url, {});
-  return response.result.find((tx) => tx.isError == "0").input;
+  return response.result.find((tx) => tx.isError == '0').input;
 }
 
 async function getContractCreationCode(network: string, address: string) {
@@ -203,17 +203,17 @@ async function getContractCreationCode(network: string, address: string) {
       errors.push(error);
     }
   }
-  throw new Error(errors.join("; "));
+  throw new Error(errors.join('; '));
 }
 
 function parseSources({ source, contract, optimized, optimizationRuns }: EtherscanData) {
-  if (source.startsWith("{") && source.endsWith("}")) {
+  if (source.startsWith('{') && source.endsWith('}')) {
     const sliced = source.slice(1, -1);
-    if (sliced.startsWith("{") && sliced.endsWith("}")) {
+    if (sliced.startsWith('{') && sliced.endsWith('}')) {
       return JSON.parse(sliced);
     } else {
       return {
-        language: "Solidity",
+        language: 'Solidity',
         settings: {
           optimizer: {
             enabled: optimized,
@@ -226,7 +226,7 @@ function parseSources({ source, contract, optimized, optimizationRuns }: Ethersc
   } else {
     // Note: legacy for tests, but is this even right?
     return {
-      language: "Solidity",
+      language: 'Solidity',
       settings: {
         optimizer: {
           enabled: optimized,
@@ -236,7 +236,7 @@ function parseSources({ source, contract, optimized, optimizationRuns }: Ethersc
       sources: {
         [`contracts/${contract}.sol`]: {
           content: source,
-          keccak256: "",
+          keccak256: '',
         },
       },
     };

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -169,7 +169,7 @@ async function pullFirstInternalTransactionForContract(network: string, address:
   const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({ ...params, ...{ apikey: '[API_KEY]'}})}`;
   debug(`Attempting to pull Contract Creation code from first internal tx at ${debugUrl}`);
   const response = await get(url, {});
-  return response.result.find(tx => tx.isError == "0")
+  return response.result.find(tx => tx.isError == "0").input
 }
 
 

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -1,8 +1,13 @@
-import { get, getEtherscanApiKey, getEtherscanApiUrl, getEtherscanUrl } from './etherscan';
+import {
+  get,
+  getEtherscanApiKey,
+  getEtherscanApiUrl,
+  getEtherscanUrl,
+} from "./etherscan";
 
 export function debug(...args: any[]) {
-  if (process.env['DEBUG']) {
-    if (typeof args[0] === 'function') {
+  if (process.env["DEBUG"]) {
+    if (typeof args[0] === "function") {
       console.log(...args[0]());
     } else {
       console.log(...args);
@@ -17,15 +22,23 @@ export function debug(...args: any[]) {
  * are temporarily moving it back into the protocol repo for easier development.
  */
 
-export async function loadContract(source: string, network: string, address: string) {
-  if (address === '0x0000000000000000000000000000000000000000') {
-    throw new Error(`Cannot load ${source} contract for address ${address} on network ${network}. Address invalid.`);
+export async function loadContract(
+  source: string,
+  network: string,
+  address: string
+) {
+  if (address === "0x0000000000000000000000000000000000000000") {
+    throw new Error(
+      `Cannot load ${source} contract for address ${address} on network ${network}. Address invalid.`
+    );
   }
   switch (source) {
-    case 'etherscan':
+    case "etherscan":
       return await loadEtherscanContract(network, address);
     default:
-      throw new Error(`Unknown source \`${source}\`, expected one of [etherscan]`);
+      throw new Error(
+        `Unknown source \`${source}\`, expected one of [etherscan]`
+      );
   }
 }
 
@@ -52,24 +65,28 @@ interface EtherscanData {
   constructorArgs: string;
 }
 
-async function getEtherscanApiData(network: string, address: string, apiKey: string): Promise<EtherscanData> {
+async function getEtherscanApiData(
+  network: string,
+  address: string,
+  apiKey: string
+): Promise<EtherscanData> {
   let apiUrl = await getEtherscanApiUrl(network);
 
   let result = await get(apiUrl, {
-    module: 'contract',
-    action: 'getsourcecode',
+    module: "contract",
+    action: "getsourcecode",
     address,
     apikey: apiKey,
   });
 
-  if (result.status !== '1') {
+  if (result.status !== "1") {
     throw new Error(`Etherscan Error: ${result.message} - ${result.result}`);
   }
 
   let s = <EtherscanSource>(<unknown>result.result[0]);
 
-  if (s.ABI === 'Contract source code not verified') {
-    throw new Error('Contract source code not verified');
+  if (s.ABI === "Contract source code not verified") {
+    throw new Error("Contract source code not verified");
   }
 
   return {
@@ -77,27 +94,35 @@ async function getEtherscanApiData(network: string, address: string, apiKey: str
     abi: JSON.parse(s.ABI),
     contract: s.ContractName,
     compiler: s.CompilerVersion,
-    optimized: s.OptimizationUsed !== '0',
+    optimized: s.OptimizationUsed !== "0",
     optimizationRuns: Number(s.Runs),
     constructorArgs: s.ConstructorArguments,
   };
 }
 
-async function scrapeContractCreationCodeFromEtherscanApi(network: string, address: string) {
+async function scrapeContractCreationCodeFromEtherscanApi(
+  network: string,
+  address: string
+) {
   const params = {
-    module: 'proxy',
-    action: 'eth_getCode',
+    module: "proxy",
+    action: "eth_getCode",
     address,
-    apikey: getEtherscanApiKey(network)
+    apikey: getEtherscanApiKey(network),
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
-  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({ ...params, ...{ apikey: '[API_KEY]'}})}`;
+  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({
+    ...params,
+    ...{ apikey: "[API_KEY]" },
+  })}`;
 
   debug(`Attempting to pull Contract Creation code from API at ${debugUrl}`);
   const result = await get(url, {});
   const contractCreationCode = result.result;
   if (!contractCreationCode) {
-    throw new Error(`Unable to find Contract Creation code from API at ${debugUrl}`);
+    throw new Error(
+      `Unable to find Contract Creation code from API at ${debugUrl}`
+    );
   }
   debug(`Creation Code found in first tx at ${debugUrl}`);
   return contractCreationCode.slice(2);
@@ -106,18 +131,29 @@ async function scrapeContractCreationCodeFromEtherscanApi(network: string, addre
 /**
  * @description Does not work for 0x566511a1A09561e2896F8c0fD77E8544E59bFDB0 as etherscan starts using some firewall
  */
-async function scrapeContractCreationCodeFromEtherscan(network: string, address: string) {
+async function scrapeContractCreationCodeFromEtherscan(
+  network: string,
+  address: string
+) {
   const url = `${getEtherscanUrl(network)}/address/${address}#code`;
   debug(`Attempting to scrape Contract Creation code at ${url}`);
   const result = <string>await get(url, {});
   const regex = /<div id='verifiedbytecode2'>[\s\r\n]*([0-9a-fA-F]*)[\s\r\n]*<\/div>/g;
   const regexDoubleQuotes = /<div id="verifiedbytecode2">[\s\r\n]*([0-9a-fA-F]*)[\s\r\n]*<\/div>/g;
-  const matches = [...result.matchAll(regex), ...result.matchAll(regexDoubleQuotes)];
+  const matches = [
+    ...result.matchAll(regex),
+    ...result.matchAll(regexDoubleQuotes),
+  ];
   if (matches.length === 0) {
-    if (result.match(/request throttled/i) || result.match(/try again later/i)) {
+    if (
+      result.match(/request throttled/i) ||
+      result.match(/try again later/i)
+    ) {
       throw new Error(`Request throttled: ${url}`);
     } else {
-      throw new Error(`Failed to pull deployed contract code from Etherscan: ${url}`);
+      throw new Error(
+        `Failed to pull deployed contract code from Etherscan: ${url}`
+      );
     }
   }
   debug(`Scraping successful for ${url}`);
@@ -125,25 +161,37 @@ async function scrapeContractCreationCodeFromEtherscan(network: string, address:
 }
 
 function paramString(params: { [k: string]: string | number }) {
-  return Object.entries(params).map(([k,v]) => `${k}=${v}`).join('&');
+  return Object.entries(params)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("&");
 }
 
-async function pullFirstTransactionForContract (network: string, address: string, startblock = 0, endblock=99999999) {
+async function pullFirstTransactionForContract(
+  network: string,
+  address: string,
+  startblock = 0,
+  endblock = 99999999
+) {
   const params = {
-    module: 'account',
-    action: 'txlist',
+    module: "account",
+    action: "txlist",
     address,
     startblock: startblock,
     endblock: endblock,
     page: 1,
     offset: 10,
-    sort: 'asc',
-    apikey: getEtherscanApiKey(network)
+    sort: "asc",
+    apikey: getEtherscanApiKey(network),
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
-  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({ ...params, ...{ apikey: '[API_KEY]'}})}`;
+  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({
+    ...params,
+    ...{ apikey: "[API_KEY]" },
+  })}`;
 
-  debug(`Attempting to pull Contract Creation code from first tx at ${debugUrl}`);
+  debug(
+    `Attempting to pull Contract Creation code from first tx at ${debugUrl}`
+  );
   const result = await get(url, {});
   const contractCreationCode = result.result[0].input;
   if (!contractCreationCode) {
@@ -153,32 +201,41 @@ async function pullFirstTransactionForContract (network: string, address: string
   return contractCreationCode.slice(2);
 }
 
-async function pullFirstInternalTransactionForContract(network: string, address: string,startblock = 0, endblock=99999999) {
+async function pullFirstInternalTransactionForContract(
+  network: string,
+  address: string,
+  startblock = 0,
+  endblock = 99999999
+) {
   const params = {
-    module: 'account',
-    action: 'txlistinternal',
+    module: "account",
+    action: "txlistinternal",
     address,
     startblock: startblock,
     endblock: endblock,
     page: 1,
     offset: 10,
-    sort: 'asc',
-    apikey: getEtherscanApiKey(network)
+    sort: "asc",
+    apikey: getEtherscanApiKey(network),
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
-  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({ ...params, ...{ apikey: '[API_KEY]'}})}`;
-  debug(`Attempting to pull Contract Creation code from first internal tx at ${debugUrl}`);
+  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({
+    ...params,
+    ...{ apikey: "[API_KEY]" },
+  })}`;
+  debug(
+    `Attempting to pull Contract Creation code from first internal tx at ${debugUrl}`
+  );
   const response = await get(url, {});
-  return response.result.find(tx => tx.isError == "0").input
+  return response.result.find((tx) => tx.isError == "0").input;
 }
-
-
 
 async function getContractCreationCode(network: string, address: string) {
   const strategies = [
     scrapeContractCreationCodeFromEtherscan,
+    scrapeContractCreationCodeFromEtherscanApi,
     pullFirstTransactionForContract,
-    pullFirstInternalTransactionForContract
+    pullFirstInternalTransactionForContract,
   ];
   let errors = [];
   for (const strategy of strategies) {
@@ -188,42 +245,47 @@ async function getContractCreationCode(network: string, address: string) {
       errors.push(error);
     }
   }
-  throw new Error(errors.join('; '));
+  throw new Error(errors.join("; "));
 }
 
-function parseSources({ source, contract, optimized, optimizationRuns }: EtherscanData) {
-  if (source.startsWith('{') && source.endsWith('}')) {
+function parseSources({
+  source,
+  contract,
+  optimized,
+  optimizationRuns,
+}: EtherscanData) {
+  if (source.startsWith("{") && source.endsWith("}")) {
     const sliced = source.slice(1, -1);
-    if (sliced.startsWith('{') && sliced.endsWith('}')) {
+    if (sliced.startsWith("{") && sliced.endsWith("}")) {
       return JSON.parse(sliced);
     } else {
       return {
-        language: 'Solidity',
+        language: "Solidity",
         settings: {
           optimizer: {
             enabled: optimized,
             runs: optimizationRuns,
-          }
+          },
         },
-        sources: JSON.parse(source)
+        sources: JSON.parse(source),
       };
     }
   } else {
     // Note: legacy for tests, but is this even right?
     return {
-      language: 'Solidity',
+      language: "Solidity",
       settings: {
         optimizer: {
           enabled: optimized,
           runs: optimizationRuns,
-        }
+        },
       },
       sources: {
         [`contracts/${contract}.sol`]: {
           content: source,
-          keccak256: '',
-        }
-      }
+          keccak256: "",
+        },
+      },
     };
   }
 }
@@ -232,19 +294,23 @@ export async function loadEtherscanContract(network: string, address: string) {
   const apiKey = getEtherscanApiKey(network);
   const networkName = network;
   const etherscanData = await getEtherscanApiData(networkName, address, apiKey);
-  const {
-    abi,
-    contract,
-    compiler,
-    constructorArgs
-  } = etherscanData;
+  const { abi, contract, compiler, constructorArgs } = etherscanData;
   const { language, settings, sources } = parseSources(etherscanData);
   const contractPath = Object.keys(sources)[0];
   const contractFQN = `${contractPath}:${contract}`;
 
-  let contractCreationCode = await getContractCreationCode(networkName, address);
-  if (constructorArgs.length > 0 && contractCreationCode.endsWith(constructorArgs)) {
-    contractCreationCode = contractCreationCode.slice(0, -constructorArgs.length);
+  let contractCreationCode = await getContractCreationCode(
+    networkName,
+    address
+  );
+  if (
+    constructorArgs.length > 0 &&
+    contractCreationCode.endsWith(constructorArgs)
+  ) {
+    contractCreationCode = contractCreationCode.slice(
+      0,
+      -constructorArgs.length
+    );
   }
 
   const encodedABI = JSON.stringify(abi);

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -88,7 +88,7 @@ async function scrapeContractCreationCodeFromEtherscanApi(network: string, addre
     module: 'proxy',
     action: 'eth_getCode',
     address,
-    apikey: getEtherscanApiKey(network),
+    apikey: getEtherscanApiKey(network)
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
   const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({
@@ -143,7 +143,7 @@ async function pullFirstTransactionForContract(network: string, address: string,
     page: 1,
     offset: 10,
     sort: 'asc',
-    apikey: getEtherscanApiKey(network),
+    apikey: getEtherscanApiKey(network)
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
   const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({
@@ -193,7 +193,7 @@ async function getContractCreationCode(network: string, address: string) {
     scrapeContractCreationCodeFromEtherscan,
     scrapeContractCreationCodeFromEtherscanApi,
     pullFirstTransactionForContract,
-    pullFirstInternalTransactionForContract,
+    pullFirstInternalTransactionForContract
   ];
   let errors = [];
   for (const strategy of strategies) {
@@ -217,10 +217,10 @@ function parseSources({ source, contract, optimized, optimizationRuns }: Ethersc
         settings: {
           optimizer: {
             enabled: optimized,
-            runs: optimizationRuns,
+            runs: optimizationRuns
           },
         },
-        sources: JSON.parse(source),
+        sources: JSON.parse(source)
       };
     }
   } else {
@@ -231,14 +231,14 @@ function parseSources({ source, contract, optimized, optimizationRuns }: Ethersc
         optimizer: {
           enabled: optimized,
           runs: optimizationRuns,
-        },
+        }
       },
       sources: {
         [`contracts/${contract}.sol`]: {
           content: source,
           keccak256: '',
-        },
-      },
+        }
+      }
     };
   }
 }
@@ -247,7 +247,12 @@ export async function loadEtherscanContract(network: string, address: string) {
   const apiKey = getEtherscanApiKey(network);
   const networkName = network;
   const etherscanData = await getEtherscanApiData(networkName, address, apiKey);
-  const { abi, contract, compiler, constructorArgs } = etherscanData;
+  const {
+    abi,
+    contract,
+    compiler,
+    constructorArgs
+  } = etherscanData;
   const { language, settings, sources } = parseSources(etherscanData);
   const contractPath = Object.keys(sources)[0];
   const contractFQN = `${contractPath}:${contract}`;

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -128,13 +128,13 @@ function paramString(params: { [k: string]: string | number }) {
   return Object.entries(params).map(([k,v]) => `${k}=${v}`).join('&');
 }
 
-async function pullFirstTransactionForContract(network: string, address: string) {
+async function pullFirstTransactionForContract (network: string, address: string, startblock = 0, endblock=99999999) {
   const params = {
     module: 'account',
     action: 'txlist',
     address,
-    startblock: 0,
-    endblock: 99999999,
+    startblock: startblock,
+    endblock: endblock,
     page: 1,
     offset: 10,
     sort: 'asc',
@@ -153,11 +153,32 @@ async function pullFirstTransactionForContract(network: string, address: string)
   return contractCreationCode.slice(2);
 }
 
+async function pullFirstInternalTransactionForContract(network: string, address: string,startblock = 0, endblock=99999999) {
+  const params = {
+    module: 'account',
+    action: 'txlistinternal',
+    address,
+    startblock: startblock,
+    endblock: endblock,
+    page: 1,
+    offset: 10,
+    sort: 'asc',
+    apikey: getEtherscanApiKey(network)
+  };
+  const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
+  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({ ...params, ...{ apikey: '[API_KEY]'}})}`;
+  debug(`Attempting to pull Contract Creation code from first internal tx at ${debugUrl}`);
+  const response = await get(url, {});
+  return response.result.find(tx => tx.isError == "0")
+}
+
+
+
 async function getContractCreationCode(network: string, address: string) {
   const strategies = [
     scrapeContractCreationCodeFromEtherscan,
-    scrapeContractCreationCodeFromEtherscanApi,
     pullFirstTransactionForContract,
+    pullFirstInternalTransactionForContract
   ];
   let errors = [];
   for (const strategy of strategies) {

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -19,9 +19,7 @@ export function debug(...args: any[]) {
 
 export async function loadContract(source: string, network: string, address: string) {
   if (address === "0x0000000000000000000000000000000000000000") {
-    throw new Error(
-      `Cannot load ${source} contract for address ${address} on network ${network}. Address invalid.`
-    );
+    throw new Error(`Cannot load ${source} contract for address ${address} on network ${network}. Address invalid.`);
   }
   switch (source) {
     case "etherscan":
@@ -54,11 +52,7 @@ interface EtherscanData {
   constructorArgs: string;
 }
 
-async function getEtherscanApiData(
-  network: string,
-  address: string,
-  apiKey: string
-): Promise<EtherscanData> {
+async function getEtherscanApiData(network: string, address: string, apiKey: string): Promise<EtherscanData> {
   let apiUrl = await getEtherscanApiUrl(network);
 
   let result = await get(apiUrl, {
@@ -139,12 +133,7 @@ function paramString(params: { [k: string]: string | number }) {
     .join("&");
 }
 
-async function pullFirstTransactionForContract(
-  network: string,
-  address: string,
-  startblock = 0,
-  endblock = 99999999
-) {
+async function pullFirstTransactionForContract(network: string, address: string, startblock = 0, endblock = 99999999) {
   const params = {
     module: "account",
     action: "txlist",

--- a/plugins/import/import.ts
+++ b/plugins/import/import.ts
@@ -91,10 +91,7 @@ async function scrapeContractCreationCodeFromEtherscanApi(network: string, addre
     apikey: getEtherscanApiKey(network)
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
-  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({
-    ...params,
-    ...{ apikey: '[API_KEY]' },
-  })}`;
+  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({ ...params, ...{ apikey: '[API_KEY]' }})}`;
 
   debug(`Attempting to pull Contract Creation code from API at ${debugUrl}`);
   const result = await get(url, {});
@@ -128,9 +125,7 @@ async function scrapeContractCreationCodeFromEtherscan(network: string, address:
 }
 
 function paramString(params: { [k: string]: string | number }) {
-  return Object.entries(params)
-    .map(([k, v]) => `${k}=${v}`)
-    .join('&');
+  return Object.entries(params).map(([k, v]) => `${k}=${v}`).join('&');
 }
 
 async function pullFirstTransactionForContract(network: string, address: string, startblock = 0, endblock = 99999999) {
@@ -146,10 +141,7 @@ async function pullFirstTransactionForContract(network: string, address: string,
     apikey: getEtherscanApiKey(network)
   };
   const url = `${getEtherscanApiUrl(network)}?${paramString(params)}`;
-  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({
-    ...params,
-    ...{ apikey: '[API_KEY]' },
-  })}`;
+  const debugUrl = `${getEtherscanApiUrl(network)}?${paramString({ ...params, ...{ apikey: '[API_KEY]' }})}`;
 
   debug(`Attempting to pull Contract Creation code from first tx at ${debugUrl}`);
   const result = await get(url, {});
@@ -217,8 +209,8 @@ function parseSources({ source, contract, optimized, optimizationRuns }: Ethersc
         settings: {
           optimizer: {
             enabled: optimized,
-            runs: optimizationRuns
-          },
+            runs: optimizationRuns,
+          }
         },
         sources: JSON.parse(source)
       };


### PR DESCRIPTION
This PR contains improvements we did on OpenZeppelin side to use comet repo and particularly spider tool useful in monitoring stack CI/CD pipeline. 

Changes consist of: 
- Replaced hardcoded URL in favor of `BASE_RPC_URL` environment variable for `base` network
- Replaced hardcoded URL in favor of `SCROLL_RPC_URL` environment variable for `scroll` network
- Changed Scroll rpc endpoint to use `SCROLLSCAN_KEY` instead of `ETHERSCAN_KEY`
- Added contract creation code scraping strategy to `pullFirstInternalTransactionForContract`

Merging this PR implies that maintainers must agree to update env variables in repository:
- [ ] set `BASE_RPC_URL` 
- [ ] set `SCROLL_RPC_URL`
- [ ] set `SCROLLSCAN_KEY`