### PR TITLE
fix: normalize address case in maybeStore function

### DIFF
--- a/plugins/deployment_manager/Spider.ts
+++ b/plugins/deployment_manager/Spider.ts
@@ -42,7 +42,7 @@ function maybeStore(alias: Alias, address: Address, into: Aliases): boolean {
   if (maybeExists) {
     if (maybeExists.toLowerCase() === address.toLowerCase()) {
       return false;
-    } else if (maybeExists === constants.AddressZero && address !== constants.AddressZero) {
+    } else if (maybeExists.toLowerCase() === constants.AddressZero && address.toLowerCase() !== constants.AddressZero) {
       into.set(alias, address);
       return true;
     } else {


### PR DESCRIPTION
## Summary

Fixes a case-sensitivity bug in the  function in  where addresses were compared without normalizing case.

## Problem

The  function was comparing addresses case-sensitively when checking against :



This could cause issues when:
1. An address is stored with checksum casing (e.g., )
2. The comparison against  (which is lowercase ) fails due to case mismatch

## Solution

Normalize both addresses to lowercase before comparison:



This ensures consistent behavior regardless of how the address was originally formatted.

## Testing

- The fix is consistent with existing address comparison patterns in the codebase (e.g., line 43 already uses  for address comparison)
- No breaking changes to the API or behavior
- Only affects edge case where addresses have different checksum casing

## Related

This follows the same defensive programming pattern used elsewhere in the codebase, such as in  where addresses are normalized before comparison.