### PR TITLE
fix: prevent division by zero in quoteCollateral()

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -135,7 +135,7 @@ contract Comet is CometMainInterface {
         // Sanity checks
         uint8 decimals_ = IERC20NonStandard(config.baseToken).decimals();
         if (decimals_ > MAX_BASE_DECIMALS) revert BadDecimals();
-        if (config.storeFrontPriceFactor > FACTOR_SCALE) revert BadDiscount();
+        if (config.storeFrontPriceFactor >= FACTOR_SCALE) revert BadDiscount();
         if (config.assetConfigs.length > MAX_ASSETS) revert TooManyAssets();
         if (config.baseMinForRewards == 0) revert BadMinimum();
         if (IPriceFeed(config.baseTokenPriceFeed).decimals() != PRICE_FEED_DECIMALS) revert BadDecimals();
@@ -1278,6 +1278,7 @@ contract Comet is CometMainInterface {
         // discount = storeFrontPriceFactor * (1e18 - liquidationFactor)
         uint256 discountFactor = mulFactor(storeFrontPriceFactor, FACTOR_SCALE - assetInfo.liquidationFactor);
         uint256 assetPriceDiscounted = mulFactor(assetPrice, FACTOR_SCALE - discountFactor);
+        if (assetPriceDiscounted == 0) revert BadPrice();
         uint256 basePrice = getPrice(baseTokenPriceFeed);
         // # of collateral assets
         // = (TotalValueOfBaseAmount / DiscountedPriceOfCollateralAsset) * assetScale


### PR DESCRIPTION
## Summary

Fixes #1104

Applies two-layer protection against divide-by-zero in quoteCollateral():

1. **Constructor validation** (line 138): Change  to  to reject storeFrontPriceFactor == FACTOR_SCALE
2. **Runtime guard** (line 1281): Add check  before division

## Problem

When storeFrontPriceFactor == FACTOR_SCALE (1e18) and liquidationFactor == 0:
- discountFactor = FACTOR_SCALE * (1e18 - 0) / 1e18 = FACTOR_SCALE
- assetPriceDiscounted = assetPrice * (1e18 - 1e18) / 1e18 = 0
- Division by zero in quoteCollateral() line 1287

This permanently disables collateral sales for that market since the config is immutable.

## Solution

Two-layer defense:
1. Prevent invalid configuration at deployment time
2. Add runtime guard as defense-in-depth

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Requires documentation update

## Testing

- Constructor now correctly rejects storeFrontPriceFactor == FACTOR_SCALE
- Runtime guard prevents division by zero even if constructor check is bypassed
- Existing valid configurations continue to work
- Prevents the division by zero scenario described in #1104