### PR TITLE
fix: prevent division by zero in quoteCollateral

### DIFF
--- a/contracts/Comet.sol
+++ b/contracts/Comet.sol
@@ -135,7 +135,7 @@ contract Comet is CometMainInterface {
         // Sanity checks
         uint8 decimals_ = IERC20NonStandard(config.baseToken).decimals();
         if (decimals_ > MAX_BASE_DECIMALS) revert BadDecimals();
-        if (config.storeFrontPriceFactor > FACTOR_SCALE) revert BadDiscount();
+        if (config.storeFrontPriceFactor >= FACTOR_SCALE) revert BadDiscount();
         if (config.assetConfigs.length > MAX_ASSETS) revert TooManyAssets();
         if (config.baseMinForRewards == 0) revert BadMinimum();
         if (IPriceFeed(config.baseTokenPriceFeed).decimals() != PRICE_FEED_DECIMALS) revert BadDecimals();
@@ -1278,6 +1278,7 @@ contract Comet is CometMainInterface {
         // discount = storeFrontPriceFactor * (1e18 - liquidationFactor)
         uint256 discountFactor = mulFactor(storeFrontPriceFactor, FACTOR_SCALE - assetInfo.liquidationFactor);
         uint256 assetPriceDiscounted = mulFactor(assetPrice, FACTOR_SCALE - discountFactor);
+        if (assetPriceDiscounted == 0) revert BadPrice();
         uint256 basePrice = getPrice(baseTokenPriceFeed);
         // # of collateral assets
         // = (TotalValueOfBaseAmount / DiscountedPriceOfCollateralAsset) * assetScale

--- a/contracts/CometWithExtendedAssetList.sol
+++ b/contracts/CometWithExtendedAssetList.sol
@@ -116,7 +116,7 @@ contract CometWithExtendedAssetList is CometMainInterface {
         // Sanity checks
         uint8 decimals_ = IERC20NonStandard(config.baseToken).decimals();
         if (decimals_ > MAX_BASE_DECIMALS) revert BadDecimals();
-        if (config.storeFrontPriceFactor > FACTOR_SCALE) revert BadDiscount();
+        if (config.storeFrontPriceFactor >= FACTOR_SCALE) revert BadDiscount();
         if (config.assetConfigs.length > MAX_ASSETS_FOR_ASSET_LIST) revert TooManyAssets();
         if (config.baseMinForRewards == 0) revert BadMinimum();
         if (IPriceFeed(config.baseTokenPriceFeed).decimals() != PRICE_FEED_DECIMALS) revert BadDecimals();
@@ -1153,6 +1153,7 @@ contract CometWithExtendedAssetList is CometMainInterface {
         // discount = storeFrontPriceFactor * (1e18 - liquidationFactor)
         uint256 discountFactor = mulFactor(storeFrontPriceFactor, FACTOR_SCALE - assetInfo.liquidationFactor);
         uint256 assetPriceDiscounted = mulFactor(assetPrice, FACTOR_SCALE - discountFactor);
+        if (assetPriceDiscounted == 0) revert BadPrice();
         uint256 basePrice = getPrice(baseTokenPriceFeed);
         // # of collateral assets
         // = (TotalValueOfBaseAmount / DiscountedPriceOfCollateralAsset) * assetScale

--- a/contracts/ScrollComet.sol
+++ b/contracts/ScrollComet.sol
@@ -141,7 +141,7 @@ contract ScrollComet is CometMainInterface {
         // Sanity checks
         uint8 decimals_ = ERC20(config.baseToken).decimals();
         if (decimals_ > MAX_BASE_DECIMALS) revert BadDecimals();
-        if (config.storeFrontPriceFactor > FACTOR_SCALE) revert BadDiscount();
+        if (config.storeFrontPriceFactor >= FACTOR_SCALE) revert BadDiscount();
         if (config.assetConfigs.length > MAX_ASSETS) revert TooManyAssets();
         if (config.baseMinForRewards == 0) revert BadMinimum();
         if (IPriceFeed(config.baseTokenPriceFeed).decimals() != PRICE_FEED_DECIMALS) revert BadDecimals();
@@ -1225,6 +1225,7 @@ contract ScrollComet is CometMainInterface {
         // discount = storeFrontPriceFactor * (1e18 - liquidationFactor)
         uint256 discountFactor = mulFactor(storeFrontPriceFactor, FACTOR_SCALE - assetInfo.liquidationFactor);
         uint256 assetPriceDiscounted = mulFactor(assetPrice, FACTOR_SCALE - discountFactor);
+        if (assetPriceDiscounted == 0) revert BadPrice();
         uint256 basePrice = getPrice(baseTokenPriceFeed);
         // # of collateral assets
         // = (TotalValueOfBaseAmount / DiscountedPriceOfCollateralAsset) * assetScale


### PR DESCRIPTION
## Summary

Fixes #1104

This PR adds two defensive checks to prevent division by zero in the `quoteCollateral` function:

### Changes

1. **Tighten storeFrontPriceFactor validation in constructor** (all three Comet variants):
   - Changed `> FACTOR_SCALE` to `>= FACTOR_SCALE`
   - When `storeFrontPriceFactor == FACTOR_SCALE`, the `discountFactor` can reach `FACTOR_SCALE`, causing `assetPriceDiscounted` to become zero

2. **Add zero-price guard in quoteCollateral** (all three Comet variants):
   - Added `if (assetPriceDiscounted == 0) revert BadPrice();` before the discounted price is used as a divisor
   - Prevents division by zero panic when calculating collateral asset quantities

### Affected contracts
- `contracts/Comet.sol`
- `contracts/CometWithExtendedAssetList.sol`
- `contracts/ScrollComet.sol`
